### PR TITLE
check for newly added deps in the config file that aren't level 0 in lock

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -142,15 +142,7 @@ init_config() ->
                      rebar_config:consult_file(ConfigFile)
              end,
 
-    Config1 = case rebar_config:consult_file(?LOCK_FILE) of
-                  [D] ->
-                      %% We want the top level deps only from the lock file.
-                      %% This ensures deterministic overrides for configs.
-                      Deps = [X || X <- D, element(3, X) =:= 0],
-                      [{{locks, default}, D}, {{deps, default}, Deps} | Config];
-                  _ ->
-                      Config
-              end,
+    Config1 = rebar_config:merge_locks(Config, rebar_config:consult_file(?LOCK_FILE)),
 
     %% If $HOME/.rebar3/config exists load and use as global config
     Home = rebar_dir:home_dir(),
@@ -228,8 +220,6 @@ version() ->
     {ok, Vsn} = application:get_key(rebar, vsn),
     ?CONSOLE("rebar ~s on Erlang/OTP ~s Erts ~s",
              [Vsn, erlang:system_info(otp_release), erlang:system_info(version)]).
-
-
 
 %% TODO: Actually make it 'global'
 %%


### PR DESCRIPTION
Fix for https://github.com/rebar/rebar3/issues/150

Now `rebar3 compile` will discover newly added deps in `rebar.config`