### PR TITLE
Fix #140 and preserve erl_first_files order

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -130,3 +130,4 @@ Drew Varner
 Omar Yasin
 Tristan Sloughter
 Kelly McLaughlin
+Martin Karlsson


### PR DESCRIPTION
Match erl_first_files properly against all files needing
compilation and make sure the order of erl_first_files as specified in
rebar.config is preserved (rebar/rebar#445)