### PR TITLE
compile source from the symlinked directories under `_build`

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -26,7 +26,8 @@
 %% -------------------------------------------------------------------
 -module(rebar_erlc_compiler).
 
--export([compile/3,
+-export([compile/2,
+         compile/3,
          clean/2]).
 
 -include("rebar.hrl").
@@ -78,6 +79,10 @@
 %%                          {platform_define, "R13",
 %%                           'old_inets'}]}.
 %%
+
+-spec compile(rebar_state:t(), file:name()) -> 'ok'.
+compile(Config, Dir) ->
+    compile(Config, Dir, filename:join([Dir, "ebin"])).
 
 -spec compile(rebar_state:t(), file:name(), file:name()) -> 'ok'.
 compile(Config, Dir, OutDir) ->
@@ -133,8 +138,7 @@ doterl_compile(State, Dir, ODir) ->
     ErlOpts = rebar_utils:erl_opts(State),
     doterl_compile(State, Dir, ODir, [], ErlOpts).
 
-doterl_compile(Config, Dir, ODir, MoreSources, ErlOpts) ->
-    OutDir = filename:join(ODir, "ebin"),
+doterl_compile(Config, Dir, OutDir, MoreSources, ErlOpts) ->
     ErlFirstFilesConf = rebar_state:get(Config, erl_first_files, []),
     ?DEBUG("erl_opts ~p", [ErlOpts]),
     %% Support the src_dirs option allowing multiple directories to

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -370,7 +370,6 @@ compile_tests(State, TestApps, InDirs) ->
                 AppState
         end,
         ok = rebar_erlc_compiler:compile(replace_src_dirs(S, InDirs),
-                                         ec_cnv:to_list(rebar_app_info:dir(AppInfo)),
                                          ec_cnv:to_list(rebar_app_info:out_dir(AppInfo)))
     end,
     lists:foreach(F, TestApps),
@@ -382,7 +381,7 @@ compile_bare_tests(State, TestApps, InDirs) ->
         %% compile just the `test` directory of the base dir
         [] -> rebar_erlc_compiler:compile(replace_src_dirs(State, InDirs),
                                           rebar_dir:get_cwd(),
-                                          rebar_dir:base_dir(State));
+                                          filename:join([rebar_dir:base_dir(State), "ebin"]));
         %% already compiled `./test` so do nothing
         _  -> ok
     end.

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -71,7 +71,7 @@ build_app(State, AppInfo) ->
     AppDir = rebar_app_info:dir(AppInfo),
     OutDir = rebar_app_info:out_dir(AppInfo),
 
-    copy_app_dirs(AppDir, OutDir),
+    copy_app_dirs(State, AppDir, OutDir),
 
     S = case rebar_app_info:state(AppInfo) of
             undefined ->
@@ -91,7 +91,7 @@ build_app(State, AppInfo) ->
 
 compile(State, AppInfo) ->
     ?INFO("Compiling ~s", [rebar_app_info:name(AppInfo)]),
-    rebar_erlc_compiler:compile(State, ec_cnv:to_list(rebar_app_info:dir(AppInfo)), ec_cnv:to_list(rebar_app_info:out_dir(AppInfo))),
+    rebar_erlc_compiler:compile(State, ec_cnv:to_list(rebar_app_info:out_dir(AppInfo))),
     case rebar_otp_app:compile(State, AppInfo) of
         {ok, AppInfo1} ->
             AppInfo1;
@@ -108,7 +108,7 @@ handle_args(State) ->
     Jobs = proplists:get_value(jobs, Args, ?DEFAULT_JOBS),
     {ok, rebar_state:set(State, jobs, Jobs)}.
 
-copy_app_dirs(OldAppDir, AppDir) ->
+copy_app_dirs(State, OldAppDir, AppDir) ->
     case ec_cnv:to_binary(filename:absname(OldAppDir)) =/=
         ec_cnv:to_binary(filename:absname(AppDir)) of
         true ->
@@ -123,8 +123,10 @@ copy_app_dirs(OldAppDir, AppDir) ->
                     ok
             end,
             filelib:ensure_dir(filename:join(AppDir, "dummy")),
-            %% link to src to be adjacent to ebin is needed for R15 use of cover/xref
-            [symlink_or_copy(OldAppDir, AppDir, Dir) || Dir <- ["priv", "include", "src", "test"]];
+            %% link to src_dirs to be adjacent to ebin is needed for R15 use of cover/xref
+            ErlOpts = rebar_utils:erl_opts(State),
+            SrcDirs = proplists:get_value(src_dirs, ErlOpts, ["src"]),
+            [symlink_or_copy(OldAppDir, AppDir, Dir) || Dir <- ["priv", "include", "test"] ++ SrcDirs];
         false ->
             ok
     end.

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -137,7 +137,6 @@ compile_tests(State, TestApps) ->
                 AppState
         end,
         ok = rebar_erlc_compiler:compile(replace_src_dirs(S),
-                                         ec_cnv:to_list(rebar_app_info:dir(AppInfo)),
                                          ec_cnv:to_list(rebar_app_info:out_dir(AppInfo)))
     end,
     lists:foreach(F, TestApps),
@@ -149,7 +148,7 @@ compile_bare_tests(State, TestApps) ->
         %% compile just the `test` directory of the base dir
         [] -> rebar_erlc_compiler:compile(replace_src_dirs(State),
                                           rebar_dir:get_cwd(),
-                                          rebar_dir:base_dir(State));
+                                          filename:join([rebar_dir:base_dir(State), "ebin"]));
         %% already compiled `./test` so do nothing
         _  -> ok
     end.


### PR DESCRIPTION
this gets correct compile paths included in module info which is relevant to some tools