### PR TITLE
don't duplicate hooks for top level app

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -4,6 +4,7 @@
          profile_dir/2,
          deps_dir/1,
          deps_dir/2,
+         root_dir/1,
          checkouts_dir/1,
          checkouts_dir/2,
          plugins_dir/1,
@@ -48,7 +49,7 @@ deps_dir(DepsDir, App) ->
     filename:join(DepsDir, App).
 
 root_dir(State) ->
-    rebar_state:get(State, root_dir, ?DEFAULT_ROOT_DIR).
+    filename:absname(rebar_state:get(State, root_dir, ?DEFAULT_ROOT_DIR)).
 
 -spec checkouts_dir(rebar_state:t()) -> file:filename_all().
 checkouts_dir(State) ->

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -43,17 +43,14 @@ do(State) ->
     EmptyState = rebar_state:new(),
     build_apps(EmptyState, Providers, Deps),
 
-    %% Use the project State for building project apps
-    %% Set hooks to empty so top-level hooks aren't run for each project app
-    State2 = rebar_state:set(rebar_state:set(State, post_hooks, []), pre_hooks, []),
     {ok, ProjectApps1} = rebar_digraph:compile_order(ProjectApps),
 
-    ProjectApps2 = build_apps(State2, Providers, ProjectApps1),
-    State3 = rebar_state:project_apps(State2, ProjectApps2),
+    ProjectApps2 = build_apps(State, Providers, ProjectApps1),
+    State2 = rebar_state:project_apps(State, ProjectApps2),
 
-    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State3),
+    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State2),
 
-    {ok, State3}.
+    {ok, State2}.
 
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->


### PR DESCRIPTION
This patch keeps the top level config's hooks from being also considered a top level app's hooks. 

Before this fix a project like `relx` would end up running the `erlydtl` post compile hook twice. THis is done since we need to support the "project level" hooks so that a rebar.config can specify hooks even in a release project layout -- as in they aren't tied to a specific application that is being built.