### PR TITLE
[WIP] Make dialyze provider compatible with rebar dialyzer plugin

### DIFF
--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -65,10 +65,9 @@ short_desc() ->
 do(State) ->
     ?INFO("Dialyzer starting, this may take a while...", []),
     Plt = get_plt_location(State),
-    Apps = rebar_state:project_apps(State),
 
     try
-        do(State, Plt, Apps)
+        do(State, Plt)
     catch
         throw:{dialyzer_error, Error} ->
             ?PRV_ERROR({error_processing_apps, Error});
@@ -94,9 +93,9 @@ get_plt_location(State) ->
 default_plt() ->
     rebar_utils:otp_release() ++ ".plt".
 
-do(State, Plt, Apps) ->
-    {PltWarnings, State1} = update_proj_plt(State, Plt, Apps),
-    {Warnings, State2} = succ_typings(State1, Plt, Apps),
+do(State, Plt) ->
+    {PltWarnings, State1} = update_proj_plt(State, Plt),
+    {Warnings, State2} = succ_typings(State1, Plt),
     case PltWarnings + Warnings of
         0 ->
             {ok, State2};
@@ -104,31 +103,34 @@ do(State, Plt, Apps) ->
             throw({dialyzer_warnings, TotalWarnings})
     end.
 
-update_proj_plt(State, Plt, Apps) ->
+update_proj_plt(State, Plt) ->
     {Args, _} = rebar_state:command_parsed_args(State),
     case proplists:get_value(update_plt, Args) of
         false ->
             {0, State};
         _ ->
-            do_update_proj_plt(State, Plt, Apps)
+            do_update_proj_plt(State, Plt)
     end.
 
-do_update_proj_plt(State, Plt, Apps) ->
+do_update_proj_plt(State, Plt) ->
     ?INFO("Updating plt...", []),
-    Files = get_plt_files(State, Apps),
-    case read_plt(State, Plt) of
-        {ok, OldFiles} ->
-            check_plt(State, Plt, OldFiles, Files);
-        {error, no_such_file} ->
-            build_proj_plt(State, Plt, Files)
-    end.
+    {Files, Warnings} = proj_plt_files(State),
+    Warnings2 = format_warnings(Warnings),
+    {Warnings3, State2} = case read_plt(State, Plt) of
+                              {ok, OldFiles} ->
+                                  check_plt(State, Plt, OldFiles, Files);
+                              {error, no_such_file} ->
+                                  build_proj_plt(State, Plt, Files)
+                          end,
+    {Warnings2 + Warnings3, State2}.
 
-get_plt_files(State, Apps) ->
+proj_plt_files(State) ->
     BasePltApps = rebar_state:get(State, dialyzer_base_plt_apps,
                                   default_plt_apps()),
     PltApps = rebar_state:get(State, dialyzer_plt_apps, []),
+    Apps = rebar_state:project_apps(State),
     DepApps = lists:flatmap(fun rebar_app_info:applications/1, Apps),
-    get_plt_files(BasePltApps ++ PltApps ++ DepApps, Apps, [], []).
+    get_plt_files(BasePltApps ++ PltApps ++ DepApps, Apps).
 
 default_plt_apps() ->
     [erts,
@@ -136,19 +138,25 @@ default_plt_apps() ->
      kernel,
      stdlib].
 
-get_plt_files([], _, _, Files) ->
-    Files;
-get_plt_files([AppName | DepApps], Apps, PltApps, Files) ->
+get_plt_files(DepApps, Apps) ->
+    ?INFO("Resolving files...", []),
+    get_plt_files(DepApps, Apps, [], [], []).
+
+get_plt_files([], _, _, Files, Warnings) ->
+    {Files, Warnings};
+get_plt_files([AppName | DepApps], Apps, PltApps, Files, Warnings) ->
     case lists:member(AppName, PltApps) orelse app_member(AppName, Apps) of
         true ->
-            get_plt_files(DepApps, Apps, PltApps, Files);
+            get_plt_files(DepApps, Apps, PltApps, Files, Warnings);
         false ->
-            {DepApps2, Files2} = app_name_to_info(AppName),
+            {DepApps2, Files2, Warnings2} = app_name_to_info(AppName),
             ?DEBUG("~s dependencies: ~p", [AppName, DepApps2]),
             ?DEBUG("~s files: ~p", [AppName, Files2]),
             DepApps3 = DepApps2 ++ DepApps,
+            PltApps2 = [AppName | PltApps],
             Files3 = Files2 ++ Files,
-            get_plt_files(DepApps3, Apps, [AppName | PltApps], Files3)
+            Warnings3 = Warnings2 ++ Warnings,
+            get_plt_files(DepApps3, Apps, PltApps2, Files3, Warnings3)
     end.
 
 app_member(AppName, Apps) ->
