### PR TITLE
Initial `deps` command

### DIFF
--- a/src/rebar_prv_deps.erl
+++ b/src/rebar_prv_deps.erl
@@ -9,7 +9,7 @@
 -include("rebar.hrl").
 
 -define(PROVIDER, deps).
--define(DEPS, []).
+-define(DEPS, [app_discovery]).
 
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
@@ -25,11 +25,79 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+    Profiles = rebar_state:current_profiles(State),
+    List = [{Profile, rebar_state:get(State, {deps, Profile}, [])}
+            || Profile <- Profiles],
+    [display(State, Profile, Deps) || {Profile, Deps} <- List],
     {ok, State}.
 
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
+
+display(State, default, Deps) ->
+    NewDeps = merge(Deps, rebar_state:get(State, deps, [])),
+    display_deps(State, NewDeps),
+    ?CONSOLE("", []);
+display(State, Profile, Deps) ->
+    ?CONSOLE("-- ~p --", [Profile]),
+    display_deps(State, Deps),
+    ?CONSOLE("", []).
+
+merge(Deps, Deps) ->
+    Deps;
+merge(Deps, SourceDeps) ->
+    ToAdd = [Dep || Dep <- SourceDeps,
+                    not lists:keymember(ec_cnv:to_binary(element(1,Dep)), 1, Deps)],
+    Deps ++ ToAdd.
+
+display_deps(State, Deps) ->
+    lists:foreach(fun(Dep) -> display_dep(State, Dep) end, Deps).
+
+%% packages
+display_dep(_State, {Name, Vsn}) when is_list(Vsn) ->
+    ?CONSOLE("~s* (package ~s)", [ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)]);
+display_dep(_State, Name) when is_atom(Name) ->
+    ?CONSOLE("~s* (package)", [ec_cnv:to_binary(Name)]);
+%% git source
+display_dep(_State, {Name, Source}) when is_tuple(Source), element(1, Source) =:= git ->
+    ?CONSOLE("~s* (git source)", [ec_cnv:to_binary(Name)]);
+display_dep(_State, {Name, _Vsn, Source}) when is_tuple(Source), element(1, Source) =:= git ->
+    ?CONSOLE("~s* (git source)", [ec_cnv:to_binary(Name)]);
+display_dep(_State, {Name, _Vsn, Source, _Opts}) when is_tuple(Source), element(1, Source) =:= git ->
+    ?CONSOLE("~s* (git soutce)", [ec_cnv:to_binary(Name)]);
+%% unknown source
+display_dep(_State, {Name, Source}) when is_tuple(Source), element(1, Source) ->
+    ?CONSOLE("~s* (source ~p)", [ec_cnv:to_binary(Name), Source]);
+display_dep(_State, {Name, _Vsn, Source}) when is_tuple(Source) ->
+    ?CONSOLE("~s* (source ~p)", [ec_cnv:to_binary(Name), Source]);
+display_dep(_State, {Name, _Vsn, Source, _Opts}) when is_tuple(Source) ->
+    ?CONSOLE("~s* (source ~p)", [ec_cnv:to_binary(Name), Source]);
+%% Locked
+display_dep(State, {Name, Source={pkg, _, Vsn, _}, Level}) when is_integer(Level) ->
+    DepsDir = rebar_dir:deps_dir(State),
+    AppDir = filename:join([DepsDir, ec_cnv:to_binary(Name)]),
+    NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source) of
+        true -> "*";
+        false -> ""
+    end,
+    ?CONSOLE("~s~s (locked package ~s)", [Name, NeedsUpdate, Vsn]);
+display_dep(State, {Name, Source, Level}) when is_tuple(Source), is_integer(Level), element(1, Source) =:= git ->
+    DepsDir = rebar_dir:deps_dir(State),
+    AppDir = filename:join([DepsDir, ec_cnv:to_binary(Name)]),
+    NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source) of
+        true -> "*";
+        false -> ""
+    end,
+    ?CONSOLE("~s~s (locked git source)", [Name, NeedsUpdate]);
+display_dep(State, {Name, Source, Level}) when is_tuple(Source), is_integer(Level) ->
+    DepsDir = rebar_dir:deps_dir(State),
+    AppDir = filename:join([DepsDir, ec_cnv:to_binary(Name)]),
+    NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source) of
+        true -> "*";
+        false -> ""
+    end,
+    ?CONSOLE("~s~s (locked ~p)", [Name, NeedsUpdate, Source]).
 
 info(Description) ->
     io_lib:format("~s.~n"

--- a/test/rebar_deps_SUITE.erl
+++ b/test/rebar_deps_SUITE.erl
@@ -1,16 +1,14 @@
+%% TODO: add tests for:
+%% - only part of deps fetched
+%% - only part of deps locked
+%% - output only shown once
+%% - modification asterisk on locked file
 -module(rebar_deps_SUITE).
 -compile(export_all).
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> [{group, git}, {group, pkg}].
-
-groups() ->
-    [{all, [], [flat, pick_highest_left, pick_highest_right,
-                pick_smallest1, pick_smallest2,
-                circular1, circular2, circular_skip]},
-     {git, [], [{group, all}]},
-     {pkg, [], [{group, all}]}].
+all() -> [default_nodep, default_lock].
 
 init_per_suite(Config) ->
     application:start(meck),
@@ -19,203 +17,79 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     application:stop(meck).
 
-init_per_group(git, Config) ->
-    [{deps_type, git} | Config];
-init_per_group(pkg, Config) ->
-    [{deps_type, pkg} | Config];
-init_per_group(_, Config) ->
-    Config.
-
-end_per_group(_, Config) ->
-    Config.
-
 init_per_testcase(Case, Config) ->
-    {Deps, Warnings, Expect} = deps(Case),
-    Expected = case Expect of
-        {ok, List} -> {ok, format_expected_deps(List)};
-        {error, Reason} -> {error, Reason}
-    end,
-    DepsType = ?config(deps_type, Config),
-    mock_warnings(),
-    [{expect, Expected},
-     {warnings, Warnings}
-    | setup_project(Case, Config, expand_deps(DepsType, Deps))].
+    meck:new(io, [no_link, passthrough, unstick]),
+    setup_project(Case, Config).
 
 end_per_testcase(_, Config) ->
     meck:unload(),
     Config.
 
-format_expected_deps(Deps) ->
-    [case Dep of
-        {N,V} -> {dep, N, V};
-        N -> {dep, N}
-     end || Dep <- Deps].
+config_content() ->
+    [{deps, [
+        {src_a, ".*", {git, "https://example.org/ferd/src_a.git", {branch, "master"}}},
+        {src_b, {git, "https://example.org/ferd/src_b.git", {branch, "master"}}},
+        {pkg_a, "1.0.0"}
+     ]},
+     {profiles,
+      [{test,
+        [{deps, [
+            {tdep, {git, "git://example.org/ferd/tdep.git", {tag, "0.8.2"}}}
+        ]}]
+      }]}
+    ].
 
-%% format:
-%% {Spec,
-%%  [Warning],
-%%  {ok, Result} | {error, Reason}}
-%%
-%% Spec is a list of levelled dependencies of two possible forms:
-%% - {"Name", Spec}
-%% - {"Name", "Vsn", Spec}
-%%
-%% Warnings are going to match on mocked ?WARN(...)
-%% calls to be evaluated. An empty list means we do not care about
-%% warnings, not that no warnings will be printed. This means
-%% the list of warning isn't interpreted to be exhaustive, and more
-%% warnings may be generated than are listed.
-deps(flat) ->
-    {[{"B", []},
-      {"C", []}],
-     [],
-     {ok, ["B", "C"]}};
-deps(pick_highest_left) ->
-    {[{"B", [{"C", "2", []}]},
-      {"C", "1", []}],
-     [{"C","2"}],
-     {ok, ["B", {"C", "1"}]}};
-deps(pick_highest_right) ->
-    {[{"B", "1", []},
-      {"C", [{"B", "2", []}]}],
-     [{"B","2"}],
-     {ok, [{"B","1"}, "C"]}};
-deps(pick_smallest1) ->
-    {[{"B", [{"D", "1", []}]},
-      {"C", [{"D", "2", []}]}],
-     [{"D","2"}],
-     %% we pick D1 because B < C
-     {ok, ["B","C",{"D","1"}]}};
-deps(pick_smallest2) ->
-    {[{"C", [{"D", "2", []}]},
-      {"B", [{"D", "1", []}]}],
-     [{"D","2"}],
-     %% we pick D1 because B < C
-     {ok, ["B","C",{"D","1"}]}};
-deps(circular1) ->
-    {[{"B", [{"A", []}]}, % A is the top-level app
-      {"C", []}],
-     [],
-     {error, {rebar_prv_install_deps, {cycles, [[<<"A">>,<<"B">>]]}}}};
-deps(circular2) ->
-    {[{"B", [{"C", [{"B", []}]}]},
-      {"C", []}],
-     [],
-     {error, {rebar_prv_install_deps, {cycles, [[<<"B">>,<<"C">>]]}}}};
-deps(circular_skip) ->
-    %% Never spot the circular dep due to being to low in the deps tree
-    %% in source deps
-    {[{"B", [{"C", "2", [{"B", []}]}]},
-      {"C", "1", [{"D",[]}]}],
-     [{"C","2"}],
-     {ok, ["B", {"C","1"}, "D"]}}.
-
-expand_deps(_, []) -> [];
-expand_deps(git, [{Name, Deps} | Rest]) ->
-    Dep = {Name, ".*", {git, "https://example.org/user/"++Name++".git", "master"}},
-    [{Dep, expand_deps(git, Deps)} | expand_deps(git, Rest)];
-expand_deps(git, [{Name, Vsn, Deps} | Rest]) ->
-    Dep = {Name, Vsn, {git, "https://example.org/user/"++Name++".git", {tag, Vsn}}},
-    [{Dep, expand_deps(git, Deps)} | expand_deps(git, Rest)];
-expand_deps(pkg, [{Name, Deps} | Rest]) ->
-    Dep = {pkg, Name, "0.0.0", "https://example.org/user/"++Name++".tar.gz"},
-    [{Dep, expand_deps(pkg, Deps)} | expand_deps(pkg, Rest)];
-expand_deps(pkg, [{Name, Vsn, Deps} | Rest]) ->
-    Dep = {pkg, Name, Vsn, "https://example.org/user/"++Name++".tar.gz"},
-    [{Dep, expand_deps(pkg, Deps)} | expand_deps(pkg, Rest)].
-
-setup_project(Case, Config0, Deps) ->
-    DepsType = ?config(deps_type, Config0),
+setup_project(Case, Config0) ->
     Config = rebar_test_utils:init_rebar_state(
             Config0,
-            atom_to_list(Case)++"_"++atom_to_list(DepsType)++"_"
+            atom_to_list(Case)++"_"
     ),
     AppDir = ?config(apps, Config),
     rebar_test_utils:create_app(AppDir, "A", "0.0.0", [kernel, stdlib]),
-    TopDeps = top_level_deps(Deps),
+    TopDeps = proplists:get_value(deps, config_content()),
+    StringDeps = [erlang:setelement(1, Dep, atom_to_list(element(1,Dep)))
+                  || Dep <- TopDeps],
     RebarConf = rebar_test_utils:create_config(AppDir, [{deps, TopDeps}]),
-    case DepsType of
-        git ->
-            mock_git_resource:mock([{deps, flat_deps(Deps)}]);
-        pkg ->
-            mock_pkg_resource:mock([{pkgdeps, flat_pkgdeps(Deps)}])
-    end,
+    mock_git_resource:mock([{deps, lists:filter(fun src_dep/1, StringDeps)}]),
+    mock_pkg_resource:mock([{pkgdeps,
+      [{{ec_cnv:to_binary(N),
+         ec_cnv:to_binary(V)},[]}
+       || {N,V} <- lists:filter(fun pkg_dep/1, StringDeps)]}]),
     [{rebarconfig, RebarConf} | Config].
 
+src_dep(Dep) ->
+    case element(1, Dep) of
+        "src_"++_ -> true;
+        _ -> false
+    end.
 
-flat_deps([]) -> [];
-flat_deps([{{Name,_Vsn,Ref}, Deps} | Rest]) ->
-    [{{Name,vsn_from_ref(Ref)}, top_level_deps(Deps)}]
-    ++
-    flat_deps(Deps)
-    ++
-    flat_deps(Rest).
+pkg_dep(Dep) ->
+    case element(1, Dep) of
+        "pkg_"++_ -> true;
+        _ -> false
+    end.
 
-vsn_from_ref({git, _, {_, Vsn}}) -> Vsn;
-vsn_from_ref({git, _, Vsn}) -> Vsn.
-
-flat_pkgdeps([]) -> [];
-flat_pkgdeps([{{pkg, Name, Vsn, _Url}, Deps} | Rest]) ->
-    [{{iolist_to_binary(Name),iolist_to_binary(Vsn)}, top_level_deps(Deps)}]
-    ++
-    flat_pkgdeps(Deps)
-    ++
-    flat_pkgdeps(Rest).
-
-top_level_deps([]) -> [];
-top_level_deps([{{Name, Vsn, Ref}, _} | Deps]) ->
-    [{list_to_atom(Name), Vsn, Ref} | top_level_deps(Deps)];
-top_level_deps([{{pkg, Name, Vsn, _URL}, _} | Deps]) ->
-    [{list_to_atom(Name), Vsn} | top_level_deps(Deps)].
-
-app_vsn([]) -> [];
-app_vsn([{Source, Deps} | Rest]) ->
-    {Name, Vsn} = case Source of
-        {N,V,_Ref} -> {N,V};
-        {pkg, N, V, _} -> {N,V}
-    end,
-    [{Name, Vsn}] ++ app_vsn(Deps) ++ app_vsn(Rest).
-
-mock_warnings() ->
-    %% just let it do its thing, we check warnings through
-    %% the call log.
-    meck:new(rebar_log, [no_link, passthrough]).
-
-%%% TESTS %%%
-flat(Config) -> run(Config).
-pick_highest_left(Config) -> run(Config).
-pick_highest_right(Config) -> run(Config).
-pick_smallest1(Config) -> run(Config).
-pick_smallest2(Config) -> run(Config).
-circular1(Config) -> run(Config).
-circular2(Config) -> run(Config).
-circular_skip(Config) -> run(Config).
-
-run(Config) ->
+default_nodep(Config) ->
     {ok, RebarConfig} = file:consult(?config(rebarconfig, Config)),
     rebar_test_utils:run_and_check(
-        Config, RebarConfig, ["install_deps"], ?config(expect, Config)
+        Config, RebarConfig, ["deps"], {ok, []}
     ),
-    check_warnings(warning_calls(), ?config(warnings, Config), ?config(deps_type, Config)).
+    History = meck:history(io),
+    Strings = [io_lib:format(Str, Args) || {_, {io, format, [Str, Args]}, _} <- History],
+    {match, _} = re:run(Strings, "src_a\\* \\(git source\\)"),
+    {match, _} = re:run(Strings, "src_b\\* \\(git source\\)"),
+    {match, _} = re:run(Strings, "pkg_a\\* \\(package 1.0.0\\)").
 
-warning_calls() ->
-    History = meck:history(rebar_log),
-    [{Str, Args} || {_, {rebar_log, log, [warn, Str, Args]}, _} <- History].
-
-check_warnings(_, [], _) ->
-    ok;
-check_warnings(Warns, [{Name, Vsn} | Rest], Type) ->
-    ct:pal("Checking for warning ~p in ~p", [{Name,Vsn},Warns]),
-    ?assert(in_warnings(Type, Warns, Name, Vsn)),
-    check_warnings(Warns, Rest, Type).
-
-in_warnings(git, Warns, NameRaw, VsnRaw) ->
-    Name = iolist_to_binary(NameRaw),
-    1 =< length([1 || {_, [AppName, {git, _, {_, Vsn}}]} <- Warns,
-                      AppName =:= Name, Vsn =:= VsnRaw]);
-in_warnings(pkg, Warns, NameRaw, VsnRaw) ->
-    Name = iolist_to_binary(NameRaw),
-    Vsn = iolist_to_binary(VsnRaw),
-    1 =< length([1 || {_, [AppName, AppVsn]} <- Warns,
-                      AppName =:= Name, AppVsn =:= Vsn]).
-
+default_lock(Config) ->
+    {ok, RebarConfig} = file:consult(?config(rebarconfig, Config)),
+    rebar_test_utils:run_and_check(
+        Config, RebarConfig, ["lock"], {ok, []}
+    ),
+    rebar_test_utils:run_and_check(
+        Config, RebarConfig, ["deps"], {ok, []}
+    ),
+    History = meck:history(io),
+    Strings = [io_lib:format(Str, Args) || {_, {io, format, [Str, Args]}, _} <- History],
+    {match, _} = re:run(Strings, "src_a\\ \\(locked git source\\)"),
+    {match, _} = re:run(Strings, "src_b\\ \\(locked git source\\)"),
+    {match, _} = re:run(Strings, "pkg_a\\ \\(locked package 1.0.0\\)").

--- a/test/rebar_install_deps_SUITE.erl
+++ b/test/rebar_install_deps_SUITE.erl
@@ -1,0 +1,221 @@
+-module(rebar_install_deps_SUITE).
+-compile(export_all).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+all() -> [{group, git}, {group, pkg}].
+
+groups() ->
+    [{all, [], [flat, pick_highest_left, pick_highest_right,
+                pick_smallest1, pick_smallest2,
+                circular1, circular2, circular_skip]},
+     {git, [], [{group, all}]},
+     {pkg, [], [{group, all}]}].
+
+init_per_suite(Config) ->
+    application:start(meck),
+    Config.
+
+end_per_suite(_Config) ->
+    application:stop(meck).
+
+init_per_group(git, Config) ->
+    [{deps_type, git} | Config];
+init_per_group(pkg, Config) ->
+    [{deps_type, pkg} | Config];
+init_per_group(_, Config) ->
+    Config.
+
+end_per_group(_, Config) ->
+    Config.
+
+init_per_testcase(Case, Config) ->
+    {Deps, Warnings, Expect} = deps(Case),
+    Expected = case Expect of
+        {ok, List} -> {ok, format_expected_deps(List)};
+        {error, Reason} -> {error, Reason}
+    end,
+    DepsType = ?config(deps_type, Config),
+    mock_warnings(),
+    [{expect, Expected},
+     {warnings, Warnings}
+    | setup_project(Case, Config, expand_deps(DepsType, Deps))].
+
+end_per_testcase(_, Config) ->
+    meck:unload(),
+    Config.
+
+format_expected_deps(Deps) ->
+    [case Dep of
+        {N,V} -> {dep, N, V};
+        N -> {dep, N}
+     end || Dep <- Deps].
+
+%% format:
+%% {Spec,
+%%  [Warning],
+%%  {ok, Result} | {error, Reason}}
+%%
+%% Spec is a list of levelled dependencies of two possible forms:
+%% - {"Name", Spec}
+%% - {"Name", "Vsn", Spec}
+%%
+%% Warnings are going to match on mocked ?WARN(...)
+%% calls to be evaluated. An empty list means we do not care about
+%% warnings, not that no warnings will be printed. This means
+%% the list of warning isn't interpreted to be exhaustive, and more
+%% warnings may be generated than are listed.
+deps(flat) ->
+    {[{"B", []},
+      {"C", []}],
+     [],
+     {ok, ["B", "C"]}};
+deps(pick_highest_left) ->
+    {[{"B", [{"C", "2", []}]},
+      {"C", "1", []}],
+     [{"C","2"}],
+     {ok, ["B", {"C", "1"}]}};
+deps(pick_highest_right) ->
+    {[{"B", "1", []},
+      {"C", [{"B", "2", []}]}],
+     [{"B","2"}],
+     {ok, [{"B","1"}, "C"]}};
+deps(pick_smallest1) ->
+    {[{"B", [{"D", "1", []}]},
+      {"C", [{"D", "2", []}]}],
+     [{"D","2"}],
+     %% we pick D1 because B < C
+     {ok, ["B","C",{"D","1"}]}};
+deps(pick_smallest2) ->
+    {[{"C", [{"D", "2", []}]},
+      {"B", [{"D", "1", []}]}],
+     [{"D","2"}],
+     %% we pick D1 because B < C
+     {ok, ["B","C",{"D","1"}]}};
+deps(circular1) ->
+    {[{"B", [{"A", []}]}, % A is the top-level app
+      {"C", []}],
+     [],
+     {error, {rebar_prv_install_deps, {cycles, [[<<"A">>,<<"B">>]]}}}};
+deps(circular2) ->
+    {[{"B", [{"C", [{"B", []}]}]},
+      {"C", []}],
+     [],
+     {error, {rebar_prv_install_deps, {cycles, [[<<"B">>,<<"C">>]]}}}};
+deps(circular_skip) ->
+    %% Never spot the circular dep due to being to low in the deps tree
+    %% in source deps
+    {[{"B", [{"C", "2", [{"B", []}]}]},
+      {"C", "1", [{"D",[]}]}],
+     [{"C","2"}],
+     {ok, ["B", {"C","1"}, "D"]}}.
+
+expand_deps(_, []) -> [];
+expand_deps(git, [{Name, Deps} | Rest]) ->
+    Dep = {Name, ".*", {git, "https://example.org/user/"++Name++".git", "master"}},
+    [{Dep, expand_deps(git, Deps)} | expand_deps(git, Rest)];
+expand_deps(git, [{Name, Vsn, Deps} | Rest]) ->
+    Dep = {Name, Vsn, {git, "https://example.org/user/"++Name++".git", {tag, Vsn}}},
+    [{Dep, expand_deps(git, Deps)} | expand_deps(git, Rest)];
+expand_deps(pkg, [{Name, Deps} | Rest]) ->
+    Dep = {pkg, Name, "0.0.0", "https://example.org/user/"++Name++".tar.gz"},
+    [{Dep, expand_deps(pkg, Deps)} | expand_deps(pkg, Rest)];
+expand_deps(pkg, [{Name, Vsn, Deps} | Rest]) ->
+    Dep = {pkg, Name, Vsn, "https://example.org/user/"++Name++".tar.gz"},
+    [{Dep, expand_deps(pkg, Deps)} | expand_deps(pkg, Rest)].
+
+setup_project(Case, Config0, Deps) ->
+    DepsType = ?config(deps_type, Config0),
+    Config = rebar_test_utils:init_rebar_state(
+            Config0,
+            atom_to_list(Case)++"_"++atom_to_list(DepsType)++"_"
+    ),
+    AppDir = ?config(apps, Config),
+    rebar_test_utils:create_app(AppDir, "A", "0.0.0", [kernel, stdlib]),
+    TopDeps = top_level_deps(Deps),
+    RebarConf = rebar_test_utils:create_config(AppDir, [{deps, TopDeps}]),
+    case DepsType of
+        git ->
+            mock_git_resource:mock([{deps, flat_deps(Deps)}]);
+        pkg ->
+            mock_pkg_resource:mock([{pkgdeps, flat_pkgdeps(Deps)}])
+    end,
+    [{rebarconfig, RebarConf} | Config].
+
+
+flat_deps([]) -> [];
+flat_deps([{{Name,_Vsn,Ref}, Deps} | Rest]) ->
+    [{{Name,vsn_from_ref(Ref)}, top_level_deps(Deps)}]
+    ++
+    flat_deps(Deps)
+    ++
+    flat_deps(Rest).
+
+vsn_from_ref({git, _, {_, Vsn}}) -> Vsn;
+vsn_from_ref({git, _, Vsn}) -> Vsn.
+
+flat_pkgdeps([]) -> [];
+flat_pkgdeps([{{pkg, Name, Vsn, _Url}, Deps} | Rest]) ->
+    [{{iolist_to_binary(Name),iolist_to_binary(Vsn)}, top_level_deps(Deps)}]
+    ++
+    flat_pkgdeps(Deps)
+    ++
+    flat_pkgdeps(Rest).
+
+top_level_deps([]) -> [];
+top_level_deps([{{Name, Vsn, Ref}, _} | Deps]) ->
+    [{list_to_atom(Name), Vsn, Ref} | top_level_deps(Deps)];
+top_level_deps([{{pkg, Name, Vsn, _URL}, _} | Deps]) ->
+    [{list_to_atom(Name), Vsn} | top_level_deps(Deps)].
+
+app_vsn([]) -> [];
+app_vsn([{Source, Deps} | Rest]) ->
+    {Name, Vsn} = case Source of
+        {N,V,_Ref} -> {N,V};
+        {pkg, N, V, _} -> {N,V}
+    end,
+    [{Name, Vsn}] ++ app_vsn(Deps) ++ app_vsn(Rest).
+
+mock_warnings() ->
+    %% just let it do its thing, we check warnings through
+    %% the call log.
+    meck:new(rebar_log, [no_link, passthrough]).
+
+%%% TESTS %%%
+flat(Config) -> run(Config).
+pick_highest_left(Config) -> run(Config).
+pick_highest_right(Config) -> run(Config).
+pick_smallest1(Config) -> run(Config).
+pick_smallest2(Config) -> run(Config).
+circular1(Config) -> run(Config).
+circular2(Config) -> run(Config).
+circular_skip(Config) -> run(Config).
+
+run(Config) ->
+    {ok, RebarConfig} = file:consult(?config(rebarconfig, Config)),
+    rebar_test_utils:run_and_check(
+        Config, RebarConfig, ["install_deps"], ?config(expect, Config)
+    ),
+    check_warnings(warning_calls(), ?config(warnings, Config), ?config(deps_type, Config)).
+
+warning_calls() ->
+    History = meck:history(rebar_log),
+    [{Str, Args} || {_, {rebar_log, log, [warn, Str, Args]}, _} <- History].
+
+check_warnings(_, [], _) ->
+    ok;
+check_warnings(Warns, [{Name, Vsn} | Rest], Type) ->
+    ct:pal("Checking for warning ~p in ~p", [{Name,Vsn},Warns]),
+    ?assert(in_warnings(Type, Warns, Name, Vsn)),
+    check_warnings(Warns, Rest, Type).
+
+in_warnings(git, Warns, NameRaw, VsnRaw) ->
+    Name = iolist_to_binary(NameRaw),
+    1 =< length([1 || {_, [AppName, {git, _, {_, Vsn}}]} <- Warns,
+                      AppName =:= Name, Vsn =:= VsnRaw]);
+in_warnings(pkg, Warns, NameRaw, VsnRaw) ->
+    Name = iolist_to_binary(NameRaw),
+    Vsn = iolist_to_binary(VsnRaw),
+    1 =< length([1 || {_, [AppName, AppVsn]} <- Warns,
+                      AppName =:= Name, AppVsn =:= Vsn]).
+


### PR DESCRIPTION
Gives output such as:

```
$ rebar3 as test deps
ranch (locked package 1.0.0)
uuid (locked git source)
recon (locked git source)
peeranha (locked git source)
file_monitor (locked git source)
bootstrap (locked git source)

-- test --
meck* (git source)
```
And does handle fetched/non-fetched deps, locks, etc. Only package versions are displayed. Git sources are supported. Other sources are unknown and the whole `{Type, Ref}` tuple is returned.

The `*` asterisk denotes the app needs to be fetched or upgraded.
Only top-level deps are displayed.