### PR TITLE
don't create links to nonexistent directories

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -49,13 +49,18 @@ symlink_or_copy(Source, Target) ->
                _ ->
                    rebar_dir:make_relative_path(Source, Target)
            end,
-    case file:make_symlink(Link, Target) of
-        ok ->
-            ok;
-        {error, eexist} ->
-            ok;
-        {error, _} ->
-            cp_r([Source], Target)
+    case filelib:is_dir(Link) of
+        true ->
+            case file:make_symlink(Link, Target) of
+                ok ->
+                    ok;
+                {error, eexist} ->
+                    ok;
+                {error, _} ->
+                    cp_r([Source], Target)
+            end;
+        false ->
+            ok
     end.
 
 %% @doc Remove files and directories.


### PR DESCRIPTION
`file:symlink` will happily create links to nonexistent directories but we don't want those showing up in the `_build` tree