### PR TITLE
Do not automatically check plt

### DIFF
--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -380,13 +380,18 @@ run_dialyzer(State, Opts) ->
     case proplists:get_bool(get_warnings, Opts) of
         true ->
             WarningsList = rebar_state:get(State, dialyzer_warnings, []),
-            Opts2 = [{warnings, WarningsList} | Opts],
+            Opts2 = [{warnings, WarningsList},
+                     {check_plt, false} |
+                     Opts],
             {Unknowns, Warnings} = format_warnings(dialyzer:run(Opts2)),
             _ = [?CONSOLE("~s", [Unknown]) || Unknown <- Unknowns],
             _ = [?CONSOLE("~s", [Warning]) || Warning <- Warnings],
             {length(Warnings), State};
         false ->
-            _ = dialyzer:run([{warnings, no_warnings()} | Opts]),
+            Opts2 = [{warnings, no_warnings()},
+                     {check_plt, false} |
+                     Opts],
+            _ = dialyzer:run(Opts2),
             {0, State}
     end.
 


### PR DESCRIPTION
Fixes #148.

This uses an undocumented option (`{check_plt, false}`) to avoid the bug in dialyzer.erl. The option is available since at least R13B03 and if it was documented we would want to use it regardless of the bug[1]. I will do a PR to OTP to document this option (it is documented on the command line interface) and fix the actual bug in dialyzer.erl too.

[1] We check the plt explicitly with `{analysis_type, check_plt}` and currently triple check the PLT. Adding this option is a significant speed boost, especially on small applications with many dependencies.