### PR TITLE
Change PLT name and directory

### DIFF
--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -91,24 +91,7 @@ get_plt_location(State) ->
     rebar_state:get(State, dialyzer_plt, DefaultPlt).
 
 default_plt() ->
-    ".rebar3.otp-" ++ otp_version() ++ ".plt".
-
-otp_version() ->
-    Release = erlang:system_info(otp_release),
-    try otp_version(Release) of
-        Vsn ->
-            Vsn
-    catch
-        error:_ ->
-            Release
-    end.
-
-otp_version(Release) ->
-    File = filename:join([code:root_dir(), "releases", Release, "OTP_VERSION"]),
-    {ok, Contents} = file:read_file(File),
-    [Vsn] = binary:split(Contents, [<<$\n>>], [global, trim]),
-    [_ | _] = unicode:characters_to_list(Vsn).
-
+    ".rebar3.otp-" ++ rebar_utils:otp_release() ++ ".plt".
 
 do(State, Plt, Apps) ->
     {PltWarnings, State1} = update_proj_plt(State, Plt, Apps),

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -91,7 +91,7 @@ get_plt_location(State) ->
     rebar_state:get(State, dialyzer_plt, DefaultPlt).
 
 default_plt() ->
-    ".rebar3.otp-" ++ rebar_utils:otp_release() ++ ".plt".
+    rebar_utils:otp_release() ++ ".plt".
 
 do(State, Plt, Apps) ->
     {PltWarnings, State1} = update_proj_plt(State, Plt, Apps),

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -86,8 +86,8 @@ format_error(Reason) ->
 %% Internal functions
 
 get_plt_location(State) ->
-    BuildDir = rebar_state:get(State, base_dir, ?DEFAULT_BASE_DIR),
-    DefaultPlt = filename:join([BuildDir, default_plt()]),
+    BaseDir = rebar_dir:base_dir(State),
+    DefaultPlt = filename:join(BaseDir, default_plt()),
     rebar_state:get(State, dialyzer_plt, DefaultPlt).
 
 default_plt() ->


### PR DESCRIPTION
* Moves the PLT from `./_build/` to `./_build/profile/` to respect profiles.
* Uses rebar_utils:opt_release() to name PLT files
* Use shorter name for default PLT

The current PLT name format `.rebar3.otp-{OTP_RELEASE}.plt` was chosen when project PLTs were placed in `./` (before `./_build`, `~/.config/.rebar3/` and profiles). Given that moving the project PLT to the profile directory will cause projects to rebuild their PLT's I thought it a convenience to change to a minimal naming scheme at the same moment.
