### PR TITLE
fix debug format to avoid crash with custom template

### DIFF
--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -328,7 +328,7 @@ prioritize_templates([{Name, Type, File} | Rest], Valid) ->
             prioritize_templates(Rest, Valid);
         {_, file, _} ->
             ?DEBUG("Skipping template ~p, due to presence of a custom "
-                   "template at ~s~n", [File]),
+                   "template at ~s~n", [Name, File]),
             prioritize_templates(Rest, Valid)
     end.
 


### PR DESCRIPTION
error before:

===> Uncaught error: {'EXIT',
                             {badarg,
                              [{io,format,
                                [<0.23.0>,
                                 "\e[0;36m===> Skipping template ~p, due to presence of a custom template at ~s~n~n\e[0m",
                                 ["/home/mariano/.config/rebar3/templates/fn_app/fn_app.template"]],
                                []},
                               {rebar_templater,prioritize_templates,2,
                                [{file,"src/rebar_templater.erl"},{line,330}]},
                               {rebar_templater,find_templates,1,
                                [{file,"src/rebar_templater.erl"},{line,274}]},
                               {rebar_templater,new,4,
                                [{file,"src/rebar_templater.erl"},{line,47}]},
                               {rebar_prv_new,do,1,
                                [{file,"src/rebar_prv_new.erl"},{line,44}]},
                               {rebar_core,do,2,
                                [{file,"src/rebar_core.erl"},{line,129}]},
                               {rebar3,main,1,
                                [{file,"src/rebar3.erl"},{line,46}]},
                               {escript,run,2,
                                [{file,"escript.erl"},{line,752}]}]}}