### PR TITLE
Run hooks for single application only once.

### DIFF
--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -65,10 +65,10 @@ project_app_config(AppInfo, State) ->
 %% Here we check if the app is at the root of the project.
 %% If it is, then drop the hooks from the config so they aren't run twice
 maybe_reset_hooks(C, Dir, State) ->
-    case filename:dirname(rebar_dir:root_dir(State)) of
+    case ec_file:real_dir_path(rebar_dir:root_dir(State)) of
         Dir ->
             C1 = proplists:delete(provider_hooks, C),
-            proplists:delete(hooks, C1);
+            proplists:delete(post_hooks, proplists:delete(pre_hooks, C1));
         _ ->
             C
     end.

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -37,7 +37,7 @@ do(State) ->
     ProjectApps = rebar_state:project_apps(State),
     Providers = rebar_state:providers(State),
     Deps = rebar_state:deps_to_build(State),
-    Cwd = rebar_dir:get_cwd(),
+    Cwd = rebar_state:dir(State),
 
     %% Need to allow global config vars used on deps
     %% Right now no way to differeniate and just give deps a new state

--- a/test/rebar_hooks_SUITE.erl
+++ b/test/rebar_hooks_SUITE.erl
@@ -5,7 +5,8 @@
          end_per_suite/1,
          init_per_testcase/2,
          all/0,
-         build_and_clean_app/1]).
+         build_and_clean_app/1,
+         run_hooks_once/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -24,7 +25,7 @@ init_per_testcase(_, Config) ->
     rebar_test_utils:init_rebar_state(Config).
 
 all() ->
-    [build_and_clean_app].
+    [build_and_clean_app, run_hooks_once].
 
 %% Test post provider hook cleans compiled project app, leaving it invalid
 build_and_clean_app(Config) ->
@@ -36,3 +37,13 @@ build_and_clean_app(Config) ->
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name, valid}]}),
     rebar_test_utils:run_and_check(Config, [{provider_hooks, [{post, [{compile, clean}]}]}],
                                   ["compile"], {ok, [{app, Name, invalid}]}).
+
+run_hooks_once(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    RebarConfig = [{pre_hooks, [{compile, "mkdir blah"}]}],
+    rebar_test_utils:create_config(AppDir, RebarConfig),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], {ok, [{app, Name, valid}]}).


### PR DESCRIPTION
I have litle single-application project which have to run heavy long running hooks.
```
[vkovalev@t30nix foobar]$ tree
.
|-- rebar.config
`-- src
    |-- foobar.app.src
    `-- foobar.erl

1 directory, 3 files
[vkovalev@t30nix foobar]$ cat rebar.config 
{pre_hooks, [
    {compile, "echo 'Hello there.'"}
]}.
{post_hooks, [
    {compile, "echo 'BOO!'"}
]}.
```

Now `rebar3 compile` produces next output:

```
[vkovalev@t30nix foobar]$ rebar3 compile
===> Verifying dependencies...
Hello there.
Hello there.
===> Compiling foobar
BOO!
BOO!
```

Well, this is because hooks first is ran [here] (https://github.com/rebar/rebar3/blob/master/src/rebar_prv_compile.erl#L50) as project-level hooks. Then the same hooks is ran on 'application-level' [there] (https://github.com/rebar/rebar3/blob/master/src/rebar_prv_compile.erl#L86). It is getting really annoying to do same heavy things twice, so I've added this workaround.

What do you think? Didn't I break any internal logic?