### PR TITLE
Upgrade procedure, from scratch (WIP)

### DIFF
--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -134,17 +134,17 @@ handle_deps(Profile, State, Deps) ->
 
 -spec handle_deps(atom(), rebar_state:t(), list(), list() | boolean()) ->
                          {ok, [rebar_app_info:t()], rebar_state:t()} | {error, string()}.
-handle_deps(Profile, State, Deps, Update) when is_boolean(Update) ->
-    handle_deps(Profile, State, Deps, Update, []);
+handle_deps(Profile, State, Deps, Upgrade) when is_boolean(Upgrade) ->
+    handle_deps(Profile, State, Deps, Upgrade, []);
 handle_deps(Profile, State, Deps, Locks) when is_list(Locks) ->
-    Update = rebar_state:get(State, upgrade, false),
-    handle_deps(Profile, State, Deps, Update, Locks).
+    Upgrade = rebar_state:get(State, upgrade, false),
+    handle_deps(Profile, State, Deps, Upgrade, Locks).
 
 -spec handle_deps(atom(), rebar_state:t(), list(), boolean() | {true, binary(), integer()}, list())
                  -> {ok, [rebar_app_info:t()], rebar_state:t()} | {error, string()}.
 handle_deps(_Profile, State, [], _, _) ->
     {ok, [], State};
-handle_deps(Profile, State, Deps, Update, Locks) ->
+handle_deps(Profile, State, Deps, Upgrade, Locks) ->
     %% Read in package index and dep graph
     {Packages, Graph} = rebar_packages:get_packages(State),
     %% Split source deps from pkg deps, needed to keep backwards compatibility
@@ -153,7 +153,7 @@ handle_deps(Profile, State, Deps, Update, Locks) ->
 
     %% Fetch transitive src deps
     {State1, SrcApps, PkgDeps1, Seen} =
-        update_src_deps(Profile, 0, SrcDeps, PkgDeps, [], State, Update, sets:new(), Locks),
+        update_src_deps(Profile, 0, SrcDeps, PkgDeps, [], State, Upgrade, sets:new(), Locks),
 
     {Solved, State2} = case PkgDeps1 of
                            [] -> %% No pkg deps
@@ -169,7 +169,7 @@ handle_deps(Profile, State, Deps, Update, Locks) ->
                                            [warn_skip_pkg(Pkg) || Pkg <- Discarded],
                                            Solution
                                    end,
-                               update_pkg_deps(Profile, S, Packages, Update, Seen, State1)
+                               update_pkg_deps(Profile, S, Packages, Upgrade, Seen, State1)
                        end,
 
     AllDeps = lists:ukeymerge(2
@@ -184,7 +184,7 @@ handle_deps(Profile, State, Deps, Update, Locks) ->
 %% Internal functions
 %% ===================================================================
 
-update_pkg_deps(Profile, Pkgs, Packages, Update, Seen, State) ->
+update_pkg_deps(Profile, Pkgs, Packages, Upgrade, Seen, State) ->
     %% Create app_info record for each pkg dep
     DepsDir = rebar_dir:deps_dir(State),
     {Solved, _, State1}
@@ -193,7 +193,7 @@ update_pkg_deps(Profile, Pkgs, Packages, Update, Seen, State) ->
                                                       ,Packages
                                                       ,Pkg),
                               {SeenAcc1, StateAcc1} = maybe_lock(Profile, AppInfo, SeenAcc, StateAcc, 0),
-                              case maybe_fetch(AppInfo, Update, SeenAcc1) of
+                              case maybe_fetch(AppInfo, Upgrade, SeenAcc1) of
                                   true ->
                                       {[AppInfo | Acc], SeenAcc1, StateAcc1};
                                   false ->
@@ -239,7 +239,7 @@ package_to_app(DepsDir, Packages, {Name, Vsn}) ->
     end.
 
 -spec update_src_deps(atom(), non_neg_integer(), list(), list(), list(), rebar_state:t(), boolean(), sets:set(binary()), list()) -> {rebar_state:t(), list(), list(), sets:set(binary())}.
