### PR TITLE
Add packages to code path after installation

### DIFF
--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -46,12 +46,7 @@ download_source(AppDir, Source) ->
                 code:del_path(filename:absname(filename:join(AppDir1, "ebin"))),
                 ec_file:remove(filename:absname(AppDir1), [recursive]),
                 ok = ec_file:copy(FromDir, filename:absname(AppDir1), [recursive]),
-                case ec_file:exists(filename:join(AppDir1, "ebin")) of
-                    true ->
-                        true = code:add_patha(filename:join(AppDir1, "ebin"));
-                    false ->
-                        ok
-                end,
+                true = code:add_patha(filename:join(AppDir1, "ebin")),
                 true
         end
     catch

--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -46,7 +46,12 @@ download_source(AppDir, Source) ->
                 code:del_path(filename:absname(filename:join(AppDir1, "ebin"))),
                 ec_file:remove(filename:absname(AppDir1), [recursive]),
                 ok = ec_file:copy(FromDir, filename:absname(AppDir1), [recursive]),
-                true = code:add_patha(filename:join(AppDir1, "ebin")),
+                case ec_file:exists(filename:join(AppDir1, "ebin")) of
+                    true ->
+                        true = code:add_patha(filename:join(AppDir1, "ebin"));
+                    false ->
+                        ok
+                end,
                 true
         end
     catch

--- a/src/rebar_fetch.erl
+++ b/src/rebar_fetch.erl
@@ -46,6 +46,7 @@ download_source(AppDir, Source) ->
                 code:del_path(filename:absname(filename:join(AppDir1, "ebin"))),
                 ec_file:remove(filename:absname(AppDir1), [recursive]),
                 ok = ec_file:copy(FromDir, filename:absname(AppDir1), [recursive]),
+                true = code:add_patha(filename:join(AppDir1, "ebin")),
                 true
         end
     catch

--- a/test/mock_pkg_resource.erl
+++ b/test/mock_pkg_resource.erl
@@ -78,7 +78,7 @@ mock_download(Opts) ->
             App = binary_to_list(AppBin),
             filelib:ensure_dir(Dir),
             AppDeps = proplists:get_value({App,Vsn}, Deps, []),
-            {ok, AppInfo} = rebar_test_utils:create_app(
+            {ok, AppInfo} = rebar_test_utils:create_empty_app(
                 Dir, App, Vsn,
                 [element(1,D) || D  <- AppDeps]
             ),


### PR DESCRIPTION
Fix a bug where packages are not added to the code path after installation. Dependent applications that build from source are not affected by this issue since the `build_apps` function in `rebar_prv_compiler` takes care of the code path changes for them. It is only the precompiled packages that suffer from this issue.

A good example of the problem is trying to use the `lager` package with an application with source files that requires the lager parse_transform. The build fails the first time with an error similar to this:

```
/home/kelly/repos/myproject/src/myapp_app.erl:none: undefined parse transform 'lager_transform'

Makefile:12: recipe for target 'compile' failed
make: *** [compile] Error 1
```

Subsequent build attempts are successful because the package is already installed, but the fresh instsall case is the problem.

The sensible fix to me seemed to just be to add the package `ebin` to the code path immediately after it is copied over from the temporary download directory. At very least this cleared up the problem for me.