### PR TITLE
Add test case to exercise the eunit provider using the test profile

### DIFF
--- a/test/rebar_eunit_SUITE.erl
+++ b/test/rebar_eunit_SUITE.erl
@@ -5,7 +5,8 @@
          end_per_suite/1,
          init_per_testcase/2,
          all/0,
-         test_basic_app/1]).
+         test_basic_app/1,
+         test_profile/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -24,7 +25,7 @@ init_per_testcase(_, Config) ->
     rebar_test_utils:init_rebar_state(Config, "eunit_").
 
 all() ->
-    [test_basic_app].
+    [test_basic_app, test_profile].
 
 test_basic_app(Config) ->
     AppDir = ?config(apps, Config),
@@ -35,3 +36,14 @@ test_basic_app(Config) ->
 
     RebarConfig = [{erl_opts, [{d, some_define}]}],
     rebar_test_utils:run_and_check(Config, RebarConfig, ["eunit"], {ok, [{app, Name}]}).
+
+test_profile(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("basic_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    RebarConfig = [{erl_opts, [{d, some_define}]},
+                  {profiles, [{test, [{erl_opts, [debug_info]}]}]}],
+    rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "test", "eunit"], {ok, [{app, Name}]}).


### PR DESCRIPTION
I came across an issue using the `test` profile to run the `eunit` command. This PR provides a failing test case for the issue. 

The `{d, 'TEST'}` tuple is duplicated in the final merged version of the `erl_opts` so an error is thrown. The problem seems to be that the profiles are applied twice when using `as`. Once by `rebar_prv_as` and then again when `rebar_core:process_command/2` is called from `rebar_prv_do` when the tasks are being processed. 

I tested adding a third parameter to `rebar_core:process_command` to indicate if profiles should be applied or not and then disabled profile application from `process_command` call in `rebar_prv_do`. That resolves the duplicate define issue, but probably not the right answer when the `do` command is in use. Maybe `rebar_prv_as` needs its own version of `do_tasks` that could call `process_command` in such a way as to not re-apply profiles.