### PR TITLE
Adding tests for paths and _checkouts

### DIFF
--- a/test/mock_git_resource.erl
+++ b/test/mock_git_resource.erl
@@ -55,7 +55,7 @@ mock_lock(_) ->
 %% should be updated on a per-name basis: `{update, ["App1", "App3"]}'.
 mock_update(Opts) ->
     ToUpdate = proplists:get_value(upgrade, Opts, []),
-    ct:pal("TOUp: ~p", [ToUpdate]),
+%    ct:pal("TOUp: ~p", [ToUpdate]),
     meck:expect(
         ?MOD, needs_update,
         fun(_Dir, {git, Url, _Ref}) ->
@@ -110,7 +110,7 @@ mock_download(Opts) ->
             AppDeps = proplists:get_value({App,Vsn}, Deps, []),
             rebar_test_utils:create_app(
                 Dir, App, Vsn,
-                [element(1,D) || D  <- AppDeps]
+                [kernel, stdlib] ++ [element(1,D) || D  <- AppDeps]
             ),
             rebar_test_utils:create_config(Dir, [{deps, AppDeps}]),
             {ok, 'WHATEVER'}

--- a/test/mock_pkg_resource.erl
+++ b/test/mock_pkg_resource.erl
@@ -78,9 +78,9 @@ mock_download(Opts) ->
             App = binary_to_list(AppBin),
             filelib:ensure_dir(Dir),
             AppDeps = proplists:get_value({App,Vsn}, Deps, []),
-            {ok, AppInfo} = rebar_test_utils:create_empty_app(
-                Dir, App, Vsn,
-                [element(1,D) || D  <- AppDeps]
+            {ok, AppInfo} = rebar_test_utils:create_app(
+                Dir, App, binary_to_list(Vsn),
+                [kernel, stdlib] ++ [element(1,D) || D  <- AppDeps]
             ),
             rebar_test_utils:create_config(Dir, [{deps, AppDeps}]),
             Tarball = filename:join([Dir, App++"-"++binary_to_list(Vsn)++".tar"]),

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -4,6 +4,7 @@
          init_per_suite/1,
          end_per_suite/1,
          init_per_testcase/2,
+         end_per_testcase/2,
          all/0,
          build_basic_app/1,
          build_release_apps/1,
@@ -12,7 +13,9 @@
          build_all_srcdirs/1,
          recompile_when_opts_change/1,
          dont_recompile_when_opts_dont_change/1,
-         dont_recompile_yrl_or_xrl/1]).
+         dont_recompile_yrl_or_xrl/1,
+         deps_in_path/1,
+         checkout_priority/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -30,12 +33,15 @@ end_per_suite(_Config) ->
 init_per_testcase(_, Config) ->
     rebar_test_utils:init_rebar_state(Config).
 
+end_per_testcase(_, _Config) ->
+    catch meck:unload().
+
 all() ->
     [build_basic_app, build_release_apps,
      build_checkout_apps, build_checkout_deps,
      build_all_srcdirs,
      recompile_when_opts_change, dont_recompile_when_opts_dont_change,
-     dont_recompile_yrl_or_xrl].
+     dont_recompile_yrl_or_xrl, deps_in_path, checkout_priority].
 
 build_basic_app(Config) ->
     AppDir = ?config(apps, Config),
@@ -210,4 +216,117 @@ dont_recompile_yrl_or_xrl(Config) ->
     NewModTime = filelib:last_modified(XrlBeam),
 
     ?assert(ModTime == NewModTime).
+
+deps_in_path(Config) ->
+    AppDir = ?config(apps, Config),
+    StartPaths = code:get_path(),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    DepName = rebar_test_utils:create_random_name("dep1_"),
+    PkgName = rebar_test_utils:create_random_name("pkg1_"),
+    mock_git_resource:mock([]),
+    mock_pkg_resource:mock([
+        {pkgdeps, [{{iolist_to_binary(PkgName), iolist_to_binary(Vsn)}, []}]}
+    ]),
+
+    RConfFile = rebar_test_utils:create_config(AppDir, [{deps, [
+        {list_to_atom(DepName), {git, "http://site.com/user/"++DepName++".git", {tag, Vsn}}},
+        {list_to_atom(PkgName), Vsn}
+    ]}]),
+    {ok, RConf} = file:consult(RConfFile),
+    %% Make sure apps we look for are not visible
+    %% Hope not to find src name
+    ?assertEqual([], [Path || Path <- code:get_path(),
+                              {match, _} <- [re:run(Path, DepName)]]),
+    %% Hope not to find pkg name in there
+    ?assertEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, PkgName)]]),
+    %% Build things
+    rebar_test_utils:run_and_check(
+        Config, RConf, ["compile"],
+        {ok, [{app, Name}, {dep, DepName}, {dep, PkgName}]}
+    ),
+    %% Find src name in there
+    ?assertNotEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, DepName)]]),
+    %% find pkg name in there
+    ?assertNotEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, PkgName)]]),
+    code:set_path(StartPaths),
+    %% Make sure apps we look for are not visible again
+    %% Hope not to find src name
+    ?assertEqual([], [Path || Path <- code:get_path(),
+                              {match, _} <- [re:run(Path, DepName)]]),
+    %% Hope not to find pkg name in there
+    ?assertEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, PkgName)]]),
+    %% Rebuild
+    rebar_test_utils:run_and_check(
+        Config, RConf, ["compile"],
+        {ok, [{app, Name}, {dep, DepName}, {dep, PkgName}]}
+    ),
+    %% Find src name in there
+    ?assertNotEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, DepName)]]),
+    %% find pkg name in there
+    ?assertNotEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, PkgName)]]).
+
+checkout_priority(Config) ->
+    AppDir = ?config(apps, Config),
+    CheckoutsDir = ?config(checkouts, Config),
+    StartPaths = code:get_path(),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    DepName = rebar_test_utils:create_random_name("dep1_"),
+    PkgName = rebar_test_utils:create_random_name("pkg1_"),
+    mock_git_resource:mock([]),
+    mock_pkg_resource:mock([
+        {pkgdeps, [{{iolist_to_binary(PkgName), iolist_to_binary(Vsn)}, []}]}
+    ]),
+
+    RConfFile = rebar_test_utils:create_config(AppDir, [{deps, [
+        {list_to_atom(DepName), {git, "http://site.com/user/"++DepName++".git", {tag, Vsn}}},
+        {list_to_atom(PkgName), Vsn}
+    ]}]),
+    {ok, RConf} = file:consult(RConfFile),
+
+    %% Build with deps.
+    rebar_test_utils:run_and_check(
+        Config, RConf, ["compile"],
+        {ok, [{app, Name}, {dep, DepName}, {dep, PkgName}]}
+    ),
+
+    %% Build two checkout apps similar to dependencies to be fetched,
+    %% but on a different version
+    Vsn2 = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(filename:join([CheckoutsDir,DepName]), DepName, Vsn2, [kernel, stdlib]),
+    rebar_test_utils:create_app(filename:join([CheckoutsDir,PkgName]), PkgName, Vsn2, [kernel, stdlib]),
+
+    %% Rebuild and make sure the checkout apps are in path
+    code:set_path(StartPaths),
+    rebar_test_utils:run_and_check(
+        Config, RConf, ["compile"],
+        {ok, [{app, Name}, {checkout, DepName}, {checkout, PkgName}]}
+    ),
+
+    [DepPath] = [Path || Path <- code:get_path(),
+                         {match, _} <- [re:run(Path, DepName)]],
+    [PkgPath] = [Path || Path <- code:get_path(),
+                         {match, _} <- [re:run(Path, PkgName)]],
+
+    {ok, [DepApp]} = file:consult(filename:join([DepPath, DepName ++ ".app"])),
+    {ok, [PkgApp]} = file:consult(filename:join([PkgPath, PkgName ++ ".app"])),
+
+    {application, _, DepProps} = DepApp,
+    {application, _, PkgProps} = PkgApp,
+
+    ?assertEqual(Vsn2, proplists:get_value(vsn, DepProps)),
+    ?assertEqual(Vsn2, proplists:get_value(vsn, PkgProps)).
 


### PR DESCRIPTION
The test for checkouts is crashing.

Adding checkouts to dependencies already fetched somehow has them share eachother's dependencies and creates cycles that do not exist for real.