### PR TITLE
treat _checkouts as deps that are always compiled

### DIFF
--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -14,7 +14,9 @@
 -define(FMT(Str, Args), lists:flatten(io_lib:format(Str, Args))).
 
 -define(DEFAULT_BASE_DIR, "_build").
--define(DEFAULT_PROJECT_APP_DIRS, ["_checkouts", "apps", "lib", "."]).
+-define(DEFAULT_ROOT_DIR, ".").
+-define(DEFAULT_PROJECT_APP_DIRS, ["apps", "lib", "."]).
+-define(DEFAULT_CHECKOUTS_DIR, "_checkouts").
 -define(DEFAULT_DEPS_DIR, "lib").
 -define(DEFAULT_PLUGINS_DIR, "plugins").
 -define(DEFAULT_TEST_DEPS_DIR, "test/lib").

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -34,6 +34,8 @@
          source/2,
          state/1,
          state/2,
+         is_checkout/1,
+         is_checkout/2,
          valid/1,
          valid/2]).
 
@@ -53,6 +55,7 @@
                      out_dir :: file:name(),
                      source :: string() | tuple() | undefined,
                      state :: rebar_state:t() | undefined,
+                     is_checkout=false :: boolean(),
                      valid :: boolean()}).
 
 %%============================================================================
