### PR TITLE
Add xref support for multi-app projects

### DIFF
--- a/src/rebar_prv_xref.erl
+++ b/src/rebar_prv_xref.erl
@@ -96,7 +96,8 @@ prepare(State) ->
                              rebar_state:get(State, xref_warnings, false)},
                             {verbose, rebar_log:is_verbose(State)}]),
 
-    {ok, _} = xref:add_directory(xref, "ebin"),
+    [{ok, _} = xref:add_directory(xref, rebar_app_info:ebin_dir(App))
+     || App <- rebar_state:project_apps(State)],
 
     %% Save the code path prior to doing any further code path
     %% manipulation


### PR DESCRIPTION
Add xref support for multi-app projects. Instead of only adding the top-level ebin directory to the xref server use `rebar_state:project_apps/1` to enumerate the applications for the project and add the ebin directory for each one.

This corrects an issue with #127 that added xref support.