### PR TITLE
don't lose erl_opts when compiling for tests

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -295,8 +295,8 @@ add_test_dir(Opts, InDirs) ->
     %% if no src_dirs are set we have to specify `src` or it won't
     %% be built
     case proplists:append_values(src_dirs, Opts) of
-        [] -> [{src_dirs, ["src", "test"|InDirs]}];
-        _ -> [{src_dirs, ["test"|InDirs]}]
+        [] -> [{src_dirs, ["src", "test" | InDirs]} | Opts];
+        _ -> [{src_dirs, ["test" | InDirs]} | Opts]
     end.
 
 first_files(State) ->

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -111,9 +111,9 @@ default_test_dir(State) ->
 
 test_state(State, TmpDir) ->
     ErlOpts = rebar_state:get(State, eunit_compile_opts, []) ++
-              rebar_utils:erl_opts(State),
+        rebar_utils:erl_opts(State),
     ErlOpts1 = [{outdir, TmpDir}] ++
-               add_test_dir(ErlOpts),
+        add_test_dir(ErlOpts),
     TestOpts = safe_define_test_macro(ErlOpts1),
     rebar_state:set(State, erl_opts, TestOpts).
 
@@ -121,9 +121,9 @@ add_test_dir(Opts) ->
     %% if no src_dirs are set we have to specify `src` or it won't
     %% be built
     case proplists:append_values(src_dirs, Opts) of
-        [] -> [{src_dirs, ["src", "test"]}];
-        Srcs -> [{src_dirs, ["test"|Srcs]}]
-    end ++ lists:keydelete(src_dirs, 1, Opts).
+        [] -> [{src_dirs, ["src", "test"]} | Opts];
+        _ -> [{src_dirs, ["test"]} | Opts]
+    end.
 
 safe_define_test_macro(Opts) ->
     %% defining a compile macro twice results in an exception so


### PR DESCRIPTION
@evanmcc noticed an issue with the lager transform and common tests. Turned out the `erl_opts` were getting dropped when setting up the `src_dirs`. 

Note in eunit I removed the `| Srcs]` because `src_dirs` is retrieved with `append_values` when used to compile later anyway, so that is duplicating the dirs if we keep `Opts`.