### PR TITLE
set the dep as the project app before running hooks

### DIFF
--- a/src/rebar_base_compiler.erl
+++ b/src/rebar_base_compiler.erl
@@ -114,7 +114,7 @@ compile_each([Source | Rest], Config, CompileFn) ->
         skipped ->
             ?DEBUG("~sSkipped ~s", [rebar_utils:indent(1), filename:basename(Source)]);
         Error ->
-            ?INFO("Compiling ~s failed:",
+            ?ERROR("Compiling ~s failed",
                      [maybe_absname(Config, Source)]),
             maybe_report(Error),
             ?DEBUG("Compilation failed: ~p", [Error]),

--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -4,6 +4,7 @@
          profile_dir/2,
          deps_dir/1,
          deps_dir/2,
+         root_dir/1,
          checkouts_dir/1,
          checkouts_dir/2,
          plugins_dir/1,
@@ -48,7 +49,7 @@ deps_dir(DepsDir, App) ->
     filename:join(DepsDir, App).
 
 root_dir(State) ->
-    rebar_state:get(State, root_dir, ?DEFAULT_ROOT_DIR).
+    filename:absname(rebar_state:get(State, root_dir, ?DEFAULT_ROOT_DIR)).
 
 -spec checkouts_dir(rebar_state:t()) -> file:filename_all().
 checkouts_dir(State) ->

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -43,17 +43,14 @@ do(State) ->
     EmptyState = rebar_state:new(),
     build_apps(EmptyState, Providers, Deps),
 
-    %% Use the project State for building project apps
-    %% Set hooks to empty so top-level hooks aren't run for each project app
-    State2 = rebar_state:set(rebar_state:set(State, post_hooks, []), pre_hooks, []),
     {ok, ProjectApps1} = rebar_digraph:compile_order(ProjectApps),
 
-    ProjectApps2 = build_apps(State2, Providers, ProjectApps1),
-    State3 = rebar_state:project_apps(State2, ProjectApps2),
+    ProjectApps2 = build_apps(State, Providers, ProjectApps1),
+    State2 = rebar_state:project_apps(State, ProjectApps2),
 
-    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State3),
+    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State2),
 
-    {ok, State3}.
+    {ok, State2}.
 
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->

--- a/src/rebar_prv_erlydtl_compiler.erl
+++ b/src/rebar_prv_erlydtl_compiler.erl
@@ -125,39 +125,48 @@ init(State) ->
 
 do(State) ->
     ?INFO("Running erlydtl...", []),
-    DtlOpts = proplists:unfold(rebar_state:get(State, erlydtl_opts, [])),
-
-    %% We need a project app to store the results under in _build
-    %% If there is more than 1 project app, check for an app config
-    %% if that doesn't exist, error out.
-    case rebar_state:project_apps(State) of
-        [App] ->
-            run_erlydtl(App, DtlOpts, State),
-            {ok, State};
-        Apps ->
-            case option(app, DtlOpts) of
-                undefined ->
-                    ?PRV_ERROR(no_main_app);
-                Name ->
-                    run_erlydtl(rebar_app_utils:find(Name, Apps), DtlOpts, State),
-                    {ok, State}
-            end
+    case rebar_state:get(State, escript_main_app, undefined) of
+        undefined ->
+            Dir = rebar_state:dir(State),
+            case rebar_app_discover:find_app(Dir, all) of
+                {true, AppInfo} ->
+                    AllApps = rebar_state:project_apps(State) ++ rebar_state:all_deps(State),
+                    case rebar_app_utils:find(rebar_app_info:name(AppInfo), AllApps) of
+                        {ok, AppInfo1} ->
+                            %% Use the existing app info instead of newly created one
+                            run_erlydtl(AppInfo1, State);
+                        _ ->
+                            run_erlydtl(AppInfo, State)
+                    end,
+                    {ok, State};
+                _ ->
+                    ?PRV_ERROR(no_main_app)
+            end;
+        Name ->
+            AllApps = rebar_state:project_apps(State) ++ rebar_state:all_deps(State),
+            {ok, App} = rebar_app_utils:find(Name, AllApps),
+            run_erlydtl(App, State),
+            {ok, State}
     end.
 
-run_erlydtl(App, DtlOpts, State) ->
-    Dir = rebar_app_info:dir(App),
+run_erlydtl(App, State) ->
+    Dir = rebar_state:dir(State),
+    DtlOpts = proplists:unfold(rebar_state:get(State, erlydtl_opts, [])),
+    TemplateDir = filename:join(Dir, option(doc_root, DtlOpts)),
+    DtlOpts2 = [{doc_root, TemplateDir} | proplists:delete(doc_root, DtlOpts)],
     OutDir = rebar_app_info:ebin_dir(App),
