### PR TITLE
disable smp in escript

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
  [getopt, merl, erlydtl, erlware_commons, relx,  providers, rebar]}.
 {escript_top_level_app, rebar}.
 {escript_name, rebar3}.
-{escript_emu_args, "%%! +sbtu +A0 -noinput\n"}.
+{escript_emu_args, "%%! -smp disable +sbtu +A0 -noinput\n"}.
 
 {erl_opts,
  [{platform_define, "R14", no_callback_support},


### PR DESCRIPTION
Slight speed up and I can't think of a use for smp in rebar3 at this time.