### PR TITLE
update readme building instructions to prefer source

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ format_error(Reason) ->
 Building
 --------
 
-Recommended installation of [Erlang/OTP](http://www.erlang.org) is binary packages from [Erlang Solutions](https://www.erlang-solutions.com/downloads/download-erlang-otp). For source it is recommended you use [erln8](http://metadave.github.io/erln8/) or [kerl](https://github.com/yrashk/kerl).
+Recommended installation of [Erlang/OTP](http://www.erlang.org) is source built using [erln8](http://metadave.github.io/erln8/) or [kerl](https://github.com/yrashk/kerl). For binary packages use those provided by [Erlang Solutions](https://www.erlang-solutions.com/downloads/download-erlang-otp), but be sure to choose the "Standard" download option or you'll have issues building projects.
 
 ### Dependencies
 


### PR DESCRIPTION
Because Erlang Solutions now defaults to a download that includes third party libraries I think we should recommend installing from source using kerl or erln8 instead.