### PR TITLE
Mainly CT changes

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -549,7 +549,7 @@ warn_and_find_path(File, Dir) ->
         true ->
             [SrcHeader];
         false ->
-            IncludeDir = filename:join(filename:join(lists:droplast(filename:split(Dir))), "include"),
+            IncludeDir = filename:join(filename:join(rebar_utils:droplast(filename:split(Dir))), "include"),
             IncludeHeader = filename:join(IncludeDir, File),
             case filelib:is_regular(IncludeHeader) of
                 true ->

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -242,7 +242,7 @@ copy_and_compile_test_suites(State, Opts) ->
             Dirs = find_suite_dirs(AllSuites),
             lists:foreach(fun(S) ->
                 NewPath = copy(State, S),
-                compile_dir(State, NewPath)
+                compile_dir(State, S, NewPath)
             end, Dirs),
             NewSuites = lists:map(fun(S) -> retarget_path(State, S) end, AllSuites),
             [{suite, NewSuites}|lists:keydelete(suite, 1, Opts)]
@@ -254,12 +254,12 @@ copy_and_compile_test_dirs(State, Opts) ->
         %% dir is a single directory
         Dir when is_list(Dir), is_integer(hd(Dir)) ->
             NewPath = copy(State, Dir),
-            [{dir, compile_dir(State, NewPath)}|lists:keydelete(dir, 1, Opts)];
+            [{dir, compile_dir(State, Dir, NewPath)}|lists:keydelete(dir, 1, Opts)];
         %% dir is a list of directories
         Dirs when is_list(Dirs) ->
             NewDirs = lists:map(fun(Dir) ->
                 NewPath = copy(State, Dir),
-                compile_dir(State, NewPath)
+                compile_dir(State, Dir, NewPath)
             end, Dirs),
             [{dir, NewDirs}|lists:keydelete(dir, 1, Opts)]
     end.
@@ -294,11 +294,11 @@ copy(State, Target) ->
             NewTarget
     end.
 
-compile_dir(State, Dir) ->
+compile_dir(State, Dir, OutDir) ->
     NewState = replace_src_dirs(State, [Dir]),
-    ok = rebar_erlc_compiler:compile(NewState, rebar_dir:base_dir(State), Dir),
+    ok = rebar_erlc_compiler:compile(NewState, rebar_dir:base_dir(State), OutDir),
     ok = maybe_cover_compile(State, Dir),
-    Dir.
+    OutDir.
 
 retarget_path(State, Path) ->
     ProjectApps = rebar_state:project_apps(State),

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -47,11 +47,13 @@ do(State) ->
     %% Set hooks to empty so top-level hooks aren't run for each project app
     State2 = rebar_state:set(rebar_state:set(State, post_hooks, []), pre_hooks, []),
     {ok, ProjectApps1} = rebar_digraph:compile_order(ProjectApps),
+
     ProjectApps2 = build_apps(State2, Providers, ProjectApps1),
+    State3 = rebar_state:project_apps(State2, ProjectApps2),
 
-    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State),
+    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State3),
 
-    {ok, rebar_state:project_apps(State, ProjectApps2)}.
+    {ok, State3}.
 
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->

--- a/src/rebar_prv_report.erl
+++ b/src/rebar_prv_report.erl
@@ -43,7 +43,7 @@ do(State) ->
     %% Show app versions (including rebar3)
     {ok, Vsn} = application:get_key(rebar, vsn),
     {ok, Apps} = application:get_key(rebar, applications),
-    [application:ensure_started(App) || App <- Apps],
+    [application:load(App) || App <- Apps],
     Vsns = [io_lib:format("~p: ~s~n", [App, AVsn])
             || App <- lists:sort(Apps),
                {ok, AVsn} <- [application:get_key(App, vsn)]],
@@ -101,4 +101,3 @@ time_to_string({{Y,M,D},{H,Min,S}}) ->
 
 parse_task(Str) ->
     hd(re:split(Str, " ")).
-


### PR DESCRIPTION
Main change: Instead of the common test provider having compile use the copied to test directory under `_build/test/lib` it now copies everything as before but the compile function is told to compile from the original test dir to the outdir under `_build/test/lib`.

This is important so that the "find erl files" part of the compiler doesn't find erl files that were added to data dirs during former runs.