+    filelib:ensure_dir(filename:join(OutDir, "dummy.beam")),
     rebar_base_compiler:run(State,
                             [],
-                            filename:join(Dir, option(doc_root, DtlOpts)),
-                            option(source_ext, DtlOpts),
+                            TemplateDir,
+                            option(source_ext, DtlOpts2),
                             OutDir,
-                            option(module_ext, DtlOpts) ++ ".beam",
+                            option(module_ext, DtlOpts2) ++ ".beam",
                             fun(S, T, C) ->
-                                    compile_dtl(C, S, T, DtlOpts, Dir, OutDir)
+                                    compile_dtl(C, S, T, DtlOpts2, Dir, OutDir)
                             end,
                             [{check_last_mod, false},
-                             {recursive, option(recursive, DtlOpts)}]).
+                             {recursive, option(recursive, DtlOpts2)}]).
 
 -spec format_error(any()) ->  iolist().
 format_error(no_main_app) ->

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -62,17 +62,18 @@ desc() ->
 
 do(State) ->
     ?INFO("Building escript...", []),
-    case rebar_state:project_apps(State) of
-        [App] ->
-            escriptize(State, App);
-        Apps ->
-            case rebar_state:get(State, escript_main_app, undefined) of
-                undefined ->
-                    ?PRV_ERROR(no_main_app);
-                Name ->
-                    AppInfo = rebar_app_utils:find(Name, Apps),
-                    escriptize(State, AppInfo)
-            end
+    case rebar_state:get(State, escript_main_app, undefined) of
+        undefined ->
+            case rebar_state:project_apps(State) of
+                [App] ->
+                    escriptize(State, App);
+                _ ->
+                    ?PRV_ERROR(no_main_app)
+            end;
+        Name ->
+            AllApps = rebar_state:all_deps(State)++rebar_state:project_apps(State),
+            AppInfo = rebar_app_utils:find(Name, AllApps),
+            escriptize(State, AppInfo)
     end.
 
 escriptize(State0, App) ->
@@ -89,8 +90,9 @@ escriptize(State0, App) ->
     %% in the output file. We then use the .app files for each of these
     %% to pull in all the .beam files.
     InclApps = lists:usort(rebar_state:get(State, escript_incl_apps, [])
-                           ++ all_deps(State)),
-    InclBeams = get_app_beams(InclApps),
+                          ++ all_deps(State)),
+    AllApps = rebar_state:all_deps(State)++rebar_state:project_apps(State),
+    InclBeams = get_apps_beams(InclApps, AllApps),
 
     %% Look for a list of extra files to include in the output file.
     %% For internal rebar-private use only. Do not use outside rebar.
@@ -139,21 +141,31 @@ format_error(no_main_app) ->
 %% Internal functions
 %% ===================================================================
 
-get_app_beams(Apps) ->
-    get_app_beams(Apps, []).
+get_apps_beams(Apps, AllApps) ->
+    get_apps_beams(Apps, AllApps, []).
 
-get_app_beams([], Acc) ->
+get_apps_beams([], _, Acc) ->
     Acc;
-get_app_beams([App | Rest], Acc) ->
-    case code:lib_dir(App, ebin) of
-        {error, bad_name} ->
-            throw(?PRV_ERROR({bad_name, App}));
-        Path ->
-            Prefix = filename:join(atom_to_list(App), "ebin"),
-            Acc2 = load_files(Prefix, "*.beam", Path),
-            Acc3 = load_files(Prefix, "*.app", Path),
-            get_app_beams(Rest, Acc3 ++ Acc2 ++ Acc)
+get_apps_beams([App | Rest], AllApps, Acc) ->
+    case rebar_app_utils:find(ec_cnv:to_binary(App), AllApps) of
+        {ok, App1} ->
+            OutDir = filename:absname(rebar_app_info:ebin_dir(App1)),
+            Beams = get_app_beams(App, OutDir),
+            get_apps_beams(Rest, AllApps, Beams ++ Acc);
+        _->
+            case code:lib_dir(App, ebin) of
+                {error, bad_name} ->
+                    throw(?PRV_ERROR({bad_name, App}));
+                Path ->
+                    Beams = get_app_beams(App, Path),
+                    get_apps_beams(Rest, AllApps, Beams ++ Acc)
+            end
     end.
+
+get_app_beams(App, Path) ->
+    Prefix = filename:join(atom_to_list(App), "ebin"),
+    load_files(Prefix, "*.beam", Path) ++
+        load_files(Prefix, "*.app", Path).
 
 get_extra(State) ->
     Extra = rebar_state:get(State, escript_incl_extra, []),


### PR DESCRIPTION
Seeing the app that is about to be compiled as the project app before running compile hooks allows for simpler configs and providers that work the same at the top level and when part of dependencies.

Specifically I discovered this issue when using rebar3 to build rebar3 and erlydtl provider hook failing to work on relx.