-update_src_deps(Profile, Level, SrcDeps, PkgDeps, SrcApps, State, Update, Seen, Locks) ->
+update_src_deps(Profile, Level, SrcDeps, PkgDeps, SrcApps, State, Upgrade, Seen, Locks) ->
     case lists:foldl(fun(AppInfo, {SrcDepsAcc, PkgDepsAcc, SrcAppsAcc, StateAcc, SeenAcc, LocksAcc}) ->
                              %% If not seen, add to list of locks to write out
                              Name = rebar_app_info:name(AppInfo),
@@ -256,10 +256,10 @@ update_src_deps(Profile, Level, SrcDeps, PkgDeps, SrcApps, State, Update, Seen, 
                                  false ->
                                      {SeenAcc1, StateAcc1} = maybe_lock(Profile, AppInfo, SeenAcc, StateAcc, Level),
                                      {SrcDepsAcc1, PkgDepsAcc1, SrcAppsAcc1, StateAcc2, LocksAcc1} =
-                                         case Update of
+                                         case Upgrade of
                                              true ->
-                                             %{true, UpdateName, UpdateLevel} ->
-                                                 handle_update(AppInfo
+                                             %{true, UpgradeName, UpgradeLevel} ->
+                                                 handle_upgrade(AppInfo
                                                               ,SrcDepsAcc
                                                               ,PkgDepsAcc
                                                               ,SrcAppsAcc
@@ -284,10 +284,10 @@ update_src_deps(Profile, Level, SrcDeps, PkgDeps, SrcApps, State, Update, Seen, 
         {[], NewPkgDeps, NewSrcApps, State1, Seen1, _NewLocks} ->
             {State1, NewSrcApps, NewPkgDeps, Seen1};
         {NewSrcDeps, NewPkgDeps, NewSrcApps, State1, Seen1, NewLocks} ->
-            update_src_deps(Profile, Level+1, NewSrcDeps, NewPkgDeps, NewSrcApps, State1, Update, Seen1, NewLocks)
+            update_src_deps(Profile, Level+1, NewSrcDeps, NewPkgDeps, NewSrcApps, State1, Upgrade, Seen1, NewLocks)
     end.
 
-handle_update(AppInfo, SrcDeps, PkgDeps, SrcApps, Level, State, Locks) ->
+handle_upgrade(AppInfo, SrcDeps, PkgDeps, SrcApps, Level, State, Locks) ->
     Name = rebar_app_info:name(AppInfo),
     case lists:keyfind(Name, 1, Locks) of
         false ->
@@ -334,7 +334,7 @@ handle_dep(State, DepsDir, AppInfo, Locks, Level) ->
     AppInfo1 = rebar_app_info:state(AppInfo, S3),
 
     Deps = rebar_state:get(S3, deps, []),
-    %% Update lock level to be the level the dep will have in this dep tree
+    %% Upgrade lock level to be the level the dep will have in this dep tree
     NewLocks = [{DepName, Source, LockLevel+Level} ||
                    {DepName, Source, LockLevel} <- rebar_state:get(S3, {locks, default}, [])],
     AppInfo2 = rebar_app_info:deps(AppInfo1, rebar_state:deps_names(Deps)),
@@ -343,7 +343,7 @@ handle_dep(State, DepsDir, AppInfo, Locks, Level) ->
 
 -spec maybe_fetch(rebar_app_info:t(), boolean() | {true, binary(), integer()},
                   sets:set(binary())) -> boolean().
-maybe_fetch(AppInfo, Update, Seen) ->
+maybe_fetch(AppInfo, Upgrade, Seen) ->
     AppDir = ec_cnv:to_list(rebar_app_info:dir(AppInfo)),
     Apps = rebar_app_discover:find_apps(["_checkouts"], all),
     case rebar_app_utils:find(rebar_app_info:name(AppInfo), Apps) of
@@ -351,46 +351,15 @@ maybe_fetch(AppInfo, Update, Seen) ->
             %% Don't fetch dep if it exists in the _checkouts dir
             false;
         error ->
-            Exists = case rebar_app_utils:is_app_dir(filename:absname(AppDir)++"-*") of
-                         {true, _} ->
-                             true;
-                         _ ->
-                             case rebar_app_utils:is_app_dir(filename:absname(AppDir)) of
-                                 {true, _} ->
-                                     true;
-                                 _ ->
-                                     false
-                             end
-                     end,
-
-            case not Exists of% orelse Update of
+            case not app_exists(AppDir) of
                 true ->
-                    ?INFO("Fetching ~s (~p)", [rebar_app_info:name(AppInfo), rebar_app_info:source(AppInfo)]),
-                    Source = rebar_app_info:source(AppInfo),
-                    case rebar_fetch:download_source(AppDir, Source) of
-                        {error, Reason} ->
-                            throw(Reason);
-                        Result ->
-                            Result
-                    end;
-                _ ->
+                    fetch_app(AppInfo, AppDir);
+                false ->
                     case sets:is_element(rebar_app_info:name(AppInfo), Seen) of
                         true ->
                             false;
                         false ->
-                            Source = rebar_app_info:source(AppInfo),
-                            case Update andalso rebar_fetch:needs_update(AppDir, Source) of
-                                true ->
-                                    ?INFO("Updating ~s", [rebar_app_info:name(AppInfo)]),
-                                    case rebar_fetch:download_source(AppDir, Source) of
-                                        {error, Reason} ->
-                                            throw(Reason);
-                                        Result ->
-                                            Result
-                                    end;
-                                false ->
-                                    false
-                            end
+                            maybe_upgrade(AppInfo, AppDir, Upgrade)
                     end
             end
     end.
@@ -459,6 +428,46 @@ new_dep(DepsDir, Name, Vsn, Source, State) ->
     Dep1 = rebar_app_info:state(Dep,
                                rebar_state:overrides(S, ParentOverrides++Overrides)),
     rebar_app_info:source(Dep1, Source).
+
+app_exists(AppDir) ->
+    case rebar_app_utils:is_app_dir(filename:absname(AppDir)++"-*") of
+        {true, _} ->
+            true;
+        _ ->
+            case rebar_app_utils:is_app_dir(filename:absname(AppDir)) of
+                {true, _} ->
+                    true;
+                _ ->
+                    false
+            end
+    end.
+
+fetch_app(AppInfo, AppDir) ->
+    ?INFO("Fetching ~s (~p)", [rebar_app_info:name(AppInfo), rebar_app_info:source(AppInfo)]),
+    Source = rebar_app_info:source(AppInfo),
+    case rebar_fetch:download_source(AppDir, Source) of
+        {error, Reason} ->
+            throw(Reason);
+        Result ->
+            Result
+    end.
+
+maybe_upgrade(_AppInfo, _AppDir, false) ->
+    false;
+maybe_upgrade(AppInfo, AppDir, true) ->
+    Source = rebar_app_info:source(AppInfo),
+    case rebar_fetch:needs_update(AppDir, Source) of
+        true ->
+            ?INFO("Updating ~s", [rebar_app_info:name(AppInfo)]),
+            case rebar_fetch:download_source(AppDir, Source) of
+                {error, Reason} ->
+                    throw(Reason);
+                Result ->
+                    Result
+            end;
+        false ->
+            false
+    end.
 
 sort_deps(Deps) ->
     %% We need a sort stable, based on the name. So that for multiple deps on

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -287,7 +287,7 @@ update_src_deps(Profile, Level, SrcDeps, PkgDeps, SrcApps, State, Update, Seen, 
 
 handle_update(AppInfo, UpdateName, UpdateLevel, SrcDeps, PkgDeps, SrcApps, Level, State, Locks) ->
     Name = rebar_app_info:name(AppInfo),
-    {_, _, _, DepLevel} = lists:keyfind(Name, 1, Locks),
+    {_, _, DepLevel} = lists:keyfind(Name, 1, Locks),
     case UpdateLevel < DepLevel
         orelse Name =:= UpdateName of
         true ->

--- a/src/rebar_prv_lock.erl
+++ b/src/rebar_prv_lock.erl
@@ -41,7 +41,7 @@ do(State) ->
                               ,rebar_app_info:dep_level(Dep)}
                       end, AllDeps),
     Dir = rebar_state:dir(State),
-    file:write_file(filename:join(Dir, "rebar.lock"), io_lib:format("~p.~n", [Locks])),
+    file:write_file(filename:join(Dir, ?LOCK_FILE), io_lib:format("~p.~n", [Locks])),
     {ok, State}.
 
 -spec format_error(any()) -> iolist().

--- a/src/rebar_prv_upgrade.erl
+++ b/src/rebar_prv_upgrade.erl
@@ -62,7 +62,7 @@ do(State) ->
             {error, transitive_dependency};
         false ->
             ct:pal("deps: ~p", [{Name,Locks}]),
-            {error, unlocked_dependency}
+            {error, unknown_dependency}
     end.
 
 

--- a/src/rebar_prv_upgrade.erl
+++ b/src/rebar_prv_upgrade.erl
@@ -12,7 +12,10 @@
 -include("rebar.hrl").
 
 -define(PROVIDER, upgrade).
--define(DEPS, []).
+-define(DEPS, [lock]).
+%% Also only upgrade top-level (0) deps. Transitive deps shouldn't be
+%% upgradable -- if the user wants this, they should declare it at the
+%% top level and then upgrade.
 
 %% ===================================================================
 %% Public API
@@ -38,19 +41,36 @@ init(State) ->
 do(State) ->
     {Args, _} = rebar_state:command_parsed_args(State),
     Name = ec_cnv:to_binary(proplists:get_value(package, Args)),
-    Locks = rebar_state:get(State, locks, []),
-    case lists:keyfind(Name, 1, Locks) of
-        {_, _, _, Level} ->
-            Deps = rebar_state:get(State, deps),
-            case lists:keyfind(binary_to_atom(Name, utf8), 1, Deps) of
-                false ->
-                    {error, io_lib:format("No such dependency ~s~n", [Name])};
-                Dep ->
-                    rebar_prv_install_deps:handle_deps(State, [Dep], {true, Name, Level}),
-                    {ok, State}
-            end;
-        _ ->
-            {error, io_lib:format("No such dependency ~s~n", [Name])}
+    Locks = rebar_state:lock(State),
+    %% TODO: optimize by running the find + unlock in one sweep
+    case find_app(Name, Locks) of
+        {AppInfo, 0} ->
+            %% Unlock the app and all those with a lock level higher than
+            %% it has
+            NewLocks = unlock_higher_than(0, Locks -- [AppInfo]),
+            {ok, rebar_state:lock(State, NewLocks)};
+        {_AppInfo, Level} when Level > 0 ->
+            {error, transitive_dependency};
+        false ->
+            {error, unknown_dependency}
+    end.
+
+find_app(_Name, []) -> false;
+find_app(Name, [App|Apps]) ->
+    case rebar_app_info:name(App) of
+        Name -> {App, rebar_app_info:dep_level(App)};
+        _ -> find_app(Name, Apps)
+    end.
+
+%% Because we operate on a lock list, removing the app from the list
+%% unlocks it.
+unlock_higher_than(_, []) -> [];
+unlock_higher_than(Level, [App | Apps]) ->
+    case rebar_app_info:dep_level(App) of
+        N when N > Level ->
+            unlock_higher_than(Level, Apps);
+        N when N =< Level ->
+            [App | unlock_higher_than(Level, Apps)]
     end.
 
 -spec format_error(any()) -> iolist().

--- a/src/rebar_prv_upgrade.erl
+++ b/src/rebar_prv_upgrade.erl
@@ -56,12 +56,12 @@ do(State) ->
                     NewLocks = unlock_higher_than(0, Locks -- [Lock]),
                     State1 = rebar_state:set(State, {deps, default}, [{Name, Source, 0} | NewLocks]),
                     State2 = rebar_state:set(State1, {locks, default}, NewLocks),
-                    rebar_prv_install_deps:do(State2)
+                    State3 = rebar_state:set(State2, upgrade, true),
+                    rebar_prv_install_deps:do(State3)
             end;
         {_, _, Level} when Level > 0 ->
             {error, transitive_dependency};
         false ->
-            ct:pal("deps: ~p", [{Name,Locks}]),
             {error, unknown_dependency}
     end.
 

--- a/src/rebar_prv_upgrade.erl
+++ b/src/rebar_prv_upgrade.erl
@@ -29,47 +29,84 @@ init(State) ->
                                                    {module, ?MODULE},
                                                    {bare, false},
                                                    {deps, ?DEPS},
-                                                   {example, "rebar upgrade cowboy"},
+                                                   {example, "rebar upgrade cowboy[,ranch]"},
                                                    {short_desc, "Upgrade dependency."},
                                                    {desc, ""},
                                                    {opts, [
-                                                          {package, undefined, undefined, string, "Package to upgrade."}
+                                                          {package, undefined, undefined, string, "Packages to upgrade."}
                                                           ]}])),
     {ok, State1}.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     {Args, _} = rebar_state:command_parsed_args(State),
-    Name = ec_cnv:to_binary(proplists:get_value(package, Args)),
+    Names = parse_names(ec_cnv:to_binary(proplists:get_value(package, Args))),
+    %% TODO: support many names. Only a subtree can be updated per app
+    %%       mentioned. When no app is named, unlock *everything*
     Locks = rebar_state:get(State, {locks, default}, []),
+    Deps = rebar_state:get(State, deps),
+    case prepare_locks(Names, Deps, Locks, []) of
+        {error, Reason} ->
+            {error, Reason};
+        {Locks0, Unlocks0} ->
+            Deps0 = top_level_deps(Deps, Locks),
+            State1 = rebar_state:set(State, {deps, default}, Deps0),
+            State2 = rebar_state:set(State1, {locks, default}, Locks0),
+            State3 = rebar_state:set(State2, upgrade, true),
+            Res = rebar_prv_install_deps:do(State3),
+            case Res of
+                {ok, S} ->
+                    ct:pal("original locks ~p", [Locks]),
+                    ct:pal("new locks ~p", [Locks0]),
+                    ct:pal("old deps: ~p", [Deps]),
+                    ct:pal("new deps: ~p", [Deps0]),
+                    ct:pal("Unlocks: ~p", [Unlocks0]),
+                    %% TODO: replace new locks onto the old locks list
+                    rebar_prv_lock:do(S);
+                _ -> Res
+            end
+    end.
+
+parse_names(Bin) ->
+    lists:usort(re:split(Bin, <<" *, *">>, [trim])).
+
+prepare_locks([], _, Locks, Unlocks) ->
+    {Locks, Unlocks};
+prepare_locks([Name|Names], Deps, Locks, Unlocks) ->
     case lists:keyfind(Name, 1, Locks) of
         {_, _, 0} = Lock ->
-            Deps = rebar_state:get(State, deps),
-            case lists:keyfind(binary_to_atom(Name, utf8), 1, Deps) of
+            AtomName = binary_to_atom(Name, utf8),
+            case lists:keyfind(AtomName, 1, Deps) of
                 false ->
-                    {error, unknown_dependency};
+                    {error, {unknown_dependency, Name}};
                 Dep ->
                     Source = case Dep of
                         {_, Src} -> Src;
                         {_, _, Src} -> Src
                     end,
-                    NewLocks = unlock_higher_than(0, Locks -- [Lock]),
-                    State1 = rebar_state:set(State, {deps, default}, [{Name, Source, 0} | NewLocks]),
-                    State2 = rebar_state:set(State1, {locks, default}, NewLocks),
-                    State3 = rebar_state:set(State2, upgrade, true),
-                    rebar_prv_install_deps:do(State3)
+                    {NewLocks, NewUnlocks} = unlock_higher_than(0, Locks -- [Lock]),
+                    prepare_locks(Names,
+                                  %deps_like_locks(Deps, [{Name,Source,0} | NewLocks]),
+                                  Deps,
+                                  NewLocks,
+                                  [{Name, Source, 0} | NewUnlocks ++ Unlocks])
             end;
         {_, _, Level} when Level > 0 ->
-            {error, transitive_dependency};
+            {error, {transitive_dependency,Name}};
         false ->
-            {error, unknown_dependency}
+            {error, {unknown_dependency,Name}}
     end.
 
+top_level_deps(Deps, Locks) ->
+    [Dep || Dep <- Deps, lists:keymember(0, 3, Locks)].
 
-unlock_higher_than(_, []) -> [];
-unlock_higher_than(Level, [App = {_,_,AppLevel} | Apps]) ->
-    if AppLevel > Level  -> unlock_higher_than(Level, Apps);
-       AppLevel =< Level -> [App | unlock_higher_than(Level, Apps)]
+unlock_higher_than(Level, Locks) -> unlock_higher_than(Level, Locks, [], []).
+
+unlock_higher_than(_, [], Locks, Unlocks) ->
+    {Locks, Unlocks};
+unlock_higher_than(Level, [App = {_,_,AppLevel} | Apps], Locks, Unlocks) ->
+    if AppLevel > Level  -> unlock_higher_than(Level, Apps, Locks, [App | Unlocks]);
+       AppLevel =< Level -> unlock_higher_than(Level, Apps, [App | Locks], Unlocks)
     end.
 
 -spec format_error(any()) -> iolist().

--- a/test/mock_git_resource.erl
+++ b/test/mock_git_resource.erl
@@ -60,7 +60,7 @@ mock_update(Opts) ->
         ?MOD, needs_update,
         fun(_Dir, {git, Url, _Ref}) ->
             App = app(Url),
-            ct:pal("Needed update? ~p -> ~p", [App, lists:member(App, ToUpdate)]),
+            ct:pal("Needed update? ~p (~p) -> ~p", [App, {Url,_Ref}, lists:member(App, ToUpdate)]),
             lists:member(App, ToUpdate)
         end).
 
