### PR TITLE
Dep conflict as error

### DIFF
--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -48,7 +48,9 @@ merge_deps(AppInfo, State) ->
     State1 = lists:foldl(fun(Profile, StateAcc) ->
                                  AppProfDeps = rebar_state:get(AppState, {deps, Profile}, []),
                                  TopLevelProfDeps = rebar_state:get(StateAcc, {deps, Profile}, []),
-                                 ProfDeps2 = lists:keymerge(1, TopLevelProfDeps, AppProfDeps),
+                                 ProfDeps2 = dedup(lists:keymerge(1,
+                                                                  lists:keysort(1, TopLevelProfDeps),
+                                                                  lists:keysort(1, AppProfDeps))),
                                  rebar_state:set(StateAcc, {deps, Profile}, ProfDeps2)
                          end, State, lists:reverse(CurrentProfiles)),
 
@@ -166,3 +168,8 @@ create_app_info(AppDir, AppFile) ->
         _ ->
             error
     end.
+
+dedup([]) -> [];
+dedup([A]) -> [A];
+dedup([H,H|T]) -> dedup([H|T]);
+dedup([H|T]) -> [H|dedup(T)].

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -48,15 +48,19 @@ run_and_check(Config, RebarConfig, Command, Expect) ->
     %% Assumes init_rebar_state has run first
     AppDir = ?config(apps, Config),
     State = ?config(state, Config),
-    Res = rebar3:run(rebar_state:new(State, RebarConfig, AppDir), Command),
-    case Expect of
-        {error, Reason} ->
-            ?assertEqual({error, Reason}, Res);
-        {ok, Expected} ->
-            {ok, _} = Res,
-            check_results(AppDir, Expected);
-        return ->
-            Res
+    try
+        Res = rebar3:run(rebar_state:new(State, RebarConfig, AppDir), Command),
+        case Expect of
+            {error, Reason} ->
+                ?assertEqual({error, Reason}, Res);
+            {ok, Expected} ->
+                {ok, _} = Res,
+                check_results(AppDir, Expected);
+            return ->
+                Res
+        end
+    catch
+        rebar_abort when Expect =:= rebar_abort -> rebar_abort
     end.
 
 %% @doc Creates a dummy application including:


### PR DESCRIPTION
#### 1. Avoid duplicating deps in discover phase

The deps are sorted and merged, but the merge function merges lists, not
elements. This yields deps that are duplicated and ran for multiple
times.
We first add proper sorts so the keymerge is guaranteed to be fine, and
then do a dedup run to get rid of duplicates if they happen to be.

This would yield warnings when none should happen, and would break
conflict errors because all runs would automatically fail on the first dep.

#### 2. Implement deps conflicts as errors

The option {deps_error_on_conflict, true} will make it so conflicts in
deps being fetched interrupts the operation rather than just display a
warning.
Defaults to `false'.