### PR TITLE
Properly initialize command parsed args in rebar state

### DIFF
--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -51,7 +51,7 @@
                   namespace           = undefined     :: atom(),
 
                   command_args        = [],
-                  command_parsed_args = [],
+                  command_parsed_args = {[], []},
 
                   project_apps        = []          :: [rebar_app_info:t()],
                   deps_to_build       = []          :: [rebar_app_info:t()],


### PR DESCRIPTION
Say, I have following project (just for example).

```
vkovalev@dijkstra:/tmp/bar$ tree
.
├── apps
│   └── bar
│       └── src
│           └── bar.app.src
├── rebar.config
└── rebar.lock
vkovalev@dijkstra:/tmp/bar$ cat rebar.config 
{erl_opts, [debug_info]}.
{deps, [
    {jiffy, {git, "https://github.com/davisp/jiffy", {branch, "master"}}}
]}.
{overrides, [
    {override, jiffy, [
        {provider_hooks, [
            {pre, [{compile, {default, clean}}]}
        ]}
    ]}
]}.
```

`rebar3 compile` fails when trying to execute `clean` hook on any dependency. Badmatch shoots [there](https://github.com/rebar/rebar3/blob/master/src/rebar_prv_clean.erl#L81), because `command_parsed_args` field in `rebar_state` [initialized with default value `[]`](https://github.com/rebar/rebar3/blob/master/src/rebar_state.erl#L54), which, I believe, is outdated and doesn't meet any expectations.