### PR TITLE
Validate .app File Presence

### DIFF
--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -127,6 +127,7 @@ app_vsn(Config, AppFile) ->
 %% Internal functions
 %% ===================================================================
 
+load_app_file(_State, undefined) -> {error, missing_app_file};
 load_app_file(State, Filename) ->
     AppFile = {app_file, Filename},
     case rebar_state:get(State, {appfile, AppFile}, undefined) of


### PR DESCRIPTION
I tried to use rebar3 on a repo with a rebar.config, but it wasn't OTP compliant (i.e. didn't have a .app or app.src file). Without the app file, I received an error. This pull request returns an error during app validation if the app file doesn't exist.

Error received without the fix below:

```
===> Uncaught error: {'EXIT',
                             {badarg,
                              [{erlang,length,[undefined],[]},
                               {lists,suffix,2,
                                [{file,"lists.erl"},{line,203}]},
                               {rebar_app_utils,consult_app_file,1,
                                [{file,"src/rebar_app_utils.erl"},{line,155}]},
                               {rebar_app_utils,load_app_file,2,
                                [{file,"src/rebar_app_utils.erl"},{line,134}]},
                               {rebar_otp_app,validate_app,2,
                                [{file,"src/rebar_otp_app.erl"},{line,85}]},
                               {rebar_prv_compile,build,2,
                                [{file,"src/rebar_prv_compile.erl"},
                                 {line,88}]},
                               {rebar_prv_compile,'-build_apps/2-fun-0-',2,
                                [{file,"src/rebar_prv_compile.erl"},
                                 {line,80}]},
                               {lists,foreach,2,
                                [{file,"lists.erl"},{line,1336}]}]}}
```