@@ -162,8 +170,7 @@ app_member(AppName, Apps) ->
 app_name_to_info(AppName) ->
     case app_name_to_ebin(AppName) of
         {error, _} ->
-            ?CONSOLE("Unknown application ~s", [AppName]),
-            {[], []};
+            {[], [], [{unknown_application, {"", 0}, [AppName]}]};
         EbinDir ->
             ebin_to_info(EbinDir, AppName)
     end.
@@ -201,10 +208,10 @@ ebin_to_info(EbinDir, AppName) ->
             IncApps = proplists:get_value(included_applications, AppDetails,
                                           []),
             Modules = proplists:get_value(modules, AppDetails, []),
-            Files = modules_to_files(Modules, EbinDir),
-            {IncApps ++ DepApps, Files};
+            {Files, Warnings} = modules_to_files(Modules, EbinDir),
+            {IncApps ++ DepApps, Files, Warnings};
         {error, enoent} when AppName =:= erts ->
-            {[], ebin_files(EbinDir)};
+            {[], ebin_files(EbinDir), []};
         _ ->
             Error = io_lib:format("Could not parse ~p", [AppFile]),
             throw({dialyzer_error, Error})
@@ -212,17 +219,19 @@ ebin_to_info(EbinDir, AppName) ->
 
 modules_to_files(Modules, EbinDir) ->
     Ext = code:objfile_extension(),
-    Mod2File = fun(Module) -> module_to_file(Module, EbinDir, Ext) end,
-    rebar_utils:filtermap(Mod2File, Modules).
+    Result = [module_to_file(Module, EbinDir, Ext) || Module <- Modules],
+    Files = [File || {_, File} <- Result, File =/= unknown],
+    Warnings = [{unknown_module, {"", 0}, [Module]} ||
+                {Module, unknown} <- Result],
+    {Files, Warnings}.
 
 module_to_file(Module, EbinDir, Ext) ->
     File = filename:join(EbinDir, atom_to_list(Module) ++ Ext),
     case filelib:is_file(File) of
         true ->
-            {true, File};
+            {Module, File};
         false ->
-            ?CONSOLE("Unknown module ~s", [Module]),
-            false
+            {Module, unknown}
     end.
 
 ebin_files(EbinDir) ->
@@ -282,14 +291,15 @@ run_plt(State, Plt, Analysis, Files) ->
 
 build_proj_plt(State, Plt, Files) ->
     BasePlt = get_base_plt_location(State),
-    BaseFiles = get_base_plt_files(State),
-    {BaseWarnings, State1} = update_base_plt(State, BasePlt, BaseFiles),
+    {BaseFiles, BaseWarnings} = base_plt_files(State),
+    BaseWarnings2 = format_warnings(BaseWarnings),
+    {BaseWarnings3, State1} = update_base_plt(State, BasePlt, BaseFiles),
     ?INFO("Copying ~p to ~p...", [BasePlt, Plt]),
     _ = filelib:ensure_dir(Plt),
     case file:copy(BasePlt, Plt) of
         {ok, _} ->
             {CheckWarnings, State2} = check_plt(State1, Plt, BaseFiles, Files),
-            {BaseWarnings + CheckWarnings, State2};
+            {BaseWarnings2 + BaseWarnings3 + CheckWarnings, State2};
         {error, Reason} ->
             Error = io_lib:format("Could not copy PLT from ~p to ~p: ~p",
                                   [BasePlt, Plt, file:format_error(Reason)]),
@@ -302,17 +312,11 @@ get_base_plt_location(State) ->
     BasePlt = rebar_state:get(State, dialyzer_base_plt, default_plt()),
     filename:join(BaseDir, BasePlt).
 
-get_base_plt_files(State) ->
+base_plt_files(State) ->
     BasePltApps = rebar_state:get(State, dialyzer_base_plt_apps,
                                   default_plt_apps()),
-    app_names_to_files(BasePltApps).
-
-app_names_to_files(AppNames) ->
-    ToFiles = fun(AppName) ->
-                      {_, Files} = app_name_to_info(AppName),
-                      Files
-              end,
-    lists:flatmap(ToFiles, AppNames).
+    Apps = rebar_state:project_apps(State),
+    get_plt_files(BasePltApps, Apps).
 
 update_base_plt(State, BasePlt, BaseFiles) ->
     ?INFO("Updating base plt...", []),
@@ -333,33 +337,42 @@ build_plt(State, Plt, Files) ->
             {files, Files}],
     run_dialyzer(State, Opts).
 
-succ_typings(State, Plt, Apps) ->
+succ_typings(State, Plt) ->
     {Args, _} = rebar_state:command_parsed_args(State),
     case proplists:get_value(succ_typings, Args) of
         false ->
             {0, State};
         _ ->
-            do_succ_typings(State, Plt, Apps)
+            Apps = rebar_state:project_apps(State),
+            succ_typings(State, Plt, Apps)
     end.
 