@@ -108,7 +108,6 @@ mock_download(Opts) ->
             {git, Url, {_, Vsn}} = normalize_git(Git, Overrides, Default),
             App = app(Url),
             AppDeps = proplists:get_value({App,Vsn}, Deps, []),
-            ct:pal("creating app ~p", [{Dir, App, Vsn, AppDeps}]),
             rebar_test_utils:create_app(
                 Dir, App, Vsn,
                 [element(1,D) || D  <- AppDeps]

--- a/test/mock_git_resource.erl
+++ b/test/mock_git_resource.erl
@@ -60,7 +60,7 @@ mock_update(Opts) ->
         ?MOD, needs_update,
         fun(_Dir, {git, Url, _Ref}) ->
             App = app(Url),
-            ct:pal("Needed update? ~p (~p) -> ~p", [App, {Url,_Ref}, lists:member(App, ToUpdate)]),
+%            ct:pal("Needed update? ~p (~p) -> ~p", [App, {Url,_Ref}, lists:member(App, ToUpdate)]),
             lists:member(App, ToUpdate)
         end).
 

--- a/test/mock_git_resource.erl
+++ b/test/mock_git_resource.erl
@@ -54,11 +54,13 @@ mock_lock(_) ->
 %% @doc The config passed to the `mock/2' function can specify which apps
 %% should be updated on a per-name basis: `{update, ["App1", "App3"]}'.
 mock_update(Opts) ->
