### PR TITLE
Fancy profile merge fun

### DIFF
--- a/src/rebar_prv_release.erl
+++ b/src/rebar_prv_release.erl
@@ -47,7 +47,7 @@ do(State) ->
                           ,{caller, Caller}], AllOptions);
             Config ->
                 relx:main([{lib_dirs, LibDirs}
-                          ,{config, Config}
+                          ,{config, lists:reverse(Config)}
                           ,{output_dir, OutputDir}
                           ,{caller, Caller}], AllOptions)
         end,

--- a/test/rebar_profiles_SUITE.erl
+++ b/test/rebar_profiles_SUITE.erl
@@ -100,12 +100,17 @@ profile_merges(_Config) ->
                    {test2, "hello"},
                    {test3, [key3]},
                    {test4, "oldvalue"},
+                   {test5, [{key5, true}]},
+                   {test6, [{key6, false}]},
                    {profiles,
                     [{profile1,
                       [{test1, [{key3, 5}, key1]}]},
                      {profile2, [{test2, "goodbye"},
                                  {test3, []},
-                                 {test4, []}]}]}],
+                                 {test4, []},
+                                 {test5, [{key5, false}]},
+                                 {test6, [{key6, true}]}
+                                ]}]}],
     State = rebar_state:new(RebarConfig),
     State1 = rebar_state:apply_profiles(State, [profile1, profile2]),
 
@@ -118,7 +123,9 @@ profile_merges(_Config) ->
 
     %% Check that a newvalue of []/"" doesn't override non-string oldvalues
     [key3] = rebar_state:get(State1, test3),
-    [] = rebar_state:get(State1, test4).
+    [] = rebar_state:get(State1, test4),
+    [{key5, false}, {key5, true}] = rebar_state:get(State1, test5),
+    [{key6, true}, {key6, false}] = rebar_state:get(State1, test6).
 
 add_to_profile(_Config) ->
     RebarConfig = [{foo, true}, {bar, false}],


### PR DESCRIPTION
Fixing #287, includes #289 tests from @kellymclaughlin 

This works by:
1. Implementing a stable umerge function that considers keys as comparing equal if they're values and tuples, but preserves the current duplication semantics (we also make sure that the 'newer' profile always takes precedence)
2. Reversing the list of argument passed on to relx so that it always uses them in the priority *we* judge important (I guess relx uses a fold of sort to turn their config in a dictionary, so by reversing the list we get the right dictionary)

This appears to fix the bug without need for additional special-casing of arguments.