### PR TITLE
follow xdg standard. fixes #122

### DIFF
--- a/doc/templates.md
+++ b/doc/templates.md
@@ -17,7 +17,7 @@
 
 ## Global Variables
 
-Global variables can be set by editing the file at `$HOME/.rebar3/templates/globals`:
+Global variables can be set by editing the file at `$HOME/.config/rebar3/templates/globals`:
 
     {variables, [
         {author_name, "My Name Is A String"},
@@ -29,7 +29,7 @@ This will let you define variables for all templates.
 
 Variables left undefined will be ignored and revert to the default value.
 
-The override order for these variables will be: Defaults < $HOME/.rebar3/templates/globals < command line invocation.
+The override order for these variables will be: Defaults < $HOME/.config/rebar3/templates/globals < command line invocation.
 
 ## Batteries-Included Templates ##
 
@@ -77,7 +77,7 @@ Then go to the directory created for the project by rebar3.
 
 ## Custom Templates ##
 
-Custom templates can be added in `$HOME/.rebar3/templates/`. Each template is at least two files:
+Custom templates can be added in `$HOME/.config/rebar3/templates/`. Each template is at least two files:
 
 - `my_template.dtl`: There can be many of these files. They are regular Erlang files using the django template syntax for variable replacements.
 - `my_template.template`; Called the *template index*, there is one per template callable from `rebar3`. This one will be visible when calling `rebar3 new my_template`. This file regroups the different \*.dtl files into a more cohesive template.
@@ -112,7 +112,7 @@ Specifically:
 
 ### Example ###
 
-As an example, we'll create a template for Common Test test suites. Create the directory structure `~/.rebar/templates/` and then go in there.
+As an example, we'll create a template for Common Test test suites. Create the directory structure `~/.config/rebar/templates/` and then go in there.
 
 We'll start with an index for our template, called `ct_suite.template`:
 
@@ -173,7 +173,7 @@ Let's look at the details:
 
     → ./rebar3 new help ct_suite
     ct_suite:
-            custom template (/home/ferd/.rebar3/templates/ct_suite.template)
+            custom template (/home/ferd/.config/rebar3/templates/ct_suite.template)
             Description: A basic Common Test suite for an OTP application
             Variables:
                     name="suite" (Name of the suite, prepended to the standard _SUITE suffix)

--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -22,7 +22,6 @@
 -define(DEFAULT_RELEASE_DIR, "rel").
 -define(DEFAULT_CONFIG_FILE, "rebar.config").
 -define(LOCK_FILE, "rebar.lock").
--define(CONFIG_DIR, ".rebar3").
 
 -ifdef(namespaced_types).
 -type rebar_dict() :: dict:dict().

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -152,9 +152,8 @@ init_config() ->
                       Config
               end,
 
-    %% If $HOME/.rebar3/config exists load and use as global config
-    Home = rebar_dir:home_dir(),
-    GlobalConfigFile = filename:join([Home, ?CONFIG_DIR, "config"]),
+    %% If $HOME/.config/rebar3/config exists load and use as global config
+    GlobalConfigFile = rebar_dir:global_config(),
     State = case filelib:is_regular(GlobalConfigFile) of
                 true ->
                     ?DEBUG("Load global config file ~p",

--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -7,8 +7,13 @@
          lib_dirs/1,
          home_dir/0,
          global_config_dir/1,
+         global_config/1,
+         global_config/0,
+         global_cache_dir/1,
+         local_cache_dir/0,
          get_cwd/0,
-         ensure_dir/1,
+         template_globals/1,
+         template_dir/1,
          src_dirs/1,
          ebin_dir/0,
          processing_base_dir/1,
@@ -47,23 +52,31 @@ home_dir() ->
 
 global_config_dir(State) ->
     Home = home_dir(),
-    rebar_state:get(State, global_rebar_dir, filename:join(Home, ?CONFIG_DIR)).
+    rebar_state:get(State, global_rebar_dir, filename:join([Home, ".config", "rebar3"])).
+
+global_config(State) ->
+    filename:join(global_config_dir(State), "config").
+
+global_config() ->
+    Home = home_dir(),
+    filename:join([Home, ".config", "rebar3", "config"]).
+
+global_cache_dir(State) ->
+    Home = home_dir(),
+    rebar_state:get(State, global_rebar_dir, filename:join([Home, ".cache", "rebar3"])).
+
+local_cache_dir() ->
+    filename:join(get_cwd(), ".rebar3").
 
 get_cwd() ->
     {ok, Dir} = file:get_cwd(),
     Dir.
 
-%% TODO: filelib:ensure_dir/1 corrected in R13B04. Remove when we drop
-%% support for OTP releases older than R13B04.
-ensure_dir(Path) ->
-    case filelib:ensure_dir(Path) of
-        ok ->
-            ok;
-        {error,eexist} ->
-            ok;
-        Error ->
-            Error
-    end.
+template_globals(State) ->
+    filename:join([global_config_dir(State), "templates", "globals"]).
+
+template_dir(State) ->
+    filename:join([global_config_dir(State), "templates"]).
 
 -spec src_dirs([string()]) -> [file:filename(), ...].
 src_dirs([]) ->

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -283,7 +283,7 @@ check_erlcinfo(Config, _) ->
            [erlcinfo_file(Config)]).
 
 erlcinfo_file(_Config) ->
-    filename:join([rebar_dir:get_cwd(), ?CONFIG_DIR, ?ERLCINFO_FILE]).
+    filename:join(rebar_dir:local_cache_dir(), ?ERLCINFO_FILE).
 
 init_erlcinfo(Config, Erls) ->
     G = restore_erlcinfo(Config),
@@ -464,8 +464,8 @@ internal_erl_compile(Config, Dir, Source, OutDir, ErlOpts, G) ->
 -spec compile_mib(file:filename(), file:filename(),
                   rebar_state:t()) -> 'ok'.
 compile_mib(Source, Target, Config) ->
-    ok = rebar_dir:ensure_dir(Target),
-    ok = rebar_dir:ensure_dir(filename:join("include", "dummy.hrl")),
+    ok = filelib:ensure_dir(Target),
+    ok = filelib:ensure_dir(filename:join("include", "dummy.hrl")),
     Opts = [{outdir, "priv/mibs"}, {i, ["priv/mibs"]}] ++
         rebar_state:get(Config, mib_opts, []),
     case snmpc:compile(Source, Opts) of

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -12,7 +12,7 @@
 
 -spec get_packages(rebar_state:t()) -> {rebar_dict(), rebar_digraph()}.
 get_packages(State) ->
-    RebarDir = rebar_dir:global_config_dir(State),
+    RebarDir = rebar_dir:global_cache_dir(State),
     RegistryDir = filename:join(RebarDir, "packages"),
     DictFile = filename:join(RegistryDir, "dict"),
     Edges = filename:join(RegistryDir, "edges"),

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -311,8 +311,7 @@ build_proj_plt(State, Plt, Files) ->
     end.
 
 get_base_plt_location(State) ->
-    Home = rebar_dir:home_dir(),
-    GlobalConfigDir = filename:join(Home, ?CONFIG_DIR),
+    GlobalConfigDir = rebar_dir:global_config_dir(State),
     BaseDir = rebar_state:get(State, dialyzer_base_plt_dir, GlobalConfigDir),
     BasePlt = rebar_state:get(State, dialyzer_base_plt, default_plt()),
     filename:join(BaseDir, BasePlt).

--- a/src/rebar_prv_update.erl
+++ b/src/rebar_prv_update.erl
@@ -59,7 +59,7 @@ format_error(package_index_write) ->
     "Failed to write package index.".
 
 write_registry(Dict, {digraph, Edges, Vertices, Neighbors, _}, State) ->
-    Dir = rebar_dir:global_config_dir(State),
+    Dir = rebar_dir:global_cache_dir(State),
     RegistryDir = filename:join(Dir, "packages"),
     filelib:ensure_dir(filename:join(RegistryDir, "dummy")),
     ets:tab2file(Edges, filename:join(RegistryDir, "edges")),

--- a/test/rebar_new_SUITE.erl
+++ b/test/rebar_new_SUITE.erl
@@ -23,7 +23,7 @@ end_per_testcase(_, Config) ->
 
 mock_home_dir(Path) ->
     meck:new(rebar_dir, [passthrough]),
-    meck:expect(rebar_dir, home_dir, fun() -> Path end).
+    meck:expect(rebar_dir, template_dir, fun(_) -> Path end).
 
 mock_empty_escript_templates() ->
     %% Can't find escript templates unless we run

--- a/test/rebar_upgrade_SUITE.erl
+++ b/test/rebar_upgrade_SUITE.erl
@@ -357,10 +357,10 @@ upgrades(delete_d) ->
 %% running the upgrade code is enough to properly upgrade things.
 
 top_level_deps([]) -> [];
-top_level_deps([{{Name, Vsn, Ref}, _} | Deps]) ->
-    [{list_to_atom(Name), Vsn, Ref} | top_level_deps(Deps)];
 top_level_deps([{{pkg, Name, Vsn}, _} | Deps]) ->
-    [{list_to_atom(Name), Vsn} | top_level_deps(Deps)].
+    [{list_to_atom(Name), Vsn} | top_level_deps(Deps)];
+top_level_deps([{{Name, Vsn, Ref}, _} | Deps]) ->
+    [{list_to_atom(Name), Vsn, Ref} | top_level_deps(Deps)].
 
 mock_deps(git, Deps, Upgrades) ->
     catch mock_git_resource:unmock(),


### PR DESCRIPTION
Moves the rebar3 config (including templates and plugins) to `~/.config/rebar3` and the package cache to `~/.cache/rebar3`

fixes #122