-    ToUpdate = proplists:get_value(update, Opts, []),
+    ToUpdate = proplists:get_value(upgrade, Opts, []),
+    ct:pal("TOUp: ~p", [ToUpdate]),
     meck:expect(
         ?MOD, needs_update,
         fun(_Dir, {git, Url, _Ref}) ->
             App = app(Url),
+            ct:pal("Needed update? ~p -> ~p", [App, lists:member(App, ToUpdate)]),
             lists:member(App, ToUpdate)
         end).
 
@@ -106,6 +108,7 @@ mock_download(Opts) ->
             {git, Url, {_, Vsn}} = normalize_git(Git, Overrides, Default),
             App = app(Url),
             AppDeps = proplists:get_value({App,Vsn}, Deps, []),
+            ct:pal("creating app ~p", [{Dir, App, Vsn, AppDeps}]),
             rebar_test_utils:create_app(
                 Dir, App, Vsn,
                 [element(1,D) || D  <- AppDeps]

--- a/test/rebar_deps_SUITE.erl
+++ b/test/rebar_deps_SUITE.erl
@@ -1,4 +1,3 @@
-%%% TODO: check that warnings are appearing
 -module(rebar_deps_SUITE).
 -compile(export_all).
 -include_lib("common_test/include/ct.hrl").

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -53,7 +53,17 @@ run_and_check(Config, RebarConfig, Command, Expect) ->
             ?assertEqual({error, Reason}, Res);
         {ok, Expected} ->
             {ok, _} = Res,
-            check_results(AppDir, Expected)
+            check_results(AppDir, Expected);
+        {unlocked, Expected} ->
+            ct:pal("Expected: ~p", [Expected]),
+            {ok, ResState} = Res,
+            Locks = rebar_state:lock(ResState),
+            ct:pal("Locks: ~p", [Locks]),
+            ?assertEqual(lists:sort(Expected),
+                         lists:sort([rebar_app_info:name(Lock)
+                                     || Lock <- Locks]));
+        return ->
+            Res
     end.
 
 %% @doc Creates a dummy application including:

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -54,14 +54,6 @@ run_and_check(Config, RebarConfig, Command, Expect) ->
         {ok, Expected} ->
             {ok, _} = Res,
             check_results(AppDir, Expected);
-        {unlocked, Expected} ->
-            ct:pal("Expected: ~p", [Expected]),
-            {ok, ResState} = Res,
-            Locks = rebar_state:lock(ResState),
-            ct:pal("Locks: ~p", [Locks]),
-            ?assertEqual(lists:sort(Expected),
-                         lists:sort([rebar_app_info:name(Lock)
-                                     || Lock <- Locks]));
         return ->
             Res
     end.

--- a/test/rebar_upgrade_SUITE.erl
+++ b/test/rebar_upgrade_SUITE.erl
@@ -7,9 +7,9 @@ all() -> [{group, git}].%, {group, pkg}].
 
 groups() ->
     [{all, [], [top_a, top_b, top_c, top_d1, top_d2, top_e,
-                pair_a, pair_b, pair_ab, pair_c,
+                pair_a, pair_b, pair_ab, pair_c, pair_all,
                 triplet_a, triplet_b, triplet_c,
-                tree_a, tree_b, tree_c, tree_c2, tree_ac]},
+                tree_a, tree_b, tree_c, tree_c2, tree_ac, tree_all]},
      {git, [], [{group, all}]},
      {pkg, [], [{group, all}]}].
 
