### PR TITLE
support for provider_hooks in config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
          {branch, "master"}}},
        {providers, "",
         {git, "https://github.com/tsloughter/providers.git",
-         {branch, "profiles"}}},
+         {branch, "hooks"}}},
        {erlydtl, ".*",
          {git, "https://github.com/erlydtl/erlydtl.git",
           {tag, "0.9.4"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,7 @@
          {branch, "hooks"}}},
        {erlydtl, ".*",
          {git, "https://github.com/erlydtl/erlydtl.git",
-          {tag, "0.9.4"}}},
+          {tag, "0.10.0"}}},
        {relx, "",
         {git, "https://github.com/erlware/relx.git",
          {branch, "master"}}},

--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -88,15 +88,15 @@ find_app(AppDir, Validate) ->
                     case validate_application_info(AppInfo2) of
                         true ->
                             {true, AppInfo2};
-                        false ->
+                        _ ->
                             false
                     end;
                 invalid ->
                     case validate_application_info(AppInfo2) of
-                        false ->
-                            {true, AppInfo2};
                         true ->
-                            false
+                            false;
+                        _ ->
+                            {true, AppInfo2}
                     end;
                 all ->
                     {true, AppInfo2}
@@ -177,7 +177,7 @@ has_all_beams(EbinDir, [Module | ModuleList]) ->
         true ->
             has_all_beams(EbinDir, ModuleList);
         false ->
-            throw(?PRV_ERROR({missing_module, Module}))
+            ?PRV_ERROR({missing_module, Module})
     end;
 has_all_beams(_, []) ->
     true.

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -224,10 +224,10 @@ state(#app_info_t{state=State}) ->
 
 -spec valid(t()) -> boolean().
 valid(AppInfo=#app_info_t{valid=undefined}) ->
-    try
-        rebar_app_discover:validate_application_info(AppInfo)
-    catch
-        _:_ ->
+    case rebar_app_discover:validate_application_info(AppInfo) of
+        true ->
+            true;
+        _ ->
             false
     end;
 valid(#app_info_t{valid=Valid}) ->

--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -37,17 +37,18 @@ process_command(State, Command) ->
     Providers = rebar_state:providers(State),
     Namespace = rebar_state:namespace(State),
     {TargetProviders, CommandProvider} =
-     case Namespace of
-        undefined ->
-            %% undefined namespace means 'default', but on the first run;
-            %% it is used as an implicit counter for the first vs. subsequent
-            %% runs.
-            {providers:get_target_providers(Command, Providers, default),
-             providers:get_provider(Command, Providers, default)};
-        _ ->
-            {providers:get_target_providers(Command, Providers, Namespace),
-             providers:get_provider(Command, Providers, Namespace)}
-    end,
+        case Namespace of
+            undefined ->
+                %% undefined namespace means 'default', but on the first run;
+                %% it is used as an implicit counter for the first vs. subsequent
+                %% runs.
+                {providers:get_target_providers(Command, Providers, default),
+                 providers:get_provider(Command, Providers, default)};
+            _ ->
+                {providers:get_target_providers(Command, Providers, Namespace),
+                 providers:get_provider(Command, Providers, Namespace)}
+        end,
+
     case CommandProvider of
         not_found ->
             case Namespace of

--- a/src/rebar_prv_erlydtl_compiler.erl
+++ b/src/rebar_prv_erlydtl_compiler.erl
@@ -126,6 +126,7 @@ init(State) ->
     {ok, State1}.
 
 do(Config) ->
+    ?INFO("Running erlydtl...", []),
     MultiDtlOpts = erlydtl_opts(Config),
 
     Result = lists:foldl(fun(DtlOpts, _) ->

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -278,8 +278,8 @@ add_provider(State=#state_t{providers=Providers}, Provider) ->
     State#state_t{providers=[Provider | Providers]}.
 
 create_logic_providers(ProviderModules, State0) ->
-    State1 = try
-                 lists:foldl(fun(ProviderMod, StateAcc) ->
+    try
+        State1 = lists:foldl(fun(ProviderMod, StateAcc) ->
                                      case providers:new(ProviderMod, StateAcc) of
                                          {error, Reason} ->
                                              ?ERROR(Reason++"~n", []),
@@ -287,13 +287,13 @@ create_logic_providers(ProviderModules, State0) ->
                                          {ok, StateAcc1} ->
                                              StateAcc1
                                      end
-                             end, State0, ProviderModules)
-             catch
-                 C:T ->
-                     ?DEBUG("~p: ~p ~p", [C, T, erlang:get_stacktrace()]),
-                     throw({error, "Failed creating providers. Run with DEBUG=1 for stacktrace."})
-             end,
-    apply_hooks(State1).
+                             end, State0, ProviderModules),
+        apply_hooks(State1)
+    catch
+        C:T ->
+            ?DEBUG("~p: ~p ~p", [C, T, erlang:get_stacktrace()]),
+            throw({error, "Failed creating providers. Run with DEBUG=1 for stacktrace."})
+    end.
 
 apply_hooks(State0) ->
     try

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -30,7 +30,6 @@
          overrides/1, overrides/2,
          apply_overrides/2,
 
-         prepend_hook/3, append_hook/3, hooks/2,
          providers/1, providers/2, add_provider/2]).
 
 -include("rebar.hrl").
@@ -279,30 +278,49 @@ add_provider(State=#state_t{providers=Providers}, Provider) ->
     State#state_t{providers=[Provider | Providers]}.
 
 create_logic_providers(ProviderModules, State0) ->
-    lists:foldl(fun(ProviderMod, Acc) ->
-                        case providers:new(ProviderMod, Acc) of
-                            {error, Reason} ->
-                                ?ERROR(Reason++"~n", []),
-                                Acc;
-                            {ok, State1} ->
-                                State1
-                        end
-                end, State0, ProviderModules).
+    State1 = try
+                 lists:foldl(fun(ProviderMod, StateAcc) ->
+                                     case providers:new(ProviderMod, StateAcc) of
+                                         {error, Reason} ->
+                                             ?ERROR(Reason++"~n", []),
+                                             StateAcc;
+                                         {ok, StateAcc1} ->
+                                             StateAcc1
+                                     end
+                             end, State0, ProviderModules)
+             catch
+                 C:T ->
+                     ?DEBUG("~p: ~p ~p", [C, T, erlang:get_stacktrace()]),
+                     throw({error, "Failed creating providers. Run with DEBUG=1 for stacktrace."})
+             end,
+    apply_hooks(State1).
+
+apply_hooks(State0) ->
+    try
+        Hooks = rebar_state:get(State0, provider_hooks, []),
+        PreHooks = proplists:get_value(pre, Hooks, []),
+        PostHooks = proplists:get_value(post, Hooks, []),
+        State1 = lists:foldl(fun({Target, Hook}, StateAcc) ->
+                                     prepend_hook(StateAcc, Target, Hook)
+                             end, State0, PreHooks),
+        lists:foldl(fun({Target, Hook}, StateAcc) ->
+                            append_hook(StateAcc, Target, Hook)
+                    end, State1, PostHooks)
+    catch
+        C:T ->
+            ?DEBUG("~p: ~p ~p", [C, T, erlang:get_stacktrace()]),
+            throw({error, "Failed parsing provider hooks. Run with DEBUG=1 for stacktrace."})
+    end.
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
 
 prepend_hook(State=#state_t{providers=Providers}, Target, Hook) ->
     State#state_t{providers=add_hook(pre, Providers, Target, Hook)}.
 
 append_hook(State=#state_t{providers=Providers}, Target, Hook) ->
     State#state_t{providers=add_hook(post, Providers, Target, Hook)}.
-
--spec hooks(t(), atom()) -> {[providers:t()], [providers:t()]}.
-hooks(_State=#state_t{providers=Providers}, Target) ->
-    Provider = providers:get_provider(Target, Providers),
-    providers:hooks(Provider).
-
-%% ===================================================================
-%% Internal functions
-%% ===================================================================
 
 add_hook(Which, Providers, Target, Hook) ->
     Provider = providers:get_provider(Target, Providers),

--- a/test/rebar_hooks_SUITE.erl
+++ b/test/rebar_hooks_SUITE.erl
@@ -1,0 +1,37 @@
+-module(rebar_hooks_SUITE).
+
+-export([suite/0,
+         init_per_suite/1,
+         end_per_suite/1,
+         init_per_testcase/2,
+         all/0,
+         build_and_clean_app/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/file.hrl").
+
+suite() ->
+    [].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_, Config) ->
+    rebar_test_utils:init_rebar_state(Config).
+
+all() ->
+    [build_and_clean_app].
+
+%% Test post provider hook cleans compiled project app, leaving it invalid
+build_and_clean_app(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name, valid}]}),
+    rebar_test_utils:run_and_check(Config, [{provider_hooks, [{post, [{compile, clean}]}]}], ["compile"], {ok, [{app, Name, invalid}]}).

--- a/test/rebar_hooks_SUITE.erl
+++ b/test/rebar_hooks_SUITE.erl
@@ -34,4 +34,5 @@ build_and_clean_app(Config) ->
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name, valid}]}),
-    rebar_test_utils:run_and_check(Config, [{provider_hooks, [{post, [{compile, clean}]}]}], ["compile"], {ok, [{app, Name, invalid}]}).
+    rebar_test_utils:run_and_check(Config, [{provider_hooks, [{post, [{compile, clean}]}]}],
+                                  ["compile"], {ok, [{app, Name, invalid}]}).

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -102,7 +102,11 @@ check_results(AppDir, Expected) ->
     BuildDir = filename:join([AppDir, "_build", "lib"]),
     CheckoutsDir = filename:join([AppDir, "_checkouts"]),
     Apps = rebar_app_discover:find_apps([AppDir]),
+    InvalidApps = rebar_app_discover:find_apps([AppDir], invalid),
+    ValidApps = rebar_app_discover:find_apps([AppDir], valid),
     AppsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- Apps],
