### PR TITLE
install dep plugins & run provider hooks the same as shell hooks

### DIFF
--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -23,6 +23,10 @@
         %% Default log level
         {log_level, warn},
 
+        {resources, [{git, rebar_git_resource},
+                     {pkg, rebar_pkg_resource},
+                     {hg, rebar_hg_resource}]},
+
         {providers, [rebar_prv_app_discovery,
                      rebar_prv_as,
                      rebar_prv_clean,

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -124,16 +124,18 @@ run_aux(State, GlobalPluginProviders, RawArgs) ->
                             filename:join(filename:absname(rebar_state:dir(State2)), BaseDir)),
 
     {ok, Providers} = application:get_env(rebar, providers),
-    {ok, PluginProviders, State4} = rebar_plugins:install(State3),
+    {ok, Resources} = application:get_env(rebar, resources),
+    State4 = rebar_state:resources(State3, Resources),
+    {ok, PluginProviders, State5} = rebar_plugins:install(State4),
 
     %% Providers can modify profiles stored in opts, so set default after initializing providers
     AllProviders = Providers++PluginProviders++GlobalPluginProviders,
-    State5 = rebar_state:create_logic_providers(AllProviders, State4),
-    State6 = rebar_state:default(State5, rebar_state:opts(State5)),
+    State6 = rebar_state:create_logic_providers(AllProviders, State5),
+    State7 = rebar_state:default(State6, rebar_state:opts(State6)),
 
     {Task, Args} = parse_args(RawArgs),
 
-    rebar_core:init_command(rebar_state:command_args(State6, Args), Task).
+    rebar_core:init_command(rebar_state:command_args(State7, Args), Task).
 
 init_config() ->
     %% Initialize logging system

--- a/src/rebar_core.erl
+++ b/src/rebar_core.erl
@@ -26,7 +26,7 @@
 %% -------------------------------------------------------------------
 -module(rebar_core).
 
--export([init_command/2, process_namespace/2, process_command/2]).
+-export([init_command/2, process_namespace/2, process_command/2, do/2]).
 
 -include("rebar.hrl").
 

--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -1,9 +1,30 @@
 -module(rebar_hooks).
 
--export([run_compile_hooks/4]).
+-export([run_all_hooks/5]).
 
-run_compile_hooks(Dir, Type, Command, State) ->
-    Hooks = rebar_state:get(State, Type, []),
+-spec run_all_hooks(file:filename_all(), pre | post,
+                   atom() | {atom(), atom()} | string(),
+                   [providers:t()], rebar_state:t()) -> ok.
+run_all_hooks(Dir, Type, Command, Providers, State) ->
+    run_provider_hooks(Dir, Type, Command, Providers, State),
+    run_hooks(Dir, Type, Command, State).
+
+run_provider_hooks(Dir, Type, Command, Providers, State) ->
+    State1 = rebar_state:providers(rebar_state:dir(State, Dir), Providers),
+    AllHooks = rebar_state:get(State1, provider_hooks, []),
+    TypeHooks = proplists:get_value(Type, AllHooks, []),
+    HookProviders = proplists:get_all_values(Command, TypeHooks),
+    rebar_core:do(HookProviders, State1).
+
+run_hooks(Dir, Type, Command, State) ->
+    Hooks = case Type of
+                pre ->
+                    rebar_state:get(State, pre_hooks, []);
+                post ->
+                    rebar_state:get(State, post_hooks, []);
+                _ ->
+                    []
+            end,
     Env = [{"REBAR_DEPS_DIR", filename:absname(rebar_dir:deps_dir(State))}],
     lists:foreach(fun({_, C, _}=Hook) when C =:= Command ->
                           apply_hook(Dir, Env, Hook);

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -32,20 +32,23 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     ProjectApps = rebar_state:project_apps(State),
+    Providers = rebar_state:providers(State),
     Deps = rebar_state:deps_to_build(State),
     Cwd = rebar_dir:get_cwd(),
-    rebar_hooks:run_compile_hooks(Cwd, pre_hooks, compile, State),
+
+    rebar_hooks:run_all_hooks(Cwd, pre, compile, Providers, State),
 
     %% Need to allow global config vars used on deps
     %% Right now no way to differeniate and just give deps a new state
     EmptyState = rebar_state:new(),
-    build_apps(EmptyState, Deps),
+    build_apps(EmptyState, Providers, Deps),
 
     %% Use the project State for building project apps
     %% Set hooks to empty so top-level hooks aren't run for each project app
     State2 = rebar_state:set(rebar_state:set(State, post_hooks, []), pre_hooks, []),
-    ProjectApps1 = build_apps(State2, ProjectApps),
-    rebar_hooks:run_compile_hooks(Cwd, post_hooks, compile, State),
+    ProjectApps1 = build_apps(State2, Providers, ProjectApps),
+
+    rebar_hooks:run_all_hooks(Cwd, post, compile, Providers, State),
 
     {ok, rebar_state:project_apps(State, ProjectApps1)}.
 
@@ -53,10 +56,10 @@ do(State) ->
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
-build_apps(State, Apps) ->
-    [build_app(State, AppInfo) || AppInfo <- Apps].
+build_apps(State, Providers, Apps) ->
+    [build_app(State, Providers, AppInfo) || AppInfo <- Apps].
 
-build_app(State, AppInfo) ->
+build_app(State, Providers, AppInfo) ->
     AppDir = rebar_app_info:dir(AppInfo),
     OutDir = rebar_app_info:out_dir(AppInfo),
 
@@ -71,9 +74,10 @@ build_app(State, AppInfo) ->
         end,
 
     %% Legacy hook support
-    rebar_hooks:run_compile_hooks(AppDir, pre_hooks, compile, S),
+
+    rebar_hooks:run_all_hooks(AppDir, pre, compile,  Providers, S),
     AppInfo1 = compile(S, AppInfo),
-    rebar_hooks:run_compile_hooks(AppDir, post_hooks, compile, S),
+    rebar_hooks:run_all_hooks(AppDir, post, compile, Providers, S),
 
     true = code:add_patha(rebar_app_info:ebin_dir(AppInfo1)),
     AppInfo1.

--- a/src/rebar_prv_deps.erl
+++ b/src/rebar_prv_deps.erl
@@ -77,7 +77,7 @@ display_dep(_State, {Name, _Vsn, Source, _Opts}) when is_tuple(Source) ->
 display_dep(State, {Name, Source={pkg, _, Vsn}, Level}) when is_integer(Level) ->
     DepsDir = rebar_dir:deps_dir(State),
     AppDir = filename:join([DepsDir, ec_cnv:to_binary(Name)]),
-    NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source) of
+    NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source, State) of
         true -> "*";
         false -> ""
     end,
