### PR TITLE
the `as` provider should only add profiles to the list to be applied and not apply them itself

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -27,7 +27,7 @@ base_dir(State) ->
         ["default"]      -> ["default"];
         %% drop `default` from the profile dir if it's implicit and reverse order
         %%  of profiles to match order passed to `as`
-        ["default"|Rest] -> lists:reverse(Rest)
+        ["default"|Rest] -> Rest
     end,
     ProfilesDir = string:join(ProfilesStrings, "+"),
     filename:join(rebar_state:get(State, base_dir, ?DEFAULT_BASE_DIR), ProfilesDir).

--- a/src/rebar_prv_as.erl
+++ b/src/rebar_prv_as.erl
@@ -37,7 +37,10 @@ do(State) ->
         [] ->
             {error, "At least one profile must be specified when using `as`"};
         _  ->
-            State1 = rebar_state:apply_profiles(State, [list_to_atom(X) || X <- Profiles]),
+            CurrentProfiles = rebar_state:current_profiles(State),
+            NewProfiles = CurrentProfiles ++ [list_to_atom(X) || X <- Profiles],
+            ?DEBUG("Running tasks as: ~p", [NewProfiles]),
+            State1 = rebar_state:current_profiles(State, NewProfiles),
             rebar_prv_do:do_tasks(Tasks, State1)
     end.
 

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -10,7 +10,7 @@
 
          lock/1, lock/2,
 
-         current_profiles/1,
+         current_profiles/1, current_profiles/2,
 
          command_args/1, command_args/2,
          command_parsed_args/1, command_parsed_args/2,
@@ -131,6 +131,9 @@ opts(#state_t{opts=Opts}) ->
 
 current_profiles(#state_t{current_profiles=Profiles}) ->
     Profiles.
+
+current_profiles(State, Profiles) ->
+    State#state_t{current_profiles=Profiles}.
 
 lock(#state_t{lock=Lock}) ->
     Lock.

--- a/test/rebar_profiles_SUITE.erl
+++ b/test/rebar_profiles_SUITE.erl
@@ -10,7 +10,8 @@
          profile_merges/1,
          add_to_profile/1,
          add_to_existing_profile/1,
-         profiles_remain_applied_with_config_present/1]).
+         profiles_remain_applied_with_config_present/1,
+         only_apply_profiles_once/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -19,7 +20,8 @@
 all() ->
     [profile_new_key, profile_merge_keys, profile_merges,
      add_to_profile, add_to_existing_profile,
-     profiles_remain_applied_with_config_present].
+     profiles_remain_applied_with_config_present,
+     only_apply_profiles_once].
 
 init_per_suite(Config) ->
     application:start(meck),
@@ -151,3 +153,21 @@ profiles_remain_applied_with_config_present(Config) ->
     Mod = list_to_atom("not_a_real_src_" ++ Name),
 
     true = lists:member({d, not_ok}, proplists:get_value(options, Mod:module_info(compile), [])).
+
+only_apply_profiles_once(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("apply_once_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    RebarConfig = [{erl_opts, []}, {profiles, [
+        {only_once, [{erl_opts, [{d, some_define}]}]}
+    ]}],
+
+    rebar_test_utils:create_config(AppDir, RebarConfig),
+
+    %% if both `as` and `app_discovery` apply profiles this will fail with `some_define`
+    %%  being declared twice
+    rebar_test_utils:run_and_check(Config, RebarConfig,
+                                   ["as", "only_once", "compile"], {ok, [{app, Name}]}).


### PR DESCRIPTION
fixes #225 