### PR TITLE
Fix property merging

### DIFF
--- a/test/rebar_eunit_SUITE.erl
+++ b/test/rebar_eunit_SUITE.erl
@@ -5,7 +5,8 @@
          end_per_suite/1,
          init_per_testcase/2,
          all/0,
-         test_basic_app/1]).
+         test_basic_app/1,
+         test_profile/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -24,7 +25,7 @@ init_per_testcase(_, Config) ->
     rebar_test_utils:init_rebar_state(Config, "eunit_").
 
 all() ->
-    [test_basic_app].
+    [test_basic_app, test_profile].
 
 test_basic_app(Config) ->
     AppDir = ?config(apps, Config),
@@ -35,3 +36,14 @@ test_basic_app(Config) ->
 
     RebarConfig = [{erl_opts, [{d, some_define}]}],
     rebar_test_utils:run_and_check(Config, RebarConfig, ["eunit"], {ok, [{app, Name}]}).
+
+test_profile(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("basic_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    RebarConfig = [{erl_opts, [{d, some_define}]},
+                  {profiles, [{test, [{erl_opts, [debug_info]}]}]}],
+    rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "test", "eunit"], {ok, [{app, Name}]}).


### PR DESCRIPTION
Much clearer semantics now. All lists are treated as proplists, meaning
we want to:
1) allow duplicates (providers have to avoid them if they must)
2) preserve order of elements that compare equal (`a == {a, val}`)
   through a stable sort (so if `{a, b}` comes before `a`, we keep
   `{a, b}` first in the list
3) In two lists of attributes requiring a merge, we always give the
   'new' profile a priority to override the default one.

See #294