### PR TITLE
add to end of code path not the beginning in handle_deps

### DIFF
--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -153,7 +153,7 @@ handle_deps(Profile, State0, Deps, Upgrade, Locks) ->
     %% Sort all apps to build order
     State3 = rebar_state:all_deps(State2, AllDeps),
     CodePaths = [rebar_app_info:ebin_dir(A) || A <- AllDeps],
-    ok = code:add_pathsa(CodePaths),
+    ok = code:add_pathsz(CodePaths),
 
     {ok, AllDeps, State3}.
 


### PR DESCRIPTION
Fix for https://github.com/rebar/rebar3/issues/271

This way the erlydtl needed by rebar3/relx will be used when relx is building the release's scripts.