### PR TITLE
Fix #267, refactor as/do/namespace interactions

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -133,7 +133,7 @@ run_aux(State, GlobalPluginProviders, RawArgs) ->
 
     {Task, Args} = parse_args(RawArgs),
 
-    rebar_core:process_command(rebar_state:command_args(State6, Args), Task).
+    rebar_core:init_command(rebar_state:command_args(State6, Args), Task).
 
 init_config() ->
     %% Initialize logging system

--- a/src/rebar_prv_as.erl
+++ b/src/rebar_prv_as.erl
@@ -38,7 +38,17 @@ do(State) ->
             {error, "At least one profile must be specified when using `as`"};
         _  ->
             State1 = rebar_state:apply_profiles(State, [list_to_atom(X) || X <- Profiles]),
-            rebar_prv_do:do_tasks(Tasks, State1)
+            {FirstTask, FirstTaskArgs} = hd(Tasks),
+            FirstTaskAtom = list_to_atom(FirstTask),
+            case rebar_core:process_namespace(State1, FirstTaskAtom) of
+                {ok, State2, NewTask} ->
+                    rebar_prv_do:do_tasks(
+                        [{atom_to_list(NewTask),FirstTaskArgs}|tl(Tasks)],
+                        State2
+                    );
+                {error, Reason} ->
+                    {error, Reason}
+            end
     end.
 
 -spec format_error(any()) -> iolist().


### PR DESCRIPTION
Breaking up initial call to parse from the ones deep inside the provider
parsing to do smarter namespace detection, added 'as' the ability to
look into these also, and cleaned up the code a whole lot that would
depend on implicit assumptions.

A side-effect is that 'do' is now valid for all namespaces, although it
can be overriden.