### PR TITLE
Fix {dialyzer_plt_warnings, false}

### DIFF
--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -352,7 +352,7 @@ succ_typings(State, Plt, Apps) ->
     {Args, _} = rebar_state:command_parsed_args(State),
     case proplists:get_value(succ_typings, Args) of
         false ->
-            {ok, State};
+            {0, State};
         _ ->
             do_succ_typings(State, Plt, Apps)
     end.


### PR DESCRIPTION
Dialyzer can return callgraph warnings (warnings where calls will always fails as the function is not exported from a module in the PLT) even when `{get_warnings, false}`. Fixes an issue discussed with @tsloughter on IRC.

I have sneaked in a typo fix in a second commit too ;).