### PR TITLE
Fix ns help

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
          {branch, "master"}}},
        {providers, "",
         {git, "https://github.com/tsloughter/providers.git",
-         {tag, "v1.3.0"}}},
+         {tag, "v1.3.1"}}},
        {erlydtl, ".*",
          {git, "https://github.com/erlydtl/erlydtl.git",
           {tag, "0.10.0"}}},

--- a/src/rebar_prv_as.erl
+++ b/src/rebar_prv_as.erl
@@ -26,7 +26,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 as <profile1>,<profile2>,... <task1>, <task2>, ..."},
                                                                {short_desc, "Higher order provider for running multiple tasks in a sequence as a certain profiles."},
-                                                               {desc, ""},
+                                                               {desc, "Higher order provider for running multiple tasks in a sequence as a certain profiles."},
                                                                {opts, [{profile, undefined, undefined, string, "Profiles to run as."}]}])),
     {ok, State1}.
 

--- a/src/rebar_prv_clean.erl
+++ b/src/rebar_prv_clean.erl
@@ -26,7 +26,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 clean"},
                                                                {short_desc, "Remove compiled beam files from apps."},
-                                                               {desc, ""},
+                                                               {desc, "Remove compiled beam files from apps."},
                                                                {opts, [{all, $a, "all", undefined, "Clean all apps include deps"}]}])),
     {ok, State1}.
 

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -28,7 +28,7 @@ init(State) ->
                                  {bare, false},
                                  {example, "rebar3 ct"},
                                  {short_desc, "Run Common Tests."},
-                                 {desc, ""},
+                                 {desc, "Run Common Tests."},
                                  {opts, ct_opts(State)},
                                  {profiles, [test]}]),
     State1 = rebar_state:add_provider(State, Provider),

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -25,7 +25,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 compile"},
                                                                {short_desc, "Compile apps .app.src and .erl files."},
-                                                               {desc, ""},
+                                                               {desc, "Compile apps .app.src and .erl files."},
                                                                {opts, []}])),
     {ok, State1}.
 

--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -29,7 +29,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 cover"},
                                                                {short_desc, "Perform coverage analysis."},
-                                                               {desc, ""},
+                                                               {desc, "Perform coverage analysis."},
                                                                {opts, cover_opts(State)},
                                                                {profiles, [test]}])),
     {ok, State1}.

--- a/src/rebar_prv_do.erl
+++ b/src/rebar_prv_do.erl
@@ -27,7 +27,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 do <task1>, <task2>, ..."},
                                                                {short_desc, "Higher order provider for running multiple tasks in a sequence."},
-                                                               {desc, ""},
+                                                               {desc, "Higher order provider for running multiple tasks in a sequence."},
                                                                {opts, []}])),
     {ok, State1}.
 

--- a/src/rebar_prv_edoc.erl
+++ b/src/rebar_prv_edoc.erl
@@ -23,7 +23,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 edoc"},
                                                                {short_desc, "Generate documentation using edoc."},
-                                                               {desc, ""},
+                                                               {desc, "Generate documentation using edoc."},
                                                                {opts, []}])),
     {ok, State1}.
 

--- a/src/rebar_prv_erlydtl_compiler.erl
+++ b/src/rebar_prv_erlydtl_compiler.erl
@@ -119,7 +119,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 erlydtl compile"},
                                                                {short_desc, "Compile erlydtl templates."},
-                                                               {desc, ""},
+                                                               {desc, "Compile erlydtl templates."},
                                                                {opts, []}])),
     {ok, State1}.
 

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -27,7 +27,7 @@ init(State) ->
                                  {bare, false},
                                  {example, "rebar3 eunit"},
                                  {short_desc, "Run EUnit Tests."},
-                                 {desc, ""},
+                                 {desc, "Run EUnit Tests."},
                                  {opts, eunit_opts(State)},
                                  {profiles, [test]}]),
     State1 = rebar_state:add_provider(State, Provider),

--- a/src/rebar_prv_release.erl
+++ b/src/rebar_prv_release.erl
@@ -26,7 +26,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 release"},
                                                                {short_desc, "Build release of project."},
-                                                               {desc, ""},
+                                                               {desc, "Build release of project."},
                                                                {opts, relx:opt_spec_list()}])),
     {ok, State1}.
 

--- a/src/rebar_prv_tar.erl
+++ b/src/rebar_prv_tar.erl
@@ -26,7 +26,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 tar"},
                                                                {short_desc, "Tar archive of release built of project."},
-                                                               {desc, ""},
+                                                               {desc, "Tar archive of release built of project."},
                                                                {opts, relx:opt_spec_list()}])),
     {ok, State1}.
 

--- a/src/rebar_prv_update.erl
+++ b/src/rebar_prv_update.erl
@@ -27,7 +27,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 update"},
                                                                {short_desc, "Update package index."},
-                                                               {desc, ""},
+                                                               {desc, "Update package index."},
                                                                {opts, []}])),
     {ok, State1}.
 

--- a/src/rebar_prv_version.erl
+++ b/src/rebar_prv_version.erl
@@ -26,7 +26,7 @@ init(State) ->
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 version"},
                                                                {short_desc, "Print version for rebar and current Erlang."},
-                                                               {desc, ""},
+                                                               {desc, "Print version for rebar and current Erlang."},
                                                                {opts, []}])),
 
     {ok, State1}.


### PR DESCRIPTION
- `rebar3 help erlydtl compile` would not resolve, now it does and prints `Usage: rebar3 erlydtl compile`
- `rebar3 help compile` would display `Usage: rebar compile`, now displays `Usage: rebar3 compile`
- Made sure all providers have a `desc` property so there is something to show for in help.
- Fixes #314 