### PR TITLE
reset state between tasks run with `do`

### DIFF
--- a/src/rebar_prv_do.erl
+++ b/src/rebar_prv_do.erl
@@ -42,8 +42,8 @@ do_tasks([{TaskStr, Args}|Tail], State) ->
     State1 = rebar_state:set(State, task, Task),
     State2 = rebar_state:command_args(State1, Args),
     case rebar_core:process_command(State2, Task) of
-        {ok, State3} ->
-            do_tasks(Tail, State3);
+        {ok, _} ->
+            do_tasks(Tail, State);
         Error ->
             Error
     end.


### PR DESCRIPTION
so `rebar do foo, bar, baz` has the same outcome as `rebar3 foo && rebar3 bar && rebar3 baz`

fixes #191