### PR TITLE
preserve state when compiling directories with a `rebar.config`

### DIFF
--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -127,28 +127,27 @@ set_verbose(Opts) ->
     end.
 
 compile_tests(State, TestApps) ->
-    State1 = replace_src_dirs(State),
     F = fun(AppInfo) ->
         AppDir = rebar_app_info:dir(AppInfo),
         S = case rebar_app_info:state(AppInfo) of
             undefined ->
                 C = rebar_config:consult(AppDir),
-                rebar_state:new(State1, C, AppDir);
+                rebar_state:new(State, C, AppDir);
             AppState ->
                 AppState
         end,
-        ok = rebar_erlc_compiler:compile(S,
+        ok = rebar_erlc_compiler:compile(replace_src_dirs(S),
                                          ec_cnv:to_list(rebar_app_info:dir(AppInfo)),
                                          ec_cnv:to_list(rebar_app_info:out_dir(AppInfo)))
     end,
     lists:foreach(F, TestApps),
-    compile_bare_tests(State1, TestApps).
+    compile_bare_tests(State, TestApps).
 
 compile_bare_tests(State, TestApps) ->
     F = fun(App) -> rebar_app_info:dir(App) == rebar_dir:get_cwd() end,
     case lists:filter(F, TestApps) of
         %% compile just the `test` directory of the base dir
-        [] -> rebar_erlc_compiler:compile(State,
+        [] -> rebar_erlc_compiler:compile(replace_src_dirs(State),
                                           rebar_dir:get_cwd(),
                                           rebar_dir:base_dir(State));
         %% already compiled `./test` so do nothing


### PR DESCRIPTION
this fixes an issue similar to #211 but is still currently broken due to #212. i think it should still be merged however to aid in fixing #212