### PR TITLE
read in application details into app_info after fetch

### DIFF
--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -157,6 +157,19 @@ app_file(AppInfo=#app_info_t{}, AppFile) ->
     AppInfo#app_info_t{app_file=AppFile}.
 
 -spec app_details(t()) -> list().
+app_details(AppInfo=#app_info_t{app_details=[]}) ->
+    AppFile = case app_file(AppInfo) of
+                  undefined ->
+                      app_file_src(AppInfo);
+                  File ->
+                      File
+              end,
+    case file:consult(AppFile) of
+        {ok, [{application, _, AppDetails}]} ->
+            AppDetails;
+        _ ->
+            []
+    end;
 app_details(#app_info_t{app_details=AppDetails}) ->
     AppDetails.
 

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -396,7 +396,7 @@ maybe_fetch(AppInfo, Profile, Upgrade, Seen, State) ->
                             case fetch_app(AppInfo, AppDir, State) of
                                 true ->
                                     maybe_symlink_default(State, Profile, AppDir, AppInfo),
-                                    {true, AppInfo};
+                                    {true, update_app_info(AppInfo)};
                                 Other ->
                                     {Other, AppInfo}
                             end;
@@ -562,6 +562,15 @@ fetch_app(AppInfo, AppDir, State) ->
         Result ->
             Result
     end.
+
+update_app_info(AppInfo) ->
+    AppDetails = rebar_app_info:app_details(AppInfo),
+    Applications = proplists:get_value(applications, AppDetails, []),
+    IncludedApplications = proplists:get_value(included_applications, AppDetails, []),
+    AppInfo1 = rebar_app_info:applications(
+                 rebar_app_info:app_details(AppInfo, AppDetails),
+                 IncludedApplications++Applications),
+    rebar_app_info:valid(AppInfo1, false).
 
 maybe_upgrade(AppInfo, AppDir, false, State) ->
     Source = rebar_app_info:source(AppInfo),


### PR DESCRIPTION
This patch updates the `app_info` record for a dep after it is fetched so attributes like `applications` which is used for compilation order is accurate.  Fixes https://github.com/rebar/rebar3/issues/370