### PR TITLE
Ignore the build directory

### DIFF
--- a/priv/templates/gitignore
+++ b/priv/templates/gitignore
@@ -16,3 +16,4 @@ _deps
 _plugins
 _tdeps
 logs
+_build


### PR DESCRIPTION
By default rebar3's new projects include a gitignore file. This file doesn't ignore _build but this is a directory one would probably not want to check in.