### PR TITLE
output hook stdout and don't add extra newline

### DIFF
--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -22,4 +22,4 @@ apply_hook(Dir, Env, {Arch, Command, Hook}) ->
     end;
 apply_hook(Dir, Env, {Command, Hook}) ->
     Msg = lists:flatten(io_lib:format("Hook for ~p failed!~n", [Command])),
-    rebar_utils:sh(Hook, [{cd, Dir}, {env, Env}, {abort_on_error, Msg}]).
+    rebar_utils:sh(Hook, [use_stdout, {cd, Dir}, {env, Env}, {abort_on_error, Msg}]).

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -314,7 +314,8 @@ expand_sh_flag(debug_and_abort_on_error) ->
 expand_sh_flag(use_stdout) ->
     {output_handler,
      fun(Line, Acc) ->
-             ?CONSOLE("~s", [Line]),
+             %% Line already has a newline so don't use ?CONSOLE which adds one
+             io:format("~s", [Line]),
              [Line | Acc]
      end};
 expand_sh_flag({use_stdout, false}) ->


### PR DESCRIPTION
Useful especially since we are using Makefiles from hooks for c_src and get no output on error without this change.