@@ -85,7 +85,7 @@ display_dep(State, {Name, Source={pkg, _, Vsn}, Level}) when is_integer(Level) -
 display_dep(State, {Name, Source, Level}) when is_tuple(Source), is_integer(Level), element(1, Source) =:= git ->
     DepsDir = rebar_dir:deps_dir(State),
     AppDir = filename:join([DepsDir, ec_cnv:to_binary(Name)]),
-    NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source) of
+    NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source, State) of
         true -> "*";
         false -> ""
     end,
@@ -93,7 +93,7 @@ display_dep(State, {Name, Source, Level}) when is_tuple(Source), is_integer(Leve
 display_dep(State, {Name, Source, Level}) when is_tuple(Source), is_integer(Level) ->
     DepsDir = rebar_dir:deps_dir(State),
     AppDir = filename:join([DepsDir, ec_cnv:to_binary(Name)]),
-    NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source) of
+    NeedsUpdate = case rebar_fetch:needs_update(AppDir, Source, State) of
         true -> "*";
         false -> ""
     end,

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -85,7 +85,10 @@ do(State) ->
             no_cycle ->
                 case compile_order(Source, ProjectApps) of
                     {ok, ToCompile} ->
-                        {ok, rebar_state:deps_to_build(State1, ToCompile)};
+                        %% Deps may have plugins to install. Find and intall here.
+                        {ok, PluginProviders, State2} = rebar_plugins:install(State1),
+                        State3 = rebar_state:create_logic_providers(PluginProviders, State2),
+                        {ok, rebar_state:deps_to_build(State3, ToCompile)};
                     {error, Error} ->
                         {error, Error}
                 end

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -510,12 +510,12 @@ fetch_app(AppInfo, AppDir, State) ->
             Result
     end.
 
-maybe_upgrade(AppInfo, AppDir, false, _State) ->
+maybe_upgrade(AppInfo, AppDir, false, State) ->
     Source = rebar_app_info:source(AppInfo),
-    rebar_fetch:needs_update(AppDir, Source);
+    rebar_fetch:needs_update(AppDir, Source, State);
 maybe_upgrade(AppInfo, AppDir, true, State) ->
     Source = rebar_app_info:source(AppInfo),
