### PR TITLE
Manage syntax error in app.src files.

### DIFF
--- a/src/rebar_prv_app_discovery.erl
+++ b/src/rebar_prv_app_discovery.erl
@@ -45,5 +45,13 @@ do(State) ->
 -spec format_error(any()) -> iolist().
 format_error({multiple_app_files, Files}) ->
     io_lib:format("Multiple app files found in one app dir: ~s", [string:join(Files, " and ")]);
+format_error({invalid_app_file, File, Reason}) ->
+    case Reason of 
+        {Line, erl_parse, Description} ->
+            io_lib:format("Invalid app file ~s at line ~b: ~p", 
+                [File, Line, lists:flatten(Description)]);
+        _ ->
+            io_lib:format("Invalid app file ~s: ~p", [File, Reason])
+    end;
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).


### PR DESCRIPTION
- Solve "Uncaught error" failure in case of syntax error in app.src file.
- Print helpful information on the location of the syntax error.

This was the output in case of an incorrect app.src file:

```
DEBUG=1 rebar3 compile
===> Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace
===> Uncaught error: {'EXIT',
                             {function_clause,
                              [{rebar_app_info,app_file_src,
                                [error,
                                 "/home/umberto/gitlab/emmebm/src/emmebm.app.src"],
                                [{file,
                                  "/home/travis/build/rebar/rebar3/_build/default/lib/rebar/src/rebar_app_info.erl"},
                                 {line,140}]},
                               {rebar_app_discover,find_app,2,
                                [{file,
                                  "/home/travis/build/rebar/rebar3/_build/default/lib/rebar/src/rebar_app_discover.erl"},
                                 {line,162}]},
                               {rebar_utils,filtermap,2,
                                [{file,
                                  "/home/travis/build/rebar/rebar3/_build/default/lib/rebar/src/rebar_utils.erl"},
                                 {line,82}]},
                               {rebar_app_discover,do,2,
                                [{file,
                                  "/home/travis/build/rebar/rebar3/_build/default/lib/rebar/src/rebar_app_discover.erl"},
                                 {line,15}]},
                               {rebar_prv_app_discovery,do,1,
                                [{file,
                                  "/home/travis/build/rebar/rebar3/_build/default/lib/rebar/src/rebar_prv_app_discovery.erl"},
                                 {line,38}]},
                               {rebar_core,do,2,
                                [{file,
                                  "/home/travis/build/rebar/rebar3/_build/default/lib/rebar/src/rebar_core.erl"},
                                 {line,122}]},
                               {rebar3,main,1,
                                [{file,
```

The output is now the following:

```
/opt/otp/erl_libs/rebar3/rebar3 compile
===> Invalid app file /home/umberto/gitlab/emmebm/src/emmebm.app.src at line 16: "syntax error before: ']'"
```