### PR TITLE
include all pkg deps in list of deps returned from update

### DIFF
--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -210,13 +210,8 @@ handle_pkg_dep(Profile, Pkg, Packages, Upgrade, DepsDir, Fetched, Seen, State) -
     AppInfo = package_to_app(DepsDir, Packages, Pkg),
     Level = rebar_app_info:dep_level(AppInfo),
     {NewSeen, NewState} = maybe_lock(Profile, AppInfo, Seen, State, Level),
-    case maybe_fetch(AppInfo, Upgrade, Seen, NewState) of
-        true ->
-            {[AppInfo | Fetched], NewSeen, NewState};
-        false ->
-            {Fetched, NewSeen, NewState}
-    end.
-
+    maybe_fetch(AppInfo, Upgrade, Seen, NewState),
+    {[AppInfo | Fetched], NewSeen, NewState}.
 
 maybe_lock(Profile, AppInfo, Seen, State, Level) ->
     case Profile of


### PR DESCRIPTION
The list of deps returned from `update_src_deps` and `update_pkg_deps` is used to set the code path for building project apps. This change ensures all package deps apps are included in that list so the code path is updated properly.