### PR TITLE
Fix dialyzer erts file lookup for releases prior to R16B02

### DIFF
--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -202,6 +202,8 @@ ebin_to_info(EbinDir, AppName) ->
             Modules = proplists:get_value(modules, AppDetails, []),
             Files = modules_to_files(Modules, EbinDir),
             {IncApps ++ DepApps, Files};
+        {error, enoent} when AppName =:= erts ->
+            {[], ebin_files(EbinDir)};
         _ ->
             Error = io_lib:format("Could not parse ~p", [AppFile]),
             throw({dialyzer_error, Error})
@@ -221,6 +223,11 @@ module_to_file(Module, EbinDir, Ext) ->
             ?CONSOLE("Unknown module ~s", [Module]),
             false
     end.
+
+ebin_files(EbinDir) ->
+    Wildcard = "*" ++ code:objfile_extension(),
+    [filename:join(EbinDir, File) ||
+     File <- filelib:wildcard(Wildcard, EbinDir)].
 
 read_plt(_State, Plt) ->
     case dialyzer:plt_info(Plt) of


### PR DESCRIPTION
Currently `rebar3 dialyzer` is broken on OTP releases prior to (but not including) R16B02. See https://travis-ci.org/rebar/rebar3/jobs/49952886 for failing test cases.

erts.app was introduced in R16B02 (https://github.com/erlang/otp/commit/31b20cac498b98d40ed2bb15bb5259cb3c33a422) so read all beam files from the erts ebin directory if .app file does not exist.
