### PR TITLE
Preserve erl_opts from parent state in rebar_state:new/3

### DIFF
--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -97,7 +97,9 @@ new(ParentState, Config, Dir) ->
                         D = proplists:get_value(deps, Config, []),
                         dict:from_list([{{deps, default}, D} | Config])
                 end,
-    NewOpts = dict:merge(fun(_Key, Value1, _Value2) ->
+    NewOpts = dict:merge(fun(erl_opts, _Value1, Value2) ->
+                                 Value2;
+                             (_Key, Value1, _Value2) ->
                                  Value1
                          end, LocalOpts, Opts),
     ParentState#state_t{dir=Dir


### PR DESCRIPTION
Preserve the `erl_opts` set in the parent state when creating a new state
with `rebar_state:new/3`. This allows options that are set by intermediate
providers or plugins to persist through a command execution. This is
useful for example when creating an eunit testing plugin that passes
compiler options to be used when building files for test
execution. Without this change those options are lost when the eunit
provider creates a new state to pass to `rebar_erlc_compiler`.

I ran into this specifically while creating a plugin to detect and set appropriate 
compile defines for different Erlang property-based testing libraries like quickcheck.
I set my plugin as a pre provider hook for eunit and it all works well until
 [this](https://github.com/rebar/rebar3/blob/master/src/rebar_prv_eunit.erl#L46) call to `rebar_state:new/3`. With this change the plugin works as expected.