### PR TITLE
support single atoms for pkg deps, fetch highest version available

### DIFF
--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -36,12 +36,6 @@
 -type rebar_digraph() :: digraph().
 -endif.
 
--ifdef(namespaced_types).
--type rebar_tid() :: ets:tid().
--else.
--type rebar_tid() :: tid().
--endif.
-
 -define(GRAPH_VSN, 2).
 -type v() :: {digraph:vertex(), term()} | 'false'.
 -type e() :: {digraph:vertex(), digraph:vertex()}.

--- a/src/rebar.hrl
+++ b/src/rebar.hrl
@@ -36,6 +36,12 @@
 -type rebar_digraph() :: digraph().
 -endif.
 
+-ifdef(namespaced_types).
+-type rebar_tid() :: ets:tid().
+-else.
+-type rebar_tid() :: tid().
+-endif.
+
 -define(GRAPH_VSN, 2).
 -type v() :: {digraph:vertex(), term()} | 'false'.
 -type e() :: {digraph:vertex(), digraph:vertex()}.

--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -48,9 +48,9 @@ merge_deps(AppInfo, State) ->
     State1 = lists:foldl(fun(Profile, StateAcc) ->
                                  AppProfDeps = rebar_state:get(AppState, {deps, Profile}, []),
                                  TopLevelProfDeps = rebar_state:get(StateAcc, {deps, Profile}, []),
-                                 ProfDeps2 = dedup(lists:keymerge(1,
-                                                                  lists:keysort(1, TopLevelProfDeps),
-                                                                  lists:keysort(1, AppProfDeps))),
+                                 ProfDeps2 = dedup(rebar_utils:tup_umerge(
+                                                     rebar_utils:tup_sort(TopLevelProfDeps)
+                                                     ,rebar_utils:tup_sort(AppProfDeps))),
                                  rebar_state:set(StateAcc, {deps, Profile}, ProfDeps2)
                          end, State, lists:reverse(CurrentProfiles)),
 
@@ -164,7 +164,8 @@ create_app_info(AppDir, AppFile) ->
             AppInfo1 = rebar_app_info:applications(
                          rebar_app_info:app_details(AppInfo, AppDetails),
                          IncludedApplications++Applications),
-            rebar_app_info:dir(AppInfo1, AppDir);
+            Valid = rebar_app_utils:validate_application_info(AppInfo1),
+            rebar_app_info:dir(rebar_app_info:valid(AppInfo1, Valid), AppDir);
         _ ->
             error
     end.

--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -128,8 +128,8 @@ check_newly_added(Dep, LockedDeps) when is_atom(Dep) ->
                     true;
                 _ ->
                     ?WARN("Newly added dep ~s is locked at a lower level. "
-                         "If you really want to unlock it, use 'rebar3 upgrade ~s'",
-                         [NewDep, NewDep]),
+                          "If you really want to unlock it, use 'rebar3 upgrade ~s'",
+                          [NewDep, NewDep]),
                     false
             end
     end;

--- a/src/rebar_digraph.erl
+++ b/src/rebar_digraph.erl
@@ -101,7 +101,7 @@ cull_deps(Graph, Vertices, Level, Levels, Solution, Discarded) ->
                                                      DiscardedAcc1}
                                             end
                                     end, {NewVertices, SolutionAcc, LevelsAcc, DiscardedAcc}, OutNeighbors)
-                    end, {[], Solution, Levels, Discarded}, lists:sort(Vertices)),
+                    end, {[], Solution, Levels, Discarded}, lists:keysort(1, Vertices)),
     cull_deps(Graph, NV, Level+1, LS, NS, DS).
 
 subgraph(Graph, Vertices) ->

--- a/src/rebar_digraph.erl
+++ b/src/rebar_digraph.erl
@@ -72,10 +72,12 @@ cull_deps(Graph, Vertices) ->
     cull_deps(Graph,
               Vertices,
               1,
-              lists:foldl(fun({Key, _}, Levels) -> dict:store(Key, 0, Levels) end,
-                          dict:new(), Vertices),
-              lists:foldl(fun({Key, _}=N, Solution) -> dict:store(Key, N, Solution) end,
-                          dict:new(), Vertices),
+              lists:foldl(fun({Key, _}, Levels) ->
+                                  dict:store(Key, 0, Levels)
+                          end, dict:new(), Vertices),
+              lists:foldl(fun({Key, _}=N, Solution) ->
+                                  dict:store(Key, N, Solution)
+                          end, dict:new(), Vertices),
               []).
 
 cull_deps(_Graph, [], _Level, Levels, Solution, Discarded) ->
