### PR TITLE
Default deps always to the default profile

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -1,6 +1,7 @@
 -module(rebar_dir).
 
 -export([base_dir/1,
+         profile_dir/2,
          deps_dir/1,
          deps_dir/2,
          checkouts_dir/1,
@@ -24,7 +25,10 @@
 
 -spec base_dir(rebar_state:t()) -> file:filename_all().
 base_dir(State) ->
-    Profiles = rebar_state:current_profiles(State),
+    profile_dir(State, rebar_state:current_profiles(State)).
+
+-spec profile_dir(rebar_state:t(), [atom()]) -> file:filename_all().
+profile_dir(State, Profiles) ->
     ProfilesStrings = case [ec_cnv:to_list(P) || P <- Profiles] of
         ["default"]      -> ["default"];
         %% drop `default` from the profile dir if it's implicit and reverse order
@@ -33,6 +37,7 @@ base_dir(State) ->
     end,
     ProfilesDir = string:join(ProfilesStrings, "+"),
     filename:join(rebar_state:get(State, base_dir, ?DEFAULT_BASE_DIR), ProfilesDir).
+
 
 -spec deps_dir(rebar_state:t()) -> file:filename_all().
 deps_dir(State) ->

--- a/test/rebar_install_deps_SUITE.erl
+++ b/test/rebar_install_deps_SUITE.erl
@@ -2,6 +2,7 @@
 -compile(export_all).
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/file.hrl").
 
 all() -> [{group, git}, {group, pkg}].
 
@@ -9,7 +10,7 @@ groups() ->
     [{all, [], [flat, pick_highest_left, pick_highest_right,
                 pick_smallest1, pick_smallest2,
                 circular1, circular2, circular_skip,
-                fail_conflict]},
+                fail_conflict, default_profile, nondefault_profile]},
      {git, [], [{group, all}]},
      {pkg, [], [{group, all}]}].
 
@@ -114,7 +115,17 @@ deps(fail_conflict) ->
     {[{"B", [{"C", "2", []}]},
       {"C", "1", []}],
      [{"C","2"}],
-     rebar_abort}.
+     rebar_abort};
+deps(default_profile) ->
+    {[{"B", []},
+      {"C", []}],
+     [],
+     {ok, ["B", "C"]}};
+deps(nondefault_profile) ->
+    {[{"B", []},
+      {"C", []}],
+     [],
+     {ok, ["B", "C"]}}.
 
 setup_project(fail_conflict, Config0, Deps) ->
     DepsType = ?config(deps_type, Config0),
@@ -127,6 +138,25 @@ setup_project(fail_conflict, Config0, Deps) ->
     TopDeps = rebar_test_utils:top_level_deps(Deps),
     RebarConf = rebar_test_utils:create_config(AppDir, [{deps, TopDeps},
                                                         {deps_error_on_conflict, true}]),
+    case DepsType of
+        git ->
+            mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(Deps)}]);
+        pkg ->
+            mock_pkg_resource:mock([{pkgdeps, rebar_test_utils:flat_pkgdeps(Deps)}])
+    end,
+    [{rebarconfig, RebarConf} | Config];
+setup_project(nondefault_profile, Config0, Deps) ->
+    DepsType = ?config(deps_type, Config0),
+    Config = rebar_test_utils:init_rebar_state(
+            Config0,
+            "nondefault_profile_"++atom_to_list(DepsType)++"_"
+    ),
+    AppDir = ?config(apps, Config),
+    rebar_test_utils:create_app(AppDir, "A", "0.0.0", [kernel, stdlib]),
+    TopDeps = rebar_test_utils:top_level_deps(Deps),
+    RebarConf = rebar_test_utils:create_config(AppDir, [{profiles, [
+                                                            {nondef, [{deps, TopDeps}]}
+                                                       ]}]),
     case DepsType of
         git ->
             mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(Deps)}]);
@@ -173,6 +203,39 @@ fail_conflict(Config) ->
         Config, RebarConfig, ["install_deps"], ?config(expect, Config)
     ),
     check_warnings(error_calls(), ?config(warnings, Config), ?config(deps_type, Config)).
+
+default_profile(Config) ->
+    {ok, RebarConfig} = file:consult(?config(rebarconfig, Config)),
+    AppDir = ?config(apps, Config),
+    {ok, Apps} = Expect = ?config(expect, Config),
+    rebar_test_utils:run_and_check(
+        Config, RebarConfig, ["as", "profile", "install_deps"], Expect
+    ),
+    check_warnings(error_calls(), ?config(warnings, Config), ?config(deps_type, Config)),
+    BuildDir = filename:join([AppDir, "_build"]),
+    [?assertMatch({ok, #file_info{type=directory}},
+                  file:read_file_info(filename:join([BuildDir, "default", "lib", App])))
+     || {dep, App} <- Apps],
+    [?assertMatch({ok, #file_info{type=directory}}, % somehow symlinks return dirs
+                  file:read_file_info(filename:join([BuildDir, "profile", "lib", App])))
+     || {dep, App} <- Apps].
+
+nondefault_profile(Config) ->
+    {ok, RebarConfig} = file:consult(?config(rebarconfig, Config)),
+    AppDir = ?config(apps, Config),
+    {ok, Apps} = Expect = ?config(expect, Config),
+    rebar_test_utils:run_and_check(
+        Config, RebarConfig, ["as", "nondef", "install_deps"], Expect
+    ),
+    check_warnings(error_calls(), ?config(warnings, Config), ?config(deps_type, Config)),
+    BuildDir = filename:join([AppDir, "_build"]),
+    [?assertMatch({error, enoent},
+                  file:read_file_info(filename:join([BuildDir, "default", "lib", App])))
+     || {dep, App} <- Apps],
+    [?assertMatch({ok, #file_info{type=directory}},
+                  file:read_file_info(filename:join([BuildDir, "nondef", "lib", App])))
+     || {dep, App} <- Apps].
+
 
 run(Config) ->
     {ok, RebarConfig} = file:consult(?config(rebarconfig, Config)),


### PR DESCRIPTION
When fetching dependencies for the first time using a profile (`rebar3
as prod release` or `rebar3 ct`), the dependencies get fetched into the
non-default profile. This has two consequences:

- the files get re-downloaded on follow-up runs
- the lock file includes incomplete or too many deps in its list

This patch forces dependencies in the default profile to be stored in
_build/default/lib even when running under other profiles, then symlinks
them to the correct one.

This makes it so common dependencies in 'default' be downloaded there
and avoids re-downloading them. Should also fix the lock issues.

Should address https://github.com/rebar/rebar3/issues/307 and https://github.com/rebar/rebar3/issues/339