@@ -172,6 +172,15 @@ upgrades(pair_c) ->
      ],
      ["A","B","C","D"],
      {"C", {error, {transitive_dependency, <<"C">>}}}};
+upgrades(pair_all) ->
+    {[{"A", "1", [{"C", "1", []}]},
+      {"B", "1", [{"D", "1", []}]}
+     ],
+     [{"A", "2", [{"C", "2", []}]},
+      {"B", "2", [{"D", "2", []}]}
+     ],
+     ["A","B","C","D"],
+     {"", [{"A","2"},{"C","2"},{"B","2"},{"D","2"}]}};
 upgrades(triplet_a) ->
     {[{"A", "1", [{"D",[]},
                   {"E","3",[]}]},
@@ -313,7 +322,25 @@ upgrades(tree_ac) ->
      ["C","I"],
      {"C, A", [{"A","1"}, "D", "J", "E", {"I","1"},
                {"B","1"}, "F", "G",
-               {"C","1"}, "H"]}}.
+               {"C","1"}, "H"]}};
+upgrades(tree_all) ->
+    {[{"A", "1", [{"D",[{"J",[]}]},
+                  {"E",[{"I","1",[]}]}]},
+      {"B", "1", [{"F",[]},
+                  {"G",[]}]},
+      {"C", "1", [{"H",[]},
+                  {"I","2",[]}]}
+     ],
+     [{"A", "1", [{"D",[{"J",[]}]},
+                  {"E",[{"I","1",[]}]}]},
+      {"B", "1", [{"F",[]},
+                  {"G",[]}]},
+      {"C", "1", [{"H",[]}]}
+     ],
+     ["C","I"],
+     {"", [{"A","1"}, "D", "J", "E", {"I","1"},
+           {"B","1"}, "F", "G",
+           {"C","1"}, "H"]}}.
 
 %% TODO: add a test that verifies that unlocking files and then
 %% running the upgrade code is enough to properly upgrade things.
