### PR TITLE
purge mods loaded during check to see if they need to be recompiled

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -265,9 +265,11 @@ opts_changed(Opts, Target) ->
     case code:load_abs(ObjectFile) of
         {module, Mod} ->
             Compile = Mod:module_info(compile),
+            %% dialyzer and eunit have trouble without the next two lines
+            code:delete(Mod),
+            code:purge(Mod),
             lists:sort(Opts) =/= lists:sort(proplists:get_value(options,
-                                                                Compile,
-                                                                undefined));
+                                                                Compile));
         {error, nofile} -> true
     end.
 


### PR DESCRIPTION
the `needs_update/4` function loads old modules to check to see if they need to be recompiled. subsequently, the file is not reloaded even if it's recompiled. this means potential problems with tasks run after `compile`