### PR TITLE
add emulator args to escript for faster load time

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,7 @@
  [getopt, merl, erlydtl, erlware_commons, relx,  providers, rebar]}.
 {escript_top_level_app, rebar}.
 {escript_name, rebar3}.
+{escript_emu_args, "%%! +sbtu +A0 -noinput -mode minimal\n"}.
 
 {erl_opts,
  [{platform_define, "R14", no_callback_support},


### PR DESCRIPTION
Discussing how slow rebar3 was for behelit_ on irc I ended up asking him to try these args and the time for a hot compile run went from 3-4 seconds to 0.6 seconds. So I think it is important to get in.

I also had him remove erlydtl from the escript. That takes the size of the escript form 1.2M to 750K. So we may want to consider moving to a simpler templating tool. But maybe not as big of a deal with these emu arg changes.