### PR TITLE
point compiler to the right config value for which files need to be compiled first

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -135,7 +135,7 @@ doterl_compile(State, Dir) ->
 
 doterl_compile(Config, Dir, MoreSources, ErlOpts) ->
     OutDir = filename:join(Dir, "ebin"),
-    ErlFirstFilesConf = rebar_state:get(Config, erl_first_modules, []),
+    ErlFirstFilesConf = rebar_state:get(Config, erl_first_files, []),
     ?DEBUG("erl_opts ~p", [ErlOpts]),
     %% Support the src_dirs option allowing multiple directories to
     %% contain erlang source. This might be used, for example, should


### PR DESCRIPTION
pretty sure this was a typo/mistake as `erl_first_modules` isn't referenced anywhere else