### PR TITLE
install_plugins in rebar_prv_as:do

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -133,3 +133,4 @@ Kelly McLaughlin
 Martin Karlsson
 Pierre Fenoll
 David Kubecka
+Stefan Grundmann


### PR DESCRIPTION
plugins that are only in the selected profiles have to be installed as well:
for `rebar.config`
```
{plugins, [{foo, {git, ...}}]}.
{profiles, [{p1,{plugins,[{bar, {git, ...}}]}}]}.
```
running `rebar3 as p1 bar` will not work without this. 