### PR TITLE
rm old beams, make erlcinfo graph per app isntad of global to project

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -12,7 +12,7 @@
          global_config/1,
          global_config/0,
          global_cache_dir/1,
-         local_cache_dir/0,
+         local_cache_dir/1,
          get_cwd/0,
          template_globals/1,
          template_dir/1,
@@ -85,8 +85,8 @@ global_cache_dir(State) ->
     Home = home_dir(),
     rebar_state:get(State, global_rebar_dir, filename:join([Home, ".cache", "rebar3"])).
 
-local_cache_dir() ->
-    filename:join(get_cwd(), ".rebar3").
+local_cache_dir(Dir) ->
+    filename:join(Dir, ".rebar3").
 
 get_cwd() ->
     {ok, Dir} = file:get_cwd(),

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -44,10 +44,14 @@ do(State) ->
 
     case prepare_tests(State) of
         {ok, Tests} ->
-            {ok, State1} = do_tests(State, Tests),
-            %% Run eunit provider posthooks
-            rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State1),
-            {ok, State1};
+            case do_tests(State, Tests) of
+                {ok, State1} ->
+                    %% Run eunit provider posthooks
+                    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State1),
+                    {ok, State1};
+                Error ->
+                    Error
+            end;
         Error ->
             Error
     end.


### PR DESCRIPTION
This patch moves the erlc digraph found in `erlcinfo` to be per application instead of for the entire project. This allows to check if a file that was compiled before no longer exists and we can delete the corresponding beam file that was created from the now gone file.