@@ -237,6 +240,14 @@ state(AppInfo=#app_info_t{}, State) ->
 -spec state(t()) -> rebar_state:t() | undefined.
 state(#app_info_t{state=State}) ->
     State.
+
+-spec is_checkout(t(), boolean()) -> t().
+is_checkout(AppInfo=#app_info_t{}, IsCheckout) ->
+    AppInfo#app_info_t{is_checkout=IsCheckout}.
+
+-spec is_checkout(t()) -> boolean().
+is_checkout(#app_info_t{is_checkout=IsCheckout}) ->
+    IsCheckout.
 
 -spec valid(t()) -> boolean().
 valid(AppInfo=#app_info_t{valid=undefined}) ->

--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -3,6 +3,8 @@
 -export([base_dir/1,
          deps_dir/1,
          deps_dir/2,
+         checkouts_dir/1,
+         checkouts_dir/2,
          plugins_dir/1,
          lib_dirs/1,
          home_dir/0,
@@ -39,6 +41,17 @@ deps_dir(State) ->
 -spec deps_dir(file:filename_all(), file:filename_all()) -> file:filename_all().
 deps_dir(DepsDir, App) ->
     filename:join(DepsDir, App).
+
+root_dir(State) ->
+    rebar_state:get(State, root_dir, ?DEFAULT_ROOT_DIR).
+
+-spec checkouts_dir(rebar_state:t()) -> file:filename_all().
+checkouts_dir(State) ->
+    filename:join(root_dir(State), rebar_state:get(State, checkouts_dir, ?DEFAULT_CHECKOUTS_DIR)).
+
+-spec checkouts_dir(rebar_state:t(), file:filename_all()) -> file:filename_all().
+checkouts_dir(State, App) ->
+    filename:join(checkouts_dir(State), App).
 
 -spec plugins_dir(rebar_state:t()) -> file:filename_all().
 plugins_dir(State) ->

--- a/src/rebar_prv_lock.erl
+++ b/src/rebar_prv_lock.erl
@@ -30,16 +30,16 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     AllDeps = rebar_state:lock(State),
-    Locks = lists:map(fun(Dep) ->
-                              Dir = rebar_app_info:dir(Dep),
-                              Source = rebar_app_info:source(Dep),
+    Locks = [begin
+                 Dir = rebar_app_info:dir(Dep),
+                 Source = rebar_app_info:source(Dep),
 
-                              %% If source is tuple it is a source dep
-                              %% e.g. {git, "git://github.com/ninenines/cowboy.git", "master"}
-                              {rebar_app_info:name(Dep)
-                              ,rebar_fetch:lock_source(Dir, Source)
-                              ,rebar_app_info:dep_level(Dep)}
-                      end, AllDeps),
+                 %% If source is tuple it is a source dep
+                 %% e.g. {git, "git://github.com/ninenines/cowboy.git", "master"}
+                 {rebar_app_info:name(Dep)
+                 ,rebar_fetch:lock_source(Dir, Source)
+                 ,rebar_app_info:dep_level(Dep)}
+             end || Dep <- AllDeps, not(rebar_app_info:is_checkout(Dep))],
     Dir = rebar_state:dir(State),
     file:write_file(filename:join(Dir, ?LOCK_FILE), io_lib:format("~p.~n", [Locks])),
     {ok, State}.

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -387,6 +387,7 @@ beams(Dir) ->
 -spec abort() -> no_return().
 abort() ->
     throw(rebar_abort).
+
 -spec abort(string(), [term()]) -> no_return().
 abort(String, Args) ->
     ?ERROR(String, Args),

--- a/test/mock_git_resource.erl
+++ b/test/mock_git_resource.erl
@@ -55,7 +55,7 @@ mock_lock(_) ->
 %% should be updated on a per-name basis: `{update, ["App1", "App3"]}'.
 mock_update(Opts) ->
     ToUpdate = proplists:get_value(upgrade, Opts, []),
-    ct:pal("TOUp: ~p", [ToUpdate]),
+%    ct:pal("TOUp: ~p", [ToUpdate]),
     meck:expect(
         ?MOD, needs_update,
         fun(_Dir, {git, Url, _Ref}) ->
@@ -110,7 +110,7 @@ mock_download(Opts) ->
             AppDeps = proplists:get_value({App,Vsn}, Deps, []),
             rebar_test_utils:create_app(
                 Dir, App, Vsn,
-                [element(1,D) || D  <- AppDeps]
+                [kernel, stdlib] ++ [element(1,D) || D  <- AppDeps]
             ),
             rebar_test_utils:create_config(Dir, [{deps, AppDeps}]),
             {ok, 'WHATEVER'}

--- a/test/mock_pkg_resource.erl
+++ b/test/mock_pkg_resource.erl
@@ -78,9 +78,9 @@ mock_download(Opts) ->
             App = binary_to_list(AppBin),
             filelib:ensure_dir(Dir),
             AppDeps = proplists:get_value({App,Vsn}, Deps, []),
-            {ok, AppInfo} = rebar_test_utils:create_empty_app(
-                Dir, App, Vsn,
-                [element(1,D) || D  <- AppDeps]
+            {ok, AppInfo} = rebar_test_utils:create_app(
+                Dir, App, binary_to_list(Vsn),
+                [kernel, stdlib] ++ [element(1,D) || D  <- AppDeps]
             ),
             rebar_test_utils:create_config(Dir, [{deps, AppDeps}]),
             Tarball = filename:join([Dir, App++"-"++binary_to_list(Vsn)++".tar"]),

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -4,6 +4,7 @@
          init_per_suite/1,
          end_per_suite/1,
          init_per_testcase/2,
+         end_per_testcase/2,
          all/0,
          build_basic_app/1,
          build_release_apps/1,
@@ -12,7 +13,9 @@
          build_all_srcdirs/1,
          recompile_when_opts_change/1,
          dont_recompile_when_opts_dont_change/1,
-         dont_recompile_yrl_or_xrl/1]).
+         dont_recompile_yrl_or_xrl/1,
+         deps_in_path/1,
+         checkout_priority/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -30,12 +33,15 @@ end_per_suite(_Config) ->
 init_per_testcase(_, Config) ->
     rebar_test_utils:init_rebar_state(Config).
 
+end_per_testcase(_, _Config) ->
+    catch meck:unload().
+
 all() ->
     [build_basic_app, build_release_apps,
      build_checkout_apps, build_checkout_deps,
      build_all_srcdirs,
      recompile_when_opts_change, dont_recompile_when_opts_dont_change,
-     dont_recompile_yrl_or_xrl].
+     dont_recompile_yrl_or_xrl, deps_in_path, checkout_priority].
 
 build_basic_app(Config) ->
     AppDir = ?config(apps, Config),
@@ -88,8 +94,11 @@ build_checkout_deps(Config) ->
     rebar_test_utils:create_app(filename:join([CheckoutsDir,Name2]), Name2, Vsn2, [kernel, stdlib]),
     rebar_test_utils:create_app(filename:join([DepsDir,Name2]), Name2, Vsn1, [kernel, stdlib]),
 
+    Deps = [{list_to_atom(Name2), Vsn2, {git, "", ""}}],
+    {ok, RebarConfig} = file:consult(rebar_test_utils:create_config(AppDir, [{deps, Deps}])),
+
     rebar_test_utils:run_and_check(
-        Config, [], ["compile"],
+        Config, RebarConfig, ["compile"],
         {ok, [{app, Name1}, {checkout, Name2}]}
     ),
     ok = application:load(list_to_atom(Name2)),
@@ -211,3 +220,115 @@ dont_recompile_yrl_or_xrl(Config) ->
 
     ?assert(ModTime == NewModTime).
 
+deps_in_path(Config) ->
+    AppDir = ?config(apps, Config),
+    StartPaths = code:get_path(),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    DepName = rebar_test_utils:create_random_name("dep1_"),
+    PkgName = rebar_test_utils:create_random_name("pkg1_"),
+    mock_git_resource:mock([]),
+    mock_pkg_resource:mock([
+        {pkgdeps, [{{iolist_to_binary(PkgName), iolist_to_binary(Vsn)}, []}]}
+    ]),
+
+    RConfFile = rebar_test_utils:create_config(AppDir, [{deps, [
+        {list_to_atom(DepName), {git, "http://site.com/user/"++DepName++".git", {tag, Vsn}}},
+        {list_to_atom(PkgName), Vsn}
+    ]}]),
+    {ok, RConf} = file:consult(RConfFile),
+    %% Make sure apps we look for are not visible
+    %% Hope not to find src name
+    ?assertEqual([], [Path || Path <- code:get_path(),
+                              {match, _} <- [re:run(Path, DepName)]]),
+    %% Hope not to find pkg name in there
+    ?assertEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, PkgName)]]),
+    %% Build things
+    rebar_test_utils:run_and_check(
+        Config, RConf, ["compile"],
+        {ok, [{app, Name}, {dep, DepName}, {dep, PkgName}]}
+    ),
+    %% Find src name in there
+    ?assertNotEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, DepName)]]),
+    %% find pkg name in there
+    ?assertNotEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, PkgName)]]),
+    code:set_path(StartPaths),
+    %% Make sure apps we look for are not visible again
+    %% Hope not to find src name
+    ?assertEqual([], [Path || Path <- code:get_path(),
+                              {match, _} <- [re:run(Path, DepName)]]),
+    %% Hope not to find pkg name in there
+    ?assertEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, PkgName)]]),
+    %% Rebuild
+    rebar_test_utils:run_and_check(
+        Config, RConf, ["compile"],
+        {ok, [{app, Name}, {dep, DepName}, {dep, PkgName}]}
+    ),
+    %% Find src name in there
+    ?assertNotEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, DepName)]]),
+    %% find pkg name in there
+    ?assertNotEqual([], [Path || Path <- code:get_path(),
+                                 {match, _} <- [re:run(Path, PkgName)]]).
+
+checkout_priority(Config) ->
+    AppDir = ?config(apps, Config),
+    CheckoutsDir = ?config(checkouts, Config),
+    StartPaths = code:get_path(),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    DepName = rebar_test_utils:create_random_name("dep1_"),
+    PkgName = rebar_test_utils:create_random_name("pkg1_"),
+    mock_git_resource:mock([]),
+    mock_pkg_resource:mock([
+        {pkgdeps, [{{iolist_to_binary(PkgName), iolist_to_binary(Vsn)}, []}]}
+    ]),
+
+    RConfFile = rebar_test_utils:create_config(AppDir, [{deps, [
+        {list_to_atom(DepName), {git, "http://site.com/user/"++DepName++".git", {tag, Vsn}}},
+        {list_to_atom(PkgName), Vsn}
+    ]}]),
+    {ok, RConf} = file:consult(RConfFile),
+
+    %% Build with deps.
+    rebar_test_utils:run_and_check(
+        Config, RConf, ["compile"],
+        {ok, [{app, Name}, {dep, DepName}, {dep, PkgName}]}
+    ),
+
+    %% Build two checkout apps similar to dependencies to be fetched,
+    %% but on a different version
+    Vsn2 = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(filename:join([CheckoutsDir,DepName]), DepName, Vsn2, [kernel, stdlib]),
+    rebar_test_utils:create_app(filename:join([CheckoutsDir,PkgName]), PkgName, Vsn2, [kernel, stdlib]),
+
+    %% Rebuild and make sure the checkout apps are in path
+    code:set_path(StartPaths),
+    rebar_test_utils:run_and_check(
+        Config, RConf, ["compile"],
+        {ok, [{app, Name}, {checkout, DepName}, {checkout, PkgName}]}
+    ),
+
+    [DepPath] = [Path || Path <- code:get_path(),
+                         {match, _} <- [re:run(Path, DepName)]],
+    [PkgPath] = [Path || Path <- code:get_path(),
+                         {match, _} <- [re:run(Path, PkgName)]],
+
+    {ok, [DepApp]} = file:consult(filename:join([DepPath, DepName ++ ".app"])),
+    {ok, [PkgApp]} = file:consult(filename:join([PkgPath, PkgName ++ ".app"])),
+
+    {application, _, DepProps} = DepApp,
+    {application, _, PkgProps} = PkgApp,
+
+    ?assertEqual(Vsn2, proplists:get_value(vsn, DepProps)),
+    ?assertEqual(Vsn2, proplists:get_value(vsn, PkgProps)).

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -25,7 +25,8 @@ init_rebar_state(Config, Name) ->
     ok = ec_file:mkdir_p(CheckoutsDir),
     Verbosity = rebar3:log_level(),
     rebar_log:init(command_line, Verbosity),
-    State = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}]),
+    State = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}
+                            ,{root_dir, AppsDir}]),
     [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, State} | Config].
 
 %% @doc Takes common test config, a rebar config ([] if empty), a command to


### PR DESCRIPTION
Don't treat an app found in `_checkouts` like a project app but instead as a dep that is always "invalid" so that any changes are compiled each run.