### PR TITLE
Remove global plugins

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -156,9 +156,8 @@ init_config() ->
                 true ->
                     ?DEBUG("Load global config file ~p",
                            [GlobalConfigFile]),
-                    GlobalConfig = rebar_state:new(global, rebar_config:consult_file(GlobalConfigFile)),
-                    GlobalConfig1 = rebar_plugins:install(GlobalConfig),
-                    rebar_state:new(GlobalConfig1, Config1);
+                    GlobalConfig = rebar_state:new(rebar_config:consult_file(GlobalConfigFile)),
+                    rebar_state:new(GlobalConfig, Config1);
                 false ->
                     rebar_state:new(Config1)
             end,

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -13,18 +13,16 @@
 
 -spec install(rebar_state:t()) -> rebar_state:t().
 install(State) ->
-    DepsDir = rebar_dir:deps_dir(State),
     Plugins = rebar_state:get(State, plugins, []),
 
     ProjectApps = rebar_state:project_apps(State),
-    DepApps = rebar_app_discover:find_apps([DepsDir], all),
 
     OtherPlugins = lists:flatmap(fun(App) ->
                                          AppDir = rebar_app_info:dir(App),
                                          C = rebar_config:consult(AppDir),
                                          S = rebar_state:new(rebar_state:new(), C, AppDir),
                                          rebar_state:get(S, plugins, [])
-                                 end, ProjectApps++DepApps),
+                                 end, ProjectApps),
 
     handle_plugins(Plugins++OtherPlugins, State).
 


### PR DESCRIPTION
Removes installing of global plugins as a special case.

Additionally removes the duplication of attempts to install/load deps plugins if the dep is already installed.