### PR TITLE
one ebin to rule them all

### DIFF
--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -15,7 +15,7 @@
          command_args/1, command_args/2,
          command_parsed_args/1, command_parsed_args/2,
 
-         apply_profiles/2,
+         add_to_profile/3, apply_profiles/2,
 
          dir/1, dir/2,
          create_logic_providers/2,
@@ -186,6 +186,13 @@ apply_overrides(State=#state_t{overrides=Overrides}, AppName) ->
                    (_, StateAcc) ->
                         StateAcc
                 end, State2, Overrides).
+
+add_to_profile(State, Profile, KVs) when is_atom(Profile), is_list(KVs) ->
+    Profiles = rebar_state:get(State, profiles, []),
+    ProfileOpts = dict:from_list(proplists:get_value(Profile, Profiles, [])),
+    NewOpts = merge_opts(Profile, dict:from_list(KVs), ProfileOpts),
+    NewProfiles = [{Profile, dict:to_list(NewOpts)}|lists:keydelete(Profile, 1, Profiles)],
+    rebar_state:set(State, profiles, NewProfiles).
 
 apply_profiles(State, Profile) when not is_list(Profile) ->
     apply_profiles(State, [Profile]);


### PR DESCRIPTION
this is the pr that fixes the issue with project app structure needing to be copied alongside the test artifacts in order to make `priv` and `src` dirs discoverable. it does so by building in the `ebin` dirs of whatever apps they belong to.

of note, this adds `ct` and `eunit` profiles to the respective providers to allow for compiling with `ct` and `eunit` specific options without stepping all over the `test` profile

also of note, this addresses #158 but doesn't implement any of the solutions in that issue (except the third, the non-solution)