### PR TITLE
fix template listing (re-add escript_incl_extra)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,6 +23,9 @@
 {escript_top_level_app, rebar}.
 {escript_name, rebar3}.
 {escript_emu_args, "%%! +sbtu +A0\n"}.
+%% escript_incl_extra is for internal rebar-private use only.
+%% Do not use outside rebar. Config interface is not stable.
+{escript_incl_extra, [{"priv/templates/*", "."}, {"rebar/include/*", "."}]}.
 
 {erl_opts,
  [{platform_define, "R14", no_callback_support},


### PR DESCRIPTION
`rebar3 new help` currently doesn't find any templates

This fixes regression introduced in: https://github.com/rebar/rebar3/commit/3a63bec39fde05dcddf3f693dd780879662b599c#diff-31d7a50c99c265ca2793c20961b60979L4
