### PR TITLE
Properly setup namespace for dependency provider hooks

### DIFF
--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -48,7 +48,7 @@
 
                   lock                = [],
                   current_profiles    = [default]     :: [atom()],
-                  namespace           = undefined     :: atom(),
+                  namespace           = default       :: atom(),
 
                   command_args        = [],
                   command_parsed_args = {[], []},


### PR DESCRIPTION
All circumstances as in #455. But for now let specify hook by its *short name*. Without specifying namespace.

```
{overrides, [
    {override, jiffy, [
        {provider_hooks, [
            {pre, [{compile, clean}]}
        ]}
    ]}
]}.
```

Now it fails without saying something specific. Actually, symptoms appears [here](https://github.com/rebar/rebar3/blob/master/src/rebar_core.erl#L118). `providers:get_provider/3` returns `not_found` (or something, could not recall certainly), because namespace in *dependency state* is undefined. I think, rebar should copy namespace from its *root* state. Am I right?