### PR TITLE
cover enhancements

### DIFF
--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -29,7 +29,8 @@ init(State) ->
                                                                {example, "rebar3 cover"},
                                                                {short_desc, "Perform coverage analysis."},
                                                                {desc, ""},
-                                                               {opts, cover_opts(State)}])),
+                                                               {opts, cover_opts(State)},
+                                                               {profiles, [test]}])),
     {ok, State1}.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
@@ -333,7 +334,8 @@ verbose(State) ->
     end.
 
 cover_dir(State) ->
-    rebar_state:get(State, cover_data_dir, filename:join(["_build", "cover"])).
+    rebar_state:get(State, cover_data_dir, filename:join([rebar_dir:base_dir(State),
+                                                          "cover"])).
 
 cover_opts(_State) ->
     [{reset, $r, "reset", boolean, help(reset)},

--- a/test/rebar_cover_SUITE.erl
+++ b/test/rebar_cover_SUITE.erl
@@ -39,7 +39,7 @@ flag_coverdata_written(Config) ->
 
     Name = rebar_test_utils:create_random_name("cover_"),
     Vsn = rebar_test_utils:create_random_vsn(),
-    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:create_eunit_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [{erl_opts, [{d, some_define}]}],
     rebar_test_utils:run_and_check(Config,
@@ -47,14 +47,14 @@ flag_coverdata_written(Config) ->
                                    ["eunit", "--cover"],
                                    {ok, [{app, Name}]}),
 
-    true = filelib:is_file(filename:join(["_build", "cover", "eunit.coverdata"])).
+    true = filelib:is_file(filename:join([AppDir, "_build", "test", "cover", "eunit.coverdata"])).
 
 config_coverdata_written(Config) ->
     AppDir = ?config(apps, Config),
 
     Name = rebar_test_utils:create_random_name("cover_"),
     Vsn = rebar_test_utils:create_random_vsn(),
-    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:create_eunit_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [{erl_opts, [{d, some_define}]}, {cover_enabled, true}],
     rebar_test_utils:run_and_check(Config,
@@ -62,14 +62,14 @@ config_coverdata_written(Config) ->
                                    ["eunit"],
                                    {ok, [{app, Name}]}),
 
-    true = filelib:is_file(filename:join(["_build", "cover", "eunit.coverdata"])).
+    true = filelib:is_file(filename:join([AppDir, "_build", "test", "cover", "eunit.coverdata"])).
 
 index_written(Config) ->
     AppDir = ?config(apps, Config),
 
     Name = rebar_test_utils:create_random_name("cover_"),
     Vsn = rebar_test_utils:create_random_vsn(),
-    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:create_eunit_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [{erl_opts, [{d, some_define}]}],
     rebar_test_utils:run_and_check(Config,
@@ -77,14 +77,14 @@ index_written(Config) ->
                                    ["do", "eunit", "--cover", ",", "cover"],
                                    {ok, [{app, Name}]}),
 
-    true = filelib:is_file(filename:join(["_build", "cover", "index.html"])).
+    true = filelib:is_file(filename:join([AppDir, "_build", "test", "cover", "index.html"])).
 
 config_alt_coverdir(Config) ->
     AppDir = ?config(apps, Config),
 
     Name = rebar_test_utils:create_random_name("cover_"),
     Vsn = rebar_test_utils:create_random_vsn(),
-    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:create_eunit_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     CoverDir = filename:join(["coverage", "goes", "here"]),
 
@@ -101,7 +101,7 @@ flag_verbose(Config) ->
 
     Name = rebar_test_utils:create_random_name("cover_"),
     Vsn = rebar_test_utils:create_random_vsn(),
-    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:create_eunit_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [{erl_opts, [{d, some_define}]}],
     rebar_test_utils:run_and_check(Config,
@@ -109,14 +109,14 @@ flag_verbose(Config) ->
                                    ["do", "eunit", "--cover", ",", "cover", "--verbose"],
                                    {ok, [{app, Name}]}),
 
-    true = filelib:is_file(filename:join(["_build", "cover", "index.html"])).
+    true = filelib:is_file(filename:join([AppDir, "_build", "test", "cover", "index.html"])).
 
 config_verbose(Config) ->
     AppDir = ?config(apps, Config),
 
     Name = rebar_test_utils:create_random_name("cover_"),
     Vsn = rebar_test_utils:create_random_vsn(),
-    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:create_eunit_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     RebarConfig = [{erl_opts, [{d, some_define}]}, {cover_print_enabled, true}],
     rebar_test_utils:run_and_check(Config,
@@ -124,4 +124,4 @@ config_verbose(Config) ->
                                    ["do", "eunit", "--cover", ",", "cover"],
                                    {ok, [{app, Name}]}),
 
-    true = filelib:is_file(filename:join(["_build", "cover", "index.html"])).
+    true = filelib:is_file(filename:join([AppDir, "_build", "test", "cover", "index.html"])).


### PR DESCRIPTION
this pr moves the generated cover data to `_build/$PROFILE/cover` and runs the `cover` task under the `test` profile (like the `eunit` and `ct` tasks) so users can discriminate between different profiles coverage data

it also attempts to add paths to modules contained in the cover data so line by line coverage can be generated for them