-do_succ_typings(State, Plt, Apps) ->
+succ_typings(State, Plt, Apps) ->
     ?INFO("Doing success typing analysis...", []),
-    Files = apps_to_files(Apps),
+    {Files, Warnings} = apps_to_files(Apps),
+    Warnings2 = format_warnings(Warnings),
     ?INFO("Analyzing ~b files with ~p...", [length(Files), Plt]),
     Opts = [{analysis_type, succ_typings},
             {get_warnings, true},
             {from, byte_code},
             {files, Files},
             {init_plt, Plt}],
-    run_dialyzer(State, Opts).
+    {Warnings3, State2} = run_dialyzer(State, Opts),
+    {Warnings2 + Warnings3, State2}.
 
 apps_to_files(Apps) ->
-    lists:flatmap(fun app_to_files/1, Apps).
+    ?INFO("Resolving files...", []),
+    Result = [{Files, Warnings} ||
+              App <- Apps,
+              {Files, Warnings} <- [app_to_files(App)]],
+    Files = [File || {Files, _} <- Result, File <- Files],
+    Warnings = [Warning || {_, Warnings} <- Result, Warning <- Warnings],
+    {Files, Warnings}.
 
 app_to_files(App) ->
     AppName = ec_cnv:to_atom(rebar_app_info:name(App)),
-    {_, Files} = app_name_to_info(AppName),
-    Files.
+    {_, Files, Warnings} = app_name_to_info(AppName),
+    {Files, Warnings}.
 
 run_dialyzer(State, Opts) ->
     %% dialyzer may return callgraph warnings when get_warnings is false
@@ -370,10 +383,8 @@ run_dialyzer(State, Opts) ->
                      {check_plt, false} |
                      Opts],
             ?DEBUG("Running dialyzer with options: ~p~n", [Opts2]),
-            {Unknowns, Warnings} = format_warnings(dialyzer:run(Opts2)),
-            _ = [?CONSOLE("~s", [Unknown]) || Unknown <- Unknowns],
-            _ = [?CONSOLE("~s", [Warning]) || Warning <- Warnings],
-            {length(Warnings), State};
+            Warnings = format_warnings(dialyzer:run(Opts2)),
+            {Warnings, State};
         false ->
             Opts2 = [{warnings, no_warnings()},
                      {check_plt, false} |
@@ -384,17 +395,25 @@ run_dialyzer(State, Opts) ->
     end.
 
 format_warnings(Warnings) ->
-    format_warnings(Warnings, [], []).
+    format_warnings(Warnings, 0).
 
-format_warnings([Warning | Rest], Unknowns, Warnings) ->
-    case dialyzer:format_warning(Warning, fullpath) of
+format_warnings([Warning | Warnings], N) ->
+    format_warning(Warning),
+    format_warnings(Warnings, N + 1);
+format_warnings([], N) ->
+    N.
+
+format_warning({unknown_application, _, [AppName]}) ->
+    ?CONSOLE("Unknown application: ~s", [AppName]);
+format_warning({unknown_module, _, [Module]}) ->
+    ?CONSOLE("Unknown module: ~s", [Module]);
+format_warning(Warning) ->
+    case strip(dialyzer:format_warning(Warning, fullpath)) of
         ":0: " ++ Unknown ->
-            format_warnings(Rest, [strip(Unknown) | Unknowns], Warnings);
+            ?CONSOLE("~s", [Unknown]);
         Warning2 ->
-            format_warnings(Rest, Unknowns, [strip(Warning2) | Warnings])
-    end;
-format_warnings([], Unknowns, Warnings) ->
-    {Unknowns, Warnings}.
+            ?CONSOLE("~s", [Warning2])
+    end.
 
 strip(Warning) ->
     string:strip(Warning, right, $\n).


### PR DESCRIPTION
Rebar 2 is getting a built in dialyzer plugin (https://github.com/rebar/rebar/pull/460) and this PR aims to make `rebar` dialyzer configuration forwards compatible with `rebar3` dialyze configuration. Will use this PR to improve test coverage by requiring tests for the changes.

Todo:
* [ ] rebar dialyzer plugin merged
* [x] Error on unknown warnings
* [ ] Test: unknown module in PLT
* [ ] Test: unknown application in PLT
* [ ] Test: unknown module in success typing
* [ ] Test: unknown application in success typing
* [x] Config: `{dialyzer_plt_location, file:filename() | local | shared}`
* [ ] Test: `dialyzer_plt_location` (missing test for `shared`)
* [x] Config: `{dialyzer_plt_extra_apps, [atom()]}`
* [x] Test: `dialyzer_plt_extra_apps`
* [x] Config: `{dialyzer_shared_plt_location, file:filename() | shared}`
* [x] Test: `dialyzer_shared_plt_location`
* [x] Config: `dialyzer_warnings`
* [ ] Test: `dialyzer_warnings`