### PR TITLE
purge loaded code when it conflicts with project apps in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.rebar3
 rebar3
 _build
 .depsolver_plt

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -38,7 +38,7 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     ?INFO("Running Common Test suites...", []),
-    code:add_pathsa(rebar_state:code_paths(State, all_deps)),
+    rebar_utils:update_code(rebar_state:code_paths(State, all_deps)),
 
     %% Run ct provider prehooks
     Providers = rebar_state:providers(State),
@@ -49,7 +49,7 @@ do(State) ->
         {ok, State1} = Result ->
             %% Run ct provider posthooks
             rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State1),
-            rebar_utils:cleanup_code_path(rebar_state:code_paths(State1, default)),
+            rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
             Result;
         ?PRV_ERROR(_) = Error ->
             rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -37,7 +37,8 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     ?INFO("Performing EUnit tests...", []),
-    code:add_pathsa(rebar_state:code_paths(State, all_deps)),
+    rebar_utils:update_code(rebar_state:code_paths(State, all_deps)),
+
     %% Run eunit provider prehooks
     Providers = rebar_state:providers(State),
     Cwd = rebar_dir:get_cwd(),
@@ -49,7 +50,7 @@ do(State) ->
                 {ok, State1} ->
                     %% Run eunit provider posthooks
                     rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State1),
-                    rebar_utils:cleanup_code_path(rebar_state:code_paths(State1, default)),
+                    rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
                     {ok, State1};
                 Error ->
                     rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),


### PR DESCRIPTION
I'm not 100% on this because it doesn't repurge after the initial purge. Unsure if that is necessary. Will work on adding that tomorrow, opening for feedback and suggestions.