@@ -99,7 +101,7 @@ cull_deps(Graph, Vertices, Level, Levels, Solution, Discarded) ->
                                                      DiscardedAcc1}
                                             end
                                     end, {NewVertices, SolutionAcc, LevelsAcc, DiscardedAcc}, OutNeighbors)
-                    end, {[], Solution, Levels, Discarded}, lists:keysort(1, Vertices)),
+                    end, {[], Solution, Levels, Discarded}, lists:sort(Vertices)),
     cull_deps(Graph, NV, Level+1, LS, NS, DS).
 
 subgraph(Graph, Vertices) ->

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -43,7 +43,7 @@ get_packages(State) ->
 registry(State) ->
     Dir = rebar_dir:global_cache_dir(State),
     RegistryDir = filename:join(Dir, "packages"),
-    HexFile = filename:join(RegistryDir, "registry2"),
+    HexFile = filename:join(RegistryDir, "registry"),
     case ets:file2tab(HexFile) of
         {ok, T} ->
             {ok, T};

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -391,11 +391,11 @@ maybe_fetch(AppInfo, Upgrade, Seen, State) ->
                         {true, FoundApp} ->
                             %% Preserve the state we created with overrides
                             AppState = rebar_app_info:state(AppInfo),
-                            FoundApp = rebar_app_info:state(FoundApp, AppState),
-                            ?INFO("Linking ~s to ~s", [rebar_app_info:dir(FoundApp), AppDir]),
+                            FoundApp1 = rebar_app_info:state(FoundApp, AppState),
+                            ?INFO("Linking ~s to ~s", [rebar_app_info:dir(FoundApp1), AppDir]),
                             filelib:ensure_dir(AppDir),
-                            rebar_file_utils:symlink_or_copy(rebar_app_info:dir(FoundApp), AppDir),
-                            {true, AppInfo}
+                            rebar_file_utils:symlink_or_copy(rebar_app_info:dir(FoundApp1), AppDir),
+                            {true, FoundApp1}
                     end;
                 {true, AppInfo1} ->
                     %% Preserve the state we created with overrides

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -97,6 +97,8 @@ do(State) ->
     end.
 
 -spec format_error(any()) -> iolist().
+format_error({load_registry_fail, Dep}) ->
+    io_lib:format("Error loading registry to resolve version of ~s. Try fixing by running 'rebar3 update'", [Dep]);
 format_error({bad_constraint, Name, Constraint}) ->
     io_lib:format("Unable to parse version for package ~s: ~s", [Name, Constraint]);
 format_error({parse_dep, Dep}) ->
@@ -129,9 +131,10 @@ handle_deps(Profile, State, Deps, Locks) when is_list(Locks) ->
                  -> {ok, [rebar_app_info:t()], rebar_state:t()} | {error, string()}.
 handle_deps(_Profile, State, [], _, _) ->
     {ok, [], State};
-handle_deps(Profile, State, Deps, Upgrade, Locks) ->
+handle_deps(Profile, State0, Deps, Upgrade, Locks) ->
     %% Read in package index and dep graph
-    {Packages, Graph} = rebar_packages:get_packages(State),
+    {Packages, Graph} = rebar_state:packages(State0),
+    State = rebar_state:packages(State0, {Packages, Graph}),
     %% Split source deps from pkg deps, needed to keep backwards compatibility
     DepsDir = rebar_dir:deps_dir(State),
     {SrcDeps, PkgDeps} = parse_deps(DepsDir, Deps, State, Locks, 0),
@@ -210,8 +213,8 @@ handle_pkg_dep(Profile, Pkg, Packages, Upgrade, DepsDir, Fetched, Seen, State) -
     AppInfo = package_to_app(DepsDir, Packages, Pkg),
     Level = rebar_app_info:dep_level(AppInfo),
     {NewSeen, NewState} = maybe_lock(Profile, AppInfo, Seen, State, Level),
-    maybe_fetch(AppInfo, Upgrade, Seen, NewState),
-    {[AppInfo | Fetched], NewSeen, NewState}.
+    {_, AppInfo1} = maybe_fetch(AppInfo, Upgrade, Seen, NewState),
+    {[AppInfo1 | Fetched], NewSeen, NewState}.
 
 maybe_lock(Profile, AppInfo, Seen, State, Level) ->
     case rebar_app_info:is_checkout(AppInfo) of
