### PR TITLE
Make standalone vs complete project template clear

### DIFF
--- a/priv/templates/app.template
+++ b/priv/templates/app.template
@@ -1,4 +1,4 @@
-{description, "OTP Application"}.
+{description, "Complete OTP Application structure."}.
 {variables, [
     {name, "mylib", "Name of the OTP application"},
     {desc, "An OTP application", "Short description of the app"}

--- a/priv/templates/cmake.template
+++ b/priv/templates/cmake.template
@@ -1,2 +1,2 @@
-{description, "Makefile for building C/C++ in c_src"}.
+{description, "Standalone Makefile for building C/C++ in c_src"}.
 {template, "Makefile", "c_src/Makefile"}.

--- a/priv/templates/escript.template
+++ b/priv/templates/escript.template
@@ -1,4 +1,4 @@
-{description, "Escriptized application"}.
+{description, "Complete escriptized application structure"}.
 {variables, [
     {name, "mylib", "Name of the OTP application to be escriptized"},
     {desc, "An escript", "Short description of the project"}

--- a/priv/templates/lib.template
+++ b/priv/templates/lib.template
@@ -1,4 +1,4 @@
-{description, "OTP Library application (no processes)"}.
+{description, "Complete OTP Library application (no processes) structure"}.
 {variables, [
     {name, "mylib", "Name of the OTP library application"},
     {desc, "An OTP library", "Short description of the app"}

--- a/priv/templates/plugin.template
+++ b/priv/templates/plugin.template
@@ -1,4 +1,4 @@
-{description, "Rebar3 plugin"}.
+{description, "Rebar3 plugin project structure"}.
 {variables, [
     {name, "myplugin", "Name of the plugin"},
     {desc, "A rebar plugin", "Short description of the plugin's purpose"}


### PR DESCRIPTION
Some templates like OTP apps are usable within releases, so the text
does remain a bit vague, but hopefully less than before.