@@ -377,10 +404,12 @@ normalize_unlocks_expect({error, Reason}) ->
 normalize_unlocks_expect([]) ->
     [];
 normalize_unlocks_expect([{App,Vsn} | Rest]) ->
-    [{dep, App, Vsn}
+    [{dep, App, Vsn},
+     {lock, App, Vsn}
      | normalize_unlocks_expect(Rest)];
 normalize_unlocks_expect([App | Rest]) ->
-    [{dep, App} | normalize_unlocks_expect(Rest)].
+    [{dep, App},
+     {lock, App} | normalize_unlocks_expect(Rest)].
 
 top_a(Config) -> run(Config).
 top_b(Config) -> run(Config).
@@ -393,6 +422,7 @@ pair_a(Config) -> run(Config).
 pair_b(Config) -> run(Config).
 pair_ab(Config) -> run(Config).
 pair_c(Config) -> run(Config).
+pair_all(Config) -> run(Config).
 
 triplet_a(Config) -> run(Config).
 triplet_b(Config) -> run(Config).
@@ -403,6 +433,7 @@ tree_b(Config) -> run(Config).
 tree_c(Config) -> run(Config).
 tree_c2(Config) -> run(Config).
 tree_ac(Config) -> run(Config).
+tree_all(Config) -> run(Config).
 
 run(Config) ->
     apply(?config(mock, Config), []),

--- a/test/rebar_upgrade_SUITE.erl
+++ b/test/rebar_upgrade_SUITE.erl
@@ -1,0 +1,185 @@
+-module(rebar_upgrade_SUITE).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+all() -> [{group, git}].%, {group, pkg}].
+
+groups() ->
+    [{all, [], [top, pair, triplet, tree]},
+     {git, [], [{group, all}]},
+     {pkg, [], [{group, all}]}].
+
+init_per_suite(Config) ->
+    application:start(meck),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(meck).
+
+init_per_group(git, Config) ->
+    [{deps_type, git} | Config];
+init_per_group(pkg, Config) ->
+    [{deps_type, pkg} | Config];
+init_per_group(_, Config) ->
+    Config.
+
+end_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(Case, Config) ->
+    DepsType = ?config(deps_type, Config),
+    {Deps, Unlocks} = upgrades(Case),
+    Expanded = expand_deps(DepsType, Deps),
+    [{unlocks, normalize_unlocks(Unlocks)},
+     {mock, fun() -> mock_deps(DepsType, Expanded, []) end}
+     | setup_project(Case, Config, Expanded)].
+
+end_per_testcase(_, Config) ->
+    meck:unload(),
+    Config.
+
+setup_project(Case, Config0, Deps) ->
+    DepsType = ?config(deps_type, Config0),
+    Config = rebar_test_utils:init_rebar_state(
+            Config0,
+            atom_to_list(Case)++"_"++atom_to_list(DepsType)++"_"
+    ),
+    AppDir = ?config(apps, Config),
+    rebar_test_utils:create_app(AppDir, "Root", "0.0.0", [kernel, stdlib]),
+    TopDeps = top_level_deps(Deps),
+    RebarConf = rebar_test_utils:create_config(AppDir, [{deps, TopDeps}]),
+    [{rebarconfig, RebarConf} | Config].
+
+
+upgrades(top) ->
+    {[{"A", [{"B", [{"D", "1", []}]},
+             {"C", [{"D", "2", []}]}]}
+     ],
+     %% upgrade vs. locked after upgrade
+     [{"A", []},
+      {"B", {error, transitive_dependency}},
+      {"C", {error, transitive_dependency}},
+      {"D", "1", {error, transitive_dependency}},
+      {"D", "2", {error, unknown_dependency}}]};
+upgrades(pair) ->
+    {[{"A", [{"C", []}]},
+      {"B", [{"D", []}]}],
+     [{"A", ["B"]},
+      {"B", ["A"]},
+      {"C", {error, transitive_dependency}},
+      {"D", {error, transitive_dependency}}]};
+upgrades(triplet) ->
+    {[{"A", [{"D",[]},
+             {"E",[]}]},
+      {"B", [{"F",[]},
+             {"G",[]}]},
+      {"C", [{"H",[]},
+             {"I",[]}]}],
+     [{"A", ["B","C"]},
+      {"B", ["A","C"]},
+      {"C", ["A","B"]},
+      {"D", {error, transitive_dependency}},
+      %% ...
+      {"I", {error, transitive_dependency}}]};
+upgrades(tree) ->
+    {[{"A", [{"D",[{"J",[]}]},
+             {"E",[{"K",[]}]}]},
+      {"B", [{"F",[]},
+             {"G",[]}]},
+      {"C", [{"H",[]},
+             {"I",[]}]}],
+     [{"A", ["B","C"]},
+      {"B", ["A","C"]},
+      {"C", ["A","B"]},
+      {"D", {error, transitive_dependency}},
+      %% ...
+      {"K", {error, transitive_dependency}}]}.
+
+%% TODO: add a test that verifies that unlocking files and then
+%% running the upgrade code is enough to properly upgrade things.
+
+top_level_deps([]) -> [];
+top_level_deps([{{Name, Vsn, Ref}, _} | Deps]) ->
+    [{list_to_atom(Name), Vsn, Ref} | top_level_deps(Deps)];
+top_level_deps([{{pkg, Name, Vsn, _URL}, _} | Deps]) ->
+    [{list_to_atom(Name), Vsn} | top_level_deps(Deps)].
+
+mock_deps(git, Deps, Upgrades) ->
+    mock_git_resource:mock([{deps, flat_deps(Deps)}, {upgrade, Upgrades}]);
+mock_deps(pkg, Deps, Upgrades) ->
+    mock_pkg_resource:mock([{pkgdeps, flat_pkgdeps(Deps)}, {upgrade, Upgrades}]).
+
+flat_deps([]) -> [];
+flat_deps([{{Name,_Vsn,Ref}, Deps} | Rest]) ->
+    [{{Name,vsn_from_ref(Ref)}, top_level_deps(Deps)}]
+    ++
+    flat_deps(Deps)
+    ++
+    flat_deps(Rest).
+
+vsn_from_ref({git, _, {_, Vsn}}) -> Vsn;
+vsn_from_ref({git, _, Vsn}) -> Vsn.
+
+flat_pkgdeps([]) -> [];
+flat_pkgdeps([{{pkg, Name, Vsn, _Url}, Deps} | Rest]) ->
+    [{{iolist_to_binary(Name),iolist_to_binary(Vsn)}, top_level_deps(Deps)}]
+    ++
+    flat_pkgdeps(Deps)
+    ++
+    flat_pkgdeps(Rest).
+
+expand_deps(_, []) -> [];
+expand_deps(git, [{Name, Deps} | Rest]) ->
+    Dep = {Name, ".*", {git, "https://example.org/user/"++Name++".git", "master"}},
+    [{Dep, expand_deps(git, Deps)} | expand_deps(git, Rest)];
+expand_deps(git, [{Name, Vsn, Deps} | Rest]) ->
+    Dep = {Name, Vsn, {git, "https://example.org/user/"++Name++".git", {tag, Vsn}}},
+    [{Dep, expand_deps(git, Deps)} | expand_deps(git, Rest)];
+expand_deps(pkg, [{Name, Deps} | Rest]) ->
+    Dep = {pkg, Name, "0.0.0", "https://example.org/user/"++Name++".tar.gz"},
+    [{Dep, expand_deps(pkg, Deps)} | expand_deps(pkg, Rest)];
+expand_deps(pkg, [{Name, Vsn, Deps} | Rest]) ->
+    Dep = {pkg, Name, Vsn, "https://example.org/user/"++Name++".tar.gz"},
+    [{Dep, expand_deps(pkg, Deps)} | expand_deps(pkg, Rest)].
+
+normalize_unlocks([]) -> [];
+normalize_unlocks([{App, Locks} | Rest]) ->
+    [{iolist_to_binary(App),
+      normalize_unlocks_expect(Locks)} | normalize_unlocks(Rest)];
+normalize_unlocks([{App, Vsn, Locks} | Rest]) ->
+    [{iolist_to_binary(App), iolist_to_binary(Vsn),
+      normalize_unlocks_expect(Locks)} | normalize_unlocks(Rest)].
+
+normalize_unlocks_expect({error, Reason}) ->
+    {error, Reason};
+normalize_unlocks_expect([]) ->
+    [];
+normalize_unlocks_expect([{App,Vsn} | Rest]) ->
+    [{iolist_to_binary(App), iolist_to_binary(Vsn)}
+     | normalize_unlocks_expect(Rest)];
+normalize_unlocks_expect([App | Rest]) ->
+    [iolist_to_binary(App) | normalize_unlocks_expect(Rest)].
+
+top(Config) -> run(Config).
+pair(Config) -> run(Config).
+triplet(Config) -> run(Config).
+tree(Config) -> run(Config).
+
+run(Config) ->
+    apply(?config(mock, Config), []),
+    {ok, RebarConfig} = file:consult(?config(rebarconfig, Config)),
+    %% Install dependencies before re-mocking for an upgrade
+    rebar_test_utils:run_and_check(Config, RebarConfig, ["lock"], {ok, []}),
+    Unlocks = ?config(unlocks, Config),
+    [begin
+        ct:pal("Unlocks: ~p -> ~p", [App, Unlocked]),
+        Expectation = case Unlocked of
+            Tuple when is_tuple(Tuple) -> Tuple;
+            _ -> {unlocked, Unlocked}
+        end,
+        rebar_test_utils:run_and_check(
+            Config, RebarConfig, ["upgrade", App], Expectation
+        )
+     end || {App, Unlocked} <- Unlocks].
+


### PR DESCRIPTION
I wanted to make this one visible while I work on it a bit, and open for comments.

Currently the mechanism I tried was to:

- Only allow to upgrade a top-level dependency. There's no reason (or good way) to properly upgrade a transitive dependency in a repeatable manner.
- Just fetch dependencies as if the dependencies were not locked (i.e. reuse the topological algorithm we use for deps)
- Do it via unlocking and re-running the installation of deps.

So the trick I tried for this one (and added a good bunch of tests for) was to unlock the top-level dep, and then all deps below it, then re-run the code. This works for trivial cases, but fails for more complex ones where the dependencies that change are several layers deep or in different subtrees.

I'll have to figure out a different unlock/relock mechanism for this to work.