+    InvalidAppsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- InvalidApps],
+    ValidAppsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- ValidApps],
     Deps = rebar_app_discover:find_apps([BuildDir], all),
     DepsNames = [{ec_cnv:to_list(rebar_app_info:name(App)), App} || App <- Deps],
     Checkouts = rebar_app_discover:find_apps([CheckoutsDir], all),
@@ -111,6 +115,22 @@ check_results(AppDir, Expected) ->
         fun({app, Name}) ->
                 ct:pal("Name: ~p", [Name]),
                 case lists:keyfind(Name, 1, AppsNames) of
+                    false ->
+                        error({app_not_found, Name});
+                    {Name, _App} ->
+                        ok
+                end
+        ; ({app, Name, invalid}) ->
+                ct:pal("Name: ~p", [Name]),
+                case lists:keyfind(Name, 1, InvalidAppsNames) of
+                    false ->
+                        error({app_not_found, Name});
+                    {Name, _App} ->
+                        ok
+                end
+        ; ({app, Name, valid}) ->
+                ct:pal("Name: ~p", [Name]),
+                case lists:keyfind(Name, 1, ValidAppsNames) of
                     false ->
                         error({app_not_found, Name});
                     {Name, _App} ->


### PR DESCRIPTION
Example:

```
{provider_hooks, [{post, [{compile, {erlydtl, compile}}]}]}.
```

Looked at adding tests... Maybe I can just do something as simple as a `clean` as a post hook on `compile` and verify that the apps no longer show up as built.