### PR TITLE
factor out task/args parsing from `do` for use in other meta commands

### DIFF
--- a/src/rebar_prv_do.erl
+++ b/src/rebar_prv_do.erl
@@ -32,13 +32,12 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    Tasks = args_to_tasks(rebar_state:command_args(State)),
+    Tasks = rebar_utils:args_to_tasks(rebar_state:command_args(State)),
     do_tasks(Tasks, State).
 
 do_tasks([], State) ->
     {ok, State};
-do_tasks([TaskArgs | Tail], State) ->
-    [TaskStr | Args] = string:tokens(TaskArgs, " "),
+do_tasks([{TaskStr, Args}|Tail], State) ->
     Task = list_to_atom(TaskStr),
     State1 = rebar_state:set(State, task, Task),
     State2 = rebar_state:command_args(State1, Args),
@@ -52,6 +51,3 @@ do_tasks([TaskArgs | Tail], State) ->
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
-
-args_to_tasks(Args) ->
-    [string:strip(T) || T <- string:tokens(string:join(Args, " "), ",")].

--- a/test/rebar_utils_SUITE.erl
+++ b/test/rebar_utils_SUITE.erl
@@ -1,0 +1,120 @@
+-module(rebar_utils_SUITE).
+
+-export([all/0,
+         groups/0,
+         init_per_group/2,
+         end_per_group/2,
+         empty_arglist/1,
+         single_task/1,
+         single_task_with_immediate_comma/1,
+         single_task_with_trailing_comma/1,
+         multiple_task/1,
+         multiple_task_no_spaces/1,
+         multiple_task_with_immediate_comma/1,
+         multiple_task_with_trailing_comma/1,
+         task_with_arg/1,
+         task_with_arg_with_immediate_comma/1,
+         task_with_arg_with_trailing_comma/1,
+         task_with_multiple_args/1,
+         task_with_flag/1,
+         task_with_flag_with_immediate_comma/1,
+         task_with_flag_with_trailing_comma/1,
+         task_with_flag_with_commas/1,
+         task_with_multiple_flags/1,
+         special_task_do/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/file.hrl").
+
+
+all() ->
+    [{group, args_to_tasks}].
+
+groups() ->
+    [{args_to_tasks, [], [empty_arglist,
+                          single_task,
+                          single_task_with_immediate_comma,
+                          single_task_with_trailing_comma,
+                          multiple_task,
+                          multiple_task_no_spaces,
+                          multiple_task_with_immediate_comma,
+                          multiple_task_with_trailing_comma,
+                          task_with_arg,
+                          task_with_arg_with_immediate_comma,
+                          task_with_arg_with_trailing_comma,
+                          task_with_multiple_args,
+                          task_with_flag,
+                          task_with_flag_with_immediate_comma,
+                          task_with_flag_with_trailing_comma,
+                          task_with_flag_with_commas,
+                          task_with_multiple_flags,
+                          special_task_do]}].
+
+init_per_group(_, Config) -> Config.
+end_per_group(_, Config) -> Config.
+
+empty_arglist(_Config) ->
+    [] = rebar_utils:args_to_tasks([]).
+
+single_task(_Config) ->
+    [{"foo", []}] = rebar_utils:args_to_tasks(["foo"]).
+
+single_task_with_immediate_comma(_Config) ->
+    [{"foo", []}] = rebar_utils:args_to_tasks(["foo,"]).
+
+single_task_with_trailing_comma(_Config) ->
+    [{"foo", []}] = rebar_utils:args_to_tasks(["foo", ","]).
+
+multiple_task(_Config) ->
+    [{"foo", []}, {"bar", []}, {"baz", []}] = rebar_utils:args_to_tasks(["foo,",
+                                                                         "bar,",
+                                                                         "baz"]).
+
+multiple_task_no_spaces(_Config) ->
+    [{"foo", []}, {"bar", []}, {"baz", []}] = rebar_utils:args_to_tasks(["foo,bar,baz"]).
+
+multiple_task_with_immediate_comma(_Config) ->
+    [{"foo", []}, {"bar", []}, {"baz", []}] = rebar_utils:args_to_tasks(["foo,",
+                                                                         "bar,",
+                                                                         "baz,"]).
+
+multiple_task_with_trailing_comma(_Config) ->
+    [{"foo", []}, {"bar", []}, {"baz", []}] = rebar_utils:args_to_tasks(["foo",
+                                                                         ",",
+                                                                         "bar",
+                                                                         ",",
+                                                                         "baz",
+                                                                         ","]).
+task_with_arg(_Config) ->
+    [{"foo", ["bar"]}] = rebar_utils:args_to_tasks(["foo", "bar"]).
+
+task_with_arg_with_immediate_comma(_Config) ->
+    [{"foo", ["bar"]}, {"baz", []}] = rebar_utils:args_to_tasks(["foo", "bar,", "baz"]).
+
+task_with_arg_with_trailing_comma(_Config) ->
+    [{"foo", ["bar"]}, {"baz", []}] = rebar_utils:args_to_tasks(["foo", "bar", ",", "baz"]).
+
+task_with_multiple_args(_Config) ->
+    [{"foo", ["bar", "baz"]}] = rebar_utils:args_to_tasks(["foo", "bar", "baz"]).
+
+task_with_flag(_Config) ->
+    [{"foo", ["--bar"]}] = rebar_utils:args_to_tasks(["foo", "--bar"]).
+
+task_with_flag_with_immediate_comma(_Config) ->
+    [{"foo", ["--bar"]}, {"baz", []}] = rebar_utils:args_to_tasks(["foo", "--bar,", "baz"]).
+
+task_with_flag_with_trailing_comma(_Config) ->
+    [{"foo", ["--bar"]}, {"baz", []}] = rebar_utils:args_to_tasks(["foo", "--bar", ",", "baz"]).
+
+task_with_flag_with_commas(_Config) ->
+    [{"foo", ["--bar=baz,qux"]}] = rebar_utils:args_to_tasks(["foo", "--bar=baz,qux"]).
+
+task_with_multiple_flags(_Config) ->
+    [{"foo", ["--bar", "--baz"]}] = rebar_utils:args_to_tasks(["foo", "--bar", "--baz"]).
+
+special_task_do(_Config) ->
+    [{"foo", []}, {"do", ["bar,", "baz"]}] = rebar_utils:args_to_tasks(["foo,",
+                                                                        "do",
+                                                                        "bar,",
+                                                                        "baz"]).


### PR DESCRIPTION
this was for the `cover` meta command but the tests are useful even tho that approach is possibly not going to be used