### PR TITLE
Fix crash on non-git source deps in deps provider

### DIFF
--- a/src/rebar_prv_deps.erl
+++ b/src/rebar_prv_deps.erl
@@ -67,7 +67,7 @@ display_dep(_State, {Name, _Vsn, Source}) when is_tuple(Source), element(1, Sour
 display_dep(_State, {Name, _Vsn, Source, _Opts}) when is_tuple(Source), element(1, Source) =:= git ->
     ?CONSOLE("~s* (git soutce)", [ec_cnv:to_binary(Name)]);
 %% unknown source
-display_dep(_State, {Name, Source}) when is_tuple(Source), element(1, Source) ->
+display_dep(_State, {Name, Source}) when is_tuple(Source) ->
     ?CONSOLE("~s* (source ~p)", [ec_cnv:to_binary(Name), Source]);
 display_dep(_State, {Name, _Vsn, Source}) when is_tuple(Source) ->
     ?CONSOLE("~s* (source ~p)", [ec_cnv:to_binary(Name), Source]);


### PR DESCRIPTION
The 'element(1, ..)' guard would always fail and cause crashes.