-    case rebar_fetch:needs_update(AppDir, Source) of
+    case rebar_fetch:needs_update(AppDir, Source, State) of
         true ->
             ?INFO("Updating ~s", [rebar_app_info:name(AppInfo)]),
             case rebar_fetch:download_source(AppDir, Source, State) of

--- a/src/rebar_prv_lock.erl
+++ b/src/rebar_prv_lock.erl
@@ -37,7 +37,7 @@ do(State) ->
                  %% If source is tuple it is a source dep
                  %% e.g. {git, "git://github.com/ninenines/cowboy.git", "master"}
                  {rebar_app_info:name(Dep)
-                 ,rebar_fetch:lock_source(Dir, Source)
+                 ,rebar_fetch:lock_source(Dir, Source, State)
                  ,rebar_app_info:dep_level(Dep)}
              end || Dep <- AllDeps, not(rebar_app_info:is_checkout(Dep))],
     Dir = rebar_state:dir(State),

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -30,6 +30,7 @@
          overrides/1, overrides/2,
          apply_overrides/2,
 
+         resources/1, resources/2, add_resource/2,
          providers/1, providers/2, add_provider/2]).
 
 -include("rebar.hrl").
@@ -51,6 +52,7 @@
                   all_deps            = []          :: [rebar_app_info:t()],
 
                   overrides           = [],
+                  resources           = [],
                   providers           = []}).
 
 -export_type([t/0]).
@@ -296,6 +298,16 @@ namespace(#state_t{namespace=Namespace}) ->
 namespace(State=#state_t{}, Namespace) ->
     State#state_t{namespace=Namespace}.
 
+resources(#state_t{resources=Resources}) ->
+    Resources.
+
+resources(State, NewResources) ->
+    State#state_t{resources=NewResources}.
+
+-spec add_resource(t(), rebar_resource:resource()) -> t().
+add_resource(State=#state_t{resources=Resources}, Resource) ->
+    State#state_t{resources=[Resource | Resources]}.
+
 providers(#state_t{providers=Providers}) ->
     Providers.
 
@@ -425,4 +437,3 @@ umerge([], Olds, Merged, CmpMerged, Cmp) when CmpMerged == Cmp ->
     lists:reverse(Olds, Merged);
 umerge([], Olds, Merged, _CmpMerged, Cmp) ->
     lists:reverse(Olds, [Cmp | Merged]).
-

--- a/test/mock_git_resource.erl
+++ b/test/mock_git_resource.erl
@@ -99,6 +99,7 @@ mock_vsn(Opts) ->
 %%   into a `rebar.config' file to describe dependencies.
 mock_download(Opts) ->
     Deps = proplists:get_value(deps, Opts, []),
+    Config = proplists:get_value(config, Opts, []),
     Default = proplists:get_value(default_vsn, Opts, "0.0.0"),
     Overrides = proplists:get_value(override_vsn, Opts, []),
     meck:expect(
@@ -112,7 +113,7 @@ mock_download(Opts) ->
                 Dir, App, Vsn,
                 [kernel, stdlib] ++ [element(1,D) || D  <- AppDeps]
             ),
-            rebar_test_utils:create_config(Dir, [{deps, AppDeps}]),
+            rebar_test_utils:create_config(Dir, [{deps, AppDeps}]++Config),
             {ok, 'WHATEVER'}
         end).
 

--- a/test/rebar_resource_SUITE.erl
+++ b/test/rebar_resource_SUITE.erl
@@ -12,7 +12,10 @@ groups() ->
      {hg, [], [{group, all}]}].
 
 init_per_group(all, Config) ->
-    Config;
+    State = rebar_state:resources(rebar_state:new(), [{git, rebar_git_resource},
+                                                      {pkg, rebar_pkg_resource},
+                                                      {hg, rebar_hg_resource}]),
+    [{state, State} | Config];
 init_per_group(Name, Config) ->
     [{type, Name},
      {resource, {Name, "https://example.org/user/app", "vsn"}} | Config].
@@ -33,4 +36,5 @@ end_per_testcase(_, Config) ->
 
 change_type_upgrade(Config) ->
     ?assert(rebar_fetch:needs_update(?config(path, Config),
-                                     ?config(resource, Config))).
+                                     ?config(resource, Config),
+                                     ?config(state, Config))).


### PR DESCRIPTION
Still need to add tests and open to changing how dep plugins get installed. Currently it waits until all deps are installed and then scans all dep config files for plugins listed and installs them at that point. Pretty inefficient.