@@ -312,8 +315,8 @@ update_unseen_src_dep(AppInfo, Profile, Level, SrcDeps, PkgDeps, SrcApps, State,
                 handle_upgrade(AppInfo, SrcDeps, PkgDeps, SrcApps,
                                Level, State1, Locks);
             _ ->
-                maybe_fetch(AppInfo, false, Seen, State1),
-                handle_dep(AppInfo, SrcDeps, PkgDeps, SrcApps,
+                {_, AppInfo1} = maybe_fetch(AppInfo, false, Seen, State1),
+                handle_dep(AppInfo1, SrcDeps, PkgDeps, SrcApps,
                            Level, State1, Locks)
         end,
     {NewSrcDeps, NewPkgDeps, NewSrcApps, State2, NewSeen, NewLocks}.
@@ -323,12 +326,12 @@ handle_upgrade(AppInfo, SrcDeps, PkgDeps, SrcApps, Level, State, Locks) ->
     case lists:keyfind(Name, 1, Locks) of
         false ->
             case maybe_fetch(AppInfo, true, sets:new(), State) of
-                true ->
-                    handle_dep(AppInfo, SrcDeps, PkgDeps, SrcApps,
+                {true, AppInfo1} ->
+                    handle_dep(AppInfo1, SrcDeps, PkgDeps, SrcApps,
                                Level, State, Locks);
 
-                false ->
-                    {[AppInfo|SrcDeps], PkgDeps, SrcApps, State, Locks}
+                {false, AppInfo1} ->
+                    {[AppInfo1|SrcDeps], PkgDeps, SrcApps, State, Locks}
             end;
         _StillLocked ->
             {[AppInfo|SrcDeps], PkgDeps, SrcApps, State, Locks}
@@ -371,31 +374,37 @@ handle_dep(State, DepsDir, AppInfo, Locks, Level) ->
     {AppInfo2, SrcDeps, PkgDeps, Locks++NewLocks, State1}.
 
 -spec maybe_fetch(rebar_app_info:t(), boolean() | {true, binary(), integer()},
-                  sets:set(binary()), rebar_state:t()) -> boolean().
+                  sets:set(binary()), rebar_state:t()) -> {boolean(), rebar_app_info:t()}.
 maybe_fetch(AppInfo, Upgrade, Seen, State) ->
     AppDir = ec_cnv:to_list(rebar_app_info:dir(AppInfo)),
     %% Don't fetch dep if it exists in the _checkouts dir
     case rebar_app_info:is_checkout(AppInfo) of
         true ->
-            false;
+            {false, AppInfo};
         false ->
             case rebar_app_discover:find_app(AppDir, all) of
                 false ->
                     case in_default(AppInfo, State) of
                         false ->
-                            fetch_app(AppInfo, AppDir, State);
+                            {fetch_app(AppInfo, AppDir, State), AppInfo};
                         {true, FoundApp} ->
+                            %% Preserve the state we created with overrides
+                            AppState = rebar_app_info:state(AppInfo),
+                            FoundApp = rebar_app_info:state(FoundApp, AppState),
                             ?INFO("Linking ~s to ~s", [rebar_app_info:dir(FoundApp), AppDir]),
                             filelib:ensure_dir(AppDir),
                             rebar_file_utils:symlink_or_copy(rebar_app_info:dir(FoundApp), AppDir),
-                            true
+                            {true, AppInfo}
                     end;
-                {true, _} ->
+                {true, AppInfo1} ->
+                    %% Preserve the state we created with overrides
+                    AppState = rebar_app_info:state(AppInfo),
+                    AppInfo2 = rebar_app_info:state(AppInfo1, AppState),
                     case sets:is_element(rebar_app_info:name(AppInfo), Seen) of
                         true ->
-                            false;
+                            {false, AppInfo2};
                         false ->
-                            maybe_upgrade(AppInfo, AppDir, Upgrade, State)
+                            {maybe_upgrade(AppInfo, AppDir, Upgrade, State), AppInfo2}
                     end
             end
     end.
@@ -439,13 +448,14 @@ parse_dep({Name, Vsn}, {SrcDepsAcc, PkgDepsAcc}, DepsDir, State) when is_list(Vs
                                     ,ec_cnv:to_binary(Vsn)) | PkgDepsAcc]}
     end;
 parse_dep(Name, {SrcDepsAcc, PkgDepsAcc}, DepsDir, State) when is_atom(Name) ->
