### PR TITLE
no more mode minimal

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
  [getopt, merl, erlydtl, erlware_commons, relx,  providers, rebar]}.
 {escript_top_level_app, rebar}.
 {escript_name, rebar3}.
-{escript_emu_args, "%%! +sbtu +A0 -noinput -mode minimal\n"}.
+{escript_emu_args, "%%! +sbtu +A0 -noinput\n"}.
 
 {erl_opts,
  [{platform_define, "R14", no_callback_support},


### PR DESCRIPTION
`-mode minimal` breaks stuffs. 

If interested just do `rebar3 shell` and trying `httpc`.

I can't find documentation and what `minimal` actually does (or doesn't) do.