### PR TITLE
Initial WTF provider implementation

### DIFF
--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -43,6 +43,7 @@
                      rebar_prv_release,
                      rebar_prv_version,
                      rebar_prv_common_test,
+                     rebar_prv_wtf,
                      rebar_prv_xref,
                      rebar_prv_help]}
         ]}

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -54,7 +54,8 @@ main(Args) ->
             case code:which(Module) of
                 non_existing ->
                     ?ERROR("Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace", []),
-                    ?DEBUG("Uncaught error: ~p ~p", [Module, Reason]);
+                    ?DEBUG("Uncaught error: ~p ~p", [Module, Reason]),
+                    ?INFO("When submitting a bug report, please include the output of `rebar3 wtf \"your command\"`", []);
                 _ ->
                     ?ERROR(Module:format_error(Reason), [])
             end,
@@ -67,6 +68,7 @@ main(Args) ->
             %% Dump this error to console
             ?ERROR("Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace", []),
             ?DEBUG("Uncaught error: ~p", [Error]),
+            ?INFO("When submitting a bug report, please include the output of `rebar3 wtf \"your command\"`", []),
             erlang:halt(1)
     end.
 

--- a/src/rebar_prv_help.erl
+++ b/src/rebar_prv_help.erl
@@ -24,7 +24,7 @@ init(State) ->
                                                                {module, ?MODULE},
                                                                {bare, false},
                                                                {deps, ?DEPS},
-                                                               {example, "rebar help <task>"},
+                                                               {example, "rebar3 help <task>"},
                                                                {short_desc, "Display a list of tasks or help for a given task or subtask."},
                                                                {desc, "Display a list of tasks or help for a given task or subtask."},
                                                                {opts, [

--- a/src/rebar_prv_wtf.erl
+++ b/src/rebar_prv_wtf.erl
@@ -1,0 +1,100 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
+%% ex: ts=4 sw=4 et
+
+-module(rebar_prv_wtf).
+
+-behaviour(provider).
+
+-export([init/1,
+         do/1,
+         format_error/1]).
+
+-include("rebar.hrl").
+
+-define(PROVIDER, wtf).
+-define(DEPS, []).
+-define(ISSUES_URL, "https://github.com/rebar/rebar3/issues").
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
+                                                               {module, ?MODULE},
+                                                               {bare, false},
+                                                               {deps, ?DEPS},
+                                                               {example, "rebar3 wtf \"<task>\""},
+                                                               {short_desc, "Provide a crash report to be sent to the rebar3 issues page"},
+                                                               {desc, "Provide a crash report to be sent to the rebar3 issues page"},
+                                                               {opts, [
+                                                                      {task, undefined, undefined, string, "Task to print details for."}
+                                                                      ]}])),
+    {ok, State1}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    %% Show command
+    Task = rebar_state:command_args(State),
+    Command = parse_task(Task),
+    %% Show command version (if a plugin?)
+    %% ...
+    %% Show app versions (including rebar3)
+    {ok, Vsn} = application:get_key(rebar, vsn),
+    Vsns = application:which_applications(),
+    %% Show OS and versions
+    OS = erlang:system_info(system_architecture),
+    %% Erlang version (ERTS)
+    ERTS = erlang:system_info(system_version),
+    %% ERTS root directory
+    Root = code:root_dir(),
+    Lib = code:lib_dir(),
+    %% datetime
+    UTC = calendar:universal_time(),
+    %%
+    ?CONSOLE(
+        "Rebar3 wtf report~n"
+        " version ~s~n"
+        " generated at ~s~n"
+        "=================~n"
+        "Please submit this along with your issue at ~s "
+        "(and feel free to edit out private information, if any)~n"
+        "-----------------~n"
+        "Task: ~ts~n"
+        "Entered as:~n"
+        "  ~ts~n"
+        "-----------------~n"
+        "Operating System: ~ts~n"
+        "ERTS: ~ts"
+        "Root Directory: ~ts~n"
+        "Library directory: ~ts~n"
+        "-----------------~n"
+        "Loaded Applications:~n"
+        "~p~n"
+        "-----------------~n"
+        "Escript path: ~ts~n"
+        "Providers:~n"
+        "  ~s",
+        [Vsn, time_to_string(UTC),
+         ?ISSUES_URL, Command, Task,
+         OS, ERTS, Root, Lib,
+         Vsns,
+         rebar_state:escript_path(State),
+         [providers:format(P)++" "
+          || P <- lists:sort(rebar_state:providers(State))]
+        ]
+    ),
+    {ok, State}.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+time_to_string({{Y,M,D},{H,Min,S}}) ->
+    lists:flatten(io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0w+00:00",
+                  [Y,M,D,H,Min,S])).
+
+parse_task(Str) ->
+    hd(re:split(Str, " ")).
+


### PR DESCRIPTION
Tests missing.

Current output:

```
→ ./rebar3 wtf "do ct, eunit --someswitch"
Rebar3 wtf report
 version 3.0.0
 generated at 2015-02-12T18:05:50+00:00
=================
Please submit this along with your issue at https://github.com/rebar/rebar3/issues (and feel free to edit out private information, if any)
-----------------
Task: do
Entered as:
  do ct, eunit --someswitch
-----------------
Operating System: x86_64-apple-darwin12.5.0
ERTS: Erlang/OTP 17 [erts-6.3] [source] [64-bit] [smp:4:4] [async-threads:0] [hipe] [kernel-poll:false]

Root Directory: /Users/ferd/.kerl/builds/17.4/release_17.4
Library directory: /Users/ferd/.kerl/builds/17.4/release_17.4/lib
-----------------
Loaded Applications:
[{inets,"INETS  CXC 138 49","5.10.4"},
 {ssl,"Erlang/OTP SSL application","5.3.8"},
 {public_key,"Public key infrastructure","0.22.1"},
 {asn1,"The Erlang ASN1 compiler version 3.0.3","3.0.3"},
 {crypto,"CRYPTO","3.4.2"},
 {stdlib,"ERTS  CXC 138 10","2.3"},
 {kernel,"ERTS  CXC 138 10","3.1"}]
-----------------
Escript path: /Users/ferd/code/self/rebar3/rebar3
Providers:
app_discovery as clean compile compile ct deps dialyzer do eunit help install_deps lock new pkgs release shell tar update upgrade version wtf xref
```
Comments?