+    {PkgName, PkgVsn} = get_package(ec_cnv:to_binary(Name), State),
     CheckoutsDir = ec_cnv:to_list(rebar_dir:checkouts_dir(State, Name)),
     case rebar_app_info:discover(CheckoutsDir) of
         {ok, _App} ->
             Dep = new_dep(DepsDir, Name, [], [], State),
             {[Dep | SrcDepsAcc], PkgDepsAcc};
         not_found ->
-            {SrcDepsAcc, [ec_cnv:to_binary(Name) | PkgDepsAcc]}
+            {SrcDepsAcc, [{PkgName, PkgVsn} | PkgDepsAcc]}
     end;
 parse_dep({Name, Source}, {SrcDepsAcc, PkgDepsAcc}, DepsDir, State) when is_tuple(Source) ->
     Dep = new_dep(DepsDir, Name, [], Source, State),
@@ -561,3 +571,12 @@ warn_skip_pkg({Name, Source}, State) ->
 not_needs_compile(App) ->
     not(rebar_app_info:is_checkout(App))
         andalso rebar_app_info:valid(App).
+
+get_package(Dep, State) ->
+    case rebar_packages:registry(State) of
+        {ok, T} ->
+            HighestDepVsn = rebar_packages:find_highest_matching(Dep, "0", T),
+            {Dep, HighestDepVsn};
+        error ->
+            throw(?PRV_ERROR({load_registry_fail, Dep}))
+    end.

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -134,7 +134,8 @@ handle_deps(_Profile, State, [], _, _) ->
 handle_deps(Profile, State0, Deps, Upgrade, Locks) ->
     %% Read in package index and dep graph
     {Packages, Graph} = rebar_state:packages(State0),
-    State = rebar_state:packages(State0, {Packages, Graph}),
+    Registry = rebar_packages:registry(State0),
+    State = rebar_state:packages(rebar_state:registry(State0, Registry), {Packages, Graph}),
     %% Split source deps from pkg deps, needed to keep backwards compatibility
     DepsDir = rebar_dir:deps_dir(State),
     {SrcDeps, PkgDeps} = parse_deps(DepsDir, Deps, State, Locks, 0),
@@ -573,7 +574,7 @@ not_needs_compile(App) ->
         andalso rebar_app_info:valid(App).
 
 get_package(Dep, State) ->
-    case rebar_packages:registry(State) of
+    case rebar_state:registry(State) of
         {ok, T} ->
             HighestDepVsn = rebar_packages:find_highest_matching(Dep, "0", T),
             {Dep, HighestDepVsn};

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -55,7 +55,7 @@
                   all_deps            = []          :: [rebar_app_info:t()],
 
                   packages            = undefined   :: {rebar_dict(), rebar_digraph()} | undefined,
-                  registry            = undefined   :: {ok, rebar_tid()} | error | undefined,
+                  registry            = undefined   :: {ok, ets:tid()} | error | undefined,
                   overrides           = [],
                   resources           = [],
                   providers           = []}).

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -31,6 +31,7 @@
          apply_overrides/2,
 
          packages/1, packages/2,
+         registry/1, registry/2,
 
          resources/1, resources/2, add_resource/2,
          providers/1, providers/2, add_provider/2]).
@@ -54,7 +55,7 @@
                   all_deps            = []          :: [rebar_app_info:t()],
 
                   packages            = undefined   :: {rebar_dict(), rebar_digraph()} | undefined,
-
+                  registry            = undefined   :: {ok, rebar_tid()} | error | undefined,
                   overrides           = [],
                   resources           = [],
                   providers           = []}).
@@ -310,6 +311,14 @@ packages(#state_t{packages=Packages}) ->
 
 packages(State, Packages) ->
     State#state_t{packages=Packages}.
+
+registry(State=#state_t{registry=undefined}) ->
+    rebar_packages:registry(State);
+registry(#state_t{registry=Registry}) ->
+    Registry.
+
+registry(State, Registry) ->
+    State#state_t{registry=Registry}.
 
 -spec resources(t()) -> rebar_resource:resource().
 resources(#state_t{resources=Resources}) ->


### PR DESCRIPTION
Fixes support for a single atom as a dep, like `{deps, [cowboy]}.`

Additionally simplifies the job of `rebar3 pkgs` and fixes an issue with not knowing package deps didn't need to be recompiled by using the `AppInfo` created when doing `rebar_app_discover:find/2` instead of the new one created by install deps to be filled in -- however we override the `state` for `AppInfo` with the one newly created since that one has the overrides applied for this run.