### PR TITLE
methods for retrieving `src_dirs` and `extra_src_dirs`

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -20,7 +20,10 @@
          template_dir/1,
          processing_base_dir/1,
          processing_base_dir/2,
-         make_relative_path/2]).
+         make_relative_path/2,
+         src_dirs/1, src_dirs/2,
+         extra_src_dirs/1, extra_src_dirs/2,
+         all_src_dirs/1, all_src_dirs/3]).
 
 -include("rebar.hrl").
 
@@ -121,3 +124,35 @@ do_make_relative_path([H|T1], [H|T2]) ->
 do_make_relative_path(Source, Target) ->
     Base = lists:duplicate(max(length(Target) - 1, 0), ".."),
     filename:join(Base ++ Source).
+
+-spec src_dirs(rebar_state:t()) -> list(file:filename_all()).
+src_dirs(State) -> src_dirs(State, []).
+
+-spec src_dirs(rebar_state:t(), list(file:filename_all())) -> list(file:filename_all()).
+src_dirs(State, Default) ->
+    ErlOpts = rebar_utils:erl_opts(State),
+    Vs = proplists:get_all_values(src_dirs, ErlOpts),
+    case lists:append(Vs) of
+        []   -> Default;
+        Dirs -> Dirs
+    end.
+
+-spec extra_src_dirs(rebar_state:t()) -> list(file:filename_all()).
+extra_src_dirs(State) -> extra_src_dirs(State, []).
+
+-spec extra_src_dirs(rebar_state:t(), list(file:filename_all())) -> list(file:filename_all()).
+extra_src_dirs(State, Default) ->
+    ErlOpts = rebar_utils:erl_opts(State),
+    Vs = proplists:get_all_values(extra_src_dirs, ErlOpts),
+    case lists:append(Vs) of
+        []   -> Default;
+        Dirs -> Dirs
+    end.
+
+-spec all_src_dirs(rebar_state:t()) -> list(file:filename_all()).
+all_src_dirs(State) -> all_src_dirs(State, [], []).
+
+-spec all_src_dirs(rebar_state:t(), list(file:filename_all()), list(file:filename_all())) ->
+    list(file:filename_all()).
+all_src_dirs(State, SrcDefault, ExtraDefault) ->
+    src_dirs(State, SrcDefault) ++ extra_src_dirs(State, ExtraDefault).

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -143,8 +143,7 @@ doterl_compile(Config, Dir, OutDir, MoreSources, ErlOpts) ->
     %% Support the src_dirs option allowing multiple directories to
     %% contain erlang source. This might be used, for example, should
     %% eunit tests be separated from the core application source.
-    SrcDirs = [filename:join(Dir, X) || X <- proplists:get_value(src_dirs, ErlOpts, ["src"]) ++
-                                             proplists:get_value(extra_src_dirs, ErlOpts, [])],
+    SrcDirs = [filename:join(Dir, X) || X <- rebar_dir:all_src_dirs(Config, ["src"], [])],
     AllErlFiles = gather_src(SrcDirs, []) ++ MoreSources,
 
     %% Make sure that ebin/ exists and is on the path

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -160,9 +160,8 @@ ebin_modules(State, App, Dir) ->
     [rebar_utils:beam_to_mod(N) || N <- Filtered].
 
 extra_dirs(State) ->
-    ErlOpts = rebar_utils:erl_opts(State),
-    Extras = proplists:get_value(extra_src_dirs, ErlOpts, []),
-    SrcDirs = proplists:get_value(src_dirs, ErlOpts, ["src"]),
+    Extras = rebar_dir:extra_src_dirs(State),
+    SrcDirs = rebar_dir:src_dirs(State, ["src"]),
     %% remove any dirs that are defined in `src_dirs` from `extra_src_dirs`
     Extras -- SrcDirs.
 

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -119,9 +119,7 @@ copy_app_dirs(State, OldAppDir, AppDir) ->
             end,
             filelib:ensure_dir(filename:join(AppDir, "dummy")),
             %% link to src_dirs to be adjacent to ebin is needed for R15 use of cover/xref
-            ErlOpts = rebar_utils:erl_opts(State),
-            SrcDirs = proplists:get_value(src_dirs, ErlOpts, ["src"]) ++
-                      proplists:get_value(extra_src_dirs, ErlOpts, []),
+            SrcDirs = rebar_dir:all_src_dirs(State, ["src"], []),
             [symlink_or_copy(OldAppDir, AppDir, Dir) || Dir <- ["priv", "include"] ++ SrcDirs];
         false ->
             ok

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -1,0 +1,99 @@
+-module(rebar_dir_SUITE).
+
+-export([all/0, init_per_testcase/2, end_per_testcase/2]).
+
+-export([default_src_dirs/1, default_extra_src_dirs/1, default_all_src_dirs/1]).
+-export([src_dirs/1, extra_src_dirs/1, all_src_dirs/1]).
+-export([profile_src_dirs/1, profile_extra_src_dirs/1, profile_all_src_dirs/1]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("kernel/include/file.hrl").
+
+
+all() -> [default_src_dirs, default_extra_src_dirs, default_all_src_dirs,
+          src_dirs, extra_src_dirs, all_src_dirs,
+          profile_src_dirs, profile_extra_src_dirs, profile_all_src_dirs].
+
+init_per_testcase(_, Config) ->
+    C = rebar_test_utils:init_rebar_state(Config),
+    AppDir = ?config(apps, C),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+    C.
+
+end_per_testcase(_, _Config) -> ok.
+
+default_src_dirs(Config) ->
+    {ok, State} = rebar_test_utils:run_and_check(Config, [], ["compile"], return),
+    
+    [] = rebar_dir:src_dirs(State),
+    ["src"] = rebar_dir:src_dirs(State, ["src"]).
+
+default_extra_src_dirs(Config) ->
+    {ok, State} = rebar_test_utils:run_and_check(Config, [], ["compile"], return),
+  
+    [] = rebar_dir:extra_src_dirs(State),
+    ["src"] = rebar_dir:extra_src_dirs(State, ["src"]).
+
+default_all_src_dirs(Config) ->
+    {ok, State} = rebar_test_utils:run_and_check(Config, [], ["compile"], return),
+  
+    [] = rebar_dir:all_src_dirs(State),
+    ["src", "test"] = rebar_dir:all_src_dirs(State, ["src"], ["test"]).
+
+src_dirs(Config) ->
+    RebarConfig = [{erl_opts, [{src_dirs, ["foo", "bar", "baz"]}]}],
+    {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
+    
+    ["foo", "bar", "baz"] = rebar_dir:src_dirs(State).
+
+extra_src_dirs(Config) ->
+    RebarConfig = [{erl_opts, [{extra_src_dirs, ["foo", "bar", "baz"]}]}],
+    {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
+    
+    ["foo", "bar", "baz"] = rebar_dir:extra_src_dirs(State).
+
+all_src_dirs(Config) ->
+    RebarConfig = [{erl_opts, [{src_dirs, ["foo", "bar"]}, {extra_src_dirs, ["baz", "qux"]}]}],
+    {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
+    
+    ["foo", "bar", "baz", "qux"] = rebar_dir:all_src_dirs(State).
+
+profile_src_dirs(Config) ->
+    RebarConfig = [
+        {erl_opts, [{src_dirs, ["foo", "bar"]}]},
+        {profiles, [
+            {more, [{erl_opts, [{src_dirs, ["baz", "qux"]}]}]}
+        ]}
+    ],
+    {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "more", "compile"], return),
+    
+    R = lists:sort(["foo", "bar", "baz", "qux"]),
+    R = lists:sort(rebar_dir:src_dirs(State)).
+
+profile_extra_src_dirs(Config) ->
+    RebarConfig = [
+        {erl_opts, [{extra_src_dirs, ["foo", "bar"]}]},
+        {profiles, [
+            {more, [{erl_opts, [{extra_src_dirs, ["baz", "qux"]}]}]}
+        ]}
+    ],
+    {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "more", "compile"], return),
+    
+    R = lists:sort(["foo", "bar", "baz", "qux"]),
+    R = lists:sort(rebar_dir:extra_src_dirs(State)).
+
+profile_all_src_dirs(Config) ->
+    RebarConfig = [
+        {erl_opts, [{src_dirs, ["foo"]}, {extra_src_dirs, ["bar"]}]},
+        {profiles, [
+            {more, [{erl_opts, [{src_dirs, ["baz"]}, {extra_src_dirs, ["qux"]}]}]}
+        ]}
+    ],
+    {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "more", "compile"], return),
+    
+    R = lists:sort(["foo", "bar", "baz", "qux"]),
+    R = lists:sort(rebar_dir:all_src_dirs(State)).


### PR DESCRIPTION
note that now ALL `src_dirs` across included profiles are
compiled. previously only the last included profile's `src_dirs`
were used

fixes #448