### PR TITLE
`rebar_erlc_compiler` now looks in the right place for extra source directories

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -140,7 +140,7 @@ doterl_compile(Config, Dir, ODir, MoreSources, ErlOpts) ->
     %% Support the src_dirs option allowing multiple directories to
     %% contain erlang source. This might be used, for example, should
     %% eunit tests be separated from the core application source.
-    SrcDirs = [filename:join(Dir, X) || X <- proplists:get_value(src_dirs, ErlOpts, ["src"])],
+    SrcDirs = [filename:join(Dir, X) || X <- rebar_state:get(Config, src_dirs, ["src"])],
     AllErlFiles = gather_src(SrcDirs, []) ++ MoreSources,
 
     %% Issue: rebar/rebar3#140 (fix matching based on same path + order of

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -389,9 +389,7 @@ compile_bare_tests(State, TestApps, InDirs) ->
 
 replace_src_dirs(State, InDirs) ->
     %% replace any `src_dirs` with just the `test` dir and any `InDirs`
-    ErlOpts = rebar_state:get(State, erl_opts, []),
-    StrippedOpts = lists:keydelete(src_dirs, 1, ErlOpts),
-    rebar_state:set(State, erl_opts, [{src_dirs, ["test"|InDirs]}|StrippedOpts]).
+    rebar_state:set(State, src_dirs, ["test"|InDirs]).
 
 maybe_cover_compile(State, Opts) ->
     State1 = case proplists:get_value(cover, Opts, false) of

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -71,7 +71,7 @@ build_app(State, AppInfo) ->
     AppDir = rebar_app_info:dir(AppInfo),
     OutDir = rebar_app_info:out_dir(AppInfo),
 
-    copy_app_dirs(AppDir, OutDir),
+    copy_app_dirs(State, AppDir, OutDir),
 
     S = case rebar_app_info:state(AppInfo) of
             undefined ->
@@ -108,7 +108,7 @@ handle_args(State) ->
     Jobs = proplists:get_value(jobs, Args, ?DEFAULT_JOBS),
     {ok, rebar_state:set(State, jobs, Jobs)}.
 
-copy_app_dirs(OldAppDir, AppDir) ->
+copy_app_dirs(State, OldAppDir, AppDir) ->
     case ec_cnv:to_binary(filename:absname(OldAppDir)) =/=
         ec_cnv:to_binary(filename:absname(AppDir)) of
         true ->
@@ -123,8 +123,9 @@ copy_app_dirs(OldAppDir, AppDir) ->
                     ok
             end,
             filelib:ensure_dir(filename:join(AppDir, "dummy")),
-            %% link to src to be adjacent to ebin is needed for R15 use of cover/xref
-            [symlink_or_copy(OldAppDir, AppDir, Dir) || Dir <- ["priv", "include", "src", "test"]];
+            %% link to src_dirs to be adjacent to ebin is needed for R15 use of cover/xref
+            SrcDirs = rebar_state:get(State, src_dirs, ["src"]),
+            [symlink_or_copy(OldAppDir, AppDir, Dir) || Dir <- ["priv", "include", "test"] ++ SrcDirs];
         false ->
             ok
     end.

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -156,9 +156,7 @@ compile_bare_tests(State, TestApps) ->
 
 replace_src_dirs(State) ->
     %% replace any `src_dirs` with just the `test` dir
-    ErlOpts = rebar_state:get(State, erl_opts, []),
-    StrippedOpts = lists:keydelete(src_dirs, 1, ErlOpts),
-    rebar_state:set(State, erl_opts, [{src_dirs, ["test"]}|StrippedOpts]).
+    rebar_state:set(State, src_dirs, ["test"]).
 
 maybe_cover_compile(State, Opts) ->
     State1 = case proplists:get_value(cover, Opts, false) of

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -9,6 +9,7 @@
          build_release_apps/1,
          build_checkout_apps/1,
          build_checkout_deps/1,
+         build_all_srcdirs/1,
          recompile_when_opts_change/1,
          dont_recompile_when_opts_dont_change/1,
          dont_recompile_yrl_or_xrl/1]).
@@ -32,6 +33,7 @@ init_per_testcase(_, Config) ->
 all() ->
     [build_basic_app, build_release_apps,
      build_checkout_apps, build_checkout_deps,
+     build_all_srcdirs,
      recompile_when_opts_change, dont_recompile_when_opts_dont_change,
      dont_recompile_yrl_or_xrl].
 
@@ -93,6 +95,31 @@ build_checkout_deps(Config) ->
     ok = application:load(list_to_atom(Name2)),
     Loaded = application:loaded_applications(),
     {_, _, Vsn2} = lists:keyfind(list_to_atom(Name2), 1, Loaded).
+
+build_all_srcdirs(Config) ->
+    AppDir = ?config(apps, Config),
+
+    RebarConfig = [{src_dirs, ["src", "extra"]}],
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    ExtraSrc = <<"-module(extra_src).\n"
+        "-export([ok/0]).\n"
+        "ok() -> ok.\n">>,
+
+    ok = filelib:ensure_dir(filename:join([AppDir, "extra", "dummy"])),
+    ok = file:write_file(filename:join([AppDir, "extra", "extra_src.erl"]), ExtraSrc),
+
+    rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], {ok, [{app, Name}]}),
+
+    %% check a beam corresponding to the src in the extra src_dir exists in ebin
+    EbinDir = filename:join([AppDir, "_build", "default", "lib", Name, "ebin"]),
+    true = filelib:is_file(filename:join([EbinDir, "extra_src.beam"])),
+
+    %% check the extra src_dir was linked into the _build dir
+    true = filelib:is_dir(filename:join([AppDir, "_build", "default", "lib", Name, "extra"])).
 
 recompile_when_opts_change(Config) ->
     AppDir = ?config(apps, Config),


### PR DESCRIPTION
fixes #247