### PR TITLE
don't add `{extra_src_dirs, ["test"]}` to `test` profile

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -368,8 +368,11 @@ sub_dirs(Path) ->
 replace_src_dirs(State, Dirs) ->
     %% replace any `src_dirs` with the test dirs
     ErlOpts = rebar_state:get(State, erl_opts, []),
-    StrippedOpts = lists:keydelete(src_dirs, 1, ErlOpts),
-    rebar_state:set(State, erl_opts, [{src_dirs, Dirs}|StrippedOpts]).
+    StrippedOpts = filter_src_dirs(ErlOpts),
+    rebar_state:set(State, erl_opts, [{extra_src_dirs, Dirs}|StrippedOpts]).
+
+filter_src_dirs(ErlOpts) ->
+    lists:filter(fun({src_dirs, _}) -> false; ({extra_src_dirs, _}) -> false; (_) -> true end, ErlOpts).
 
 test_dirs(State, Opts) ->
     BareTest = filename:join([rebar_state:dir(State), "test"]),

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -119,7 +119,7 @@ copy_app_dirs(State, OldAppDir, AppDir) ->
             end,
             filelib:ensure_dir(filename:join(AppDir, "dummy")),
             %% link to src_dirs to be adjacent to ebin is needed for R15 use of cover/xref
-            SrcDirs = rebar_dir:all_src_dirs(State, ["src"], []),
+            SrcDirs = rebar_dir:all_src_dirs(State, ["src"], ["test"]),
             [symlink_or_copy(OldAppDir, AppDir, Dir) || Dir <- ["priv", "include"] ++ SrcDirs];
         false ->
             ok

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -85,8 +85,7 @@ format_error({error_running_tests, Reason}) ->
 test_state(State) ->
     ErlOpts = rebar_state:get(State, eunit_compile_opts, []),
     TestOpts = safe_define_test_macro(ErlOpts),
-    TestDir = [{extra_src_dirs, ["test"]}],
-    first_files(State) ++ [{erl_opts, TestOpts ++ TestDir}].
+    first_files(State) ++ [{erl_opts, TestOpts}].
 
 safe_define_test_macro(Opts) ->
     %% defining a compile macro twice results in an exception so
@@ -107,9 +106,48 @@ first_files(State) ->
 
 prepare_tests(State) ->
     {RawOpts, _} = rebar_state:command_parsed_args(State),
+    resolve_apps(State, RawOpts).
+
+resolve_apps(State, RawOpts) ->
+    case proplists:get_value(app, RawOpts) of
+        undefined -> resolve_suites(State, RawOpts);
+        %% convert app name strings to `rebar_app_info` objects
+        Apps      -> AppNames = string:tokens(Apps, [$,]),
+                     ProjectApps = project_apps(State),
+                     case filter_apps_by_name(AppNames, ProjectApps) of
+                         {ok, TestApps} -> resolve_suites(State, TestApps, RawOpts);
+                         Error          -> Error
+                     end
+    end.
+
+resolve_suites(State, RawOpts) -> resolve_suites(State, project_apps(State), RawOpts).
+
+resolve_suites(State, Apps, RawOpts) ->
+    case proplists:get_value(suite, RawOpts) of
+        undefined  -> compile_tests(State, Apps, all, RawOpts);
+        Suites     -> SuiteNames = string:tokens(Suites, [$,]),
+                      case filter_suites_by_apps(SuiteNames, Apps) of
+                          {ok, S} -> compile_tests(State, Apps, S, RawOpts);
+                          Error   -> Error
+                      end
+    end.
+
+compile_tests(State, TestApps, Suites, RawOpts) ->
+    F = fun(AppInfo) ->
+        AppDir = rebar_app_info:dir(AppInfo),
+        S = case rebar_app_info:state(AppInfo) of
+            undefined ->
+                C = rebar_config:consult(AppDir),
+                rebar_state:new(State, C, AppDir);
+            AppState ->
+                AppState
+        end,
+        ok = rebar_erlc_compiler:compile(replace_src_dirs(S),
+                                         ec_cnv:to_list(rebar_app_info:out_dir(AppInfo)))
+    end,
+    lists:foreach(F, TestApps),
     ok = maybe_cover_compile(State, RawOpts),
-    ProjectApps = project_apps(State),
-    resolve_apps(ProjectApps, RawOpts).
+    {ok, test_set(TestApps, Suites)}.
 
 maybe_cover_compile(State, Opts) ->
     State1 = case proplists:get_value(cover, Opts, false) of
@@ -117,27 +155,6 @@ maybe_cover_compile(State, Opts) ->
         false -> State
     end,
     rebar_prv_cover:maybe_cover_compile(State1).
-
-resolve_apps(ProjectApps, RawOpts) ->
-    case proplists:get_value(app, RawOpts) of
-        undefined -> resolve_suites(ProjectApps, RawOpts);
-        %% convert app name strings to `rebar_app_info` objects
-        Apps      -> AppNames = string:tokens(Apps, [$,]),
-                     case filter_apps_by_name(AppNames, ProjectApps) of
-                         {ok, TestApps} -> resolve_suites(TestApps, RawOpts);
-                         Error          -> Error
-                     end
-    end.
-
-resolve_suites(Apps, RawOpts) ->
-    case proplists:get_value(suite, RawOpts) of
-        undefined  -> test_set(Apps, all);
-        Suites     -> SuiteNames = string:tokens(Suites, [$,]),
-                      case filter_suites_by_apps(SuiteNames, Apps) of
-                          {ok, S} -> test_set(Apps, S);
-                          Error   -> Error
-                      end
-    end.
 
 project_apps(State) ->
     filter_checkouts(rebar_state:project_apps(State)).
@@ -205,8 +222,20 @@ app_modules([App|Rest], Acc) ->
             app_modules(Rest, NewAcc)
     end.
 
-test_set(Apps, all) -> {ok, set_apps(Apps, [])};
-test_set(_Apps, Suites) -> {ok, set_suites(Suites, [])}.
+replace_src_dirs(State) ->
+    %% replace any `src_dirs` with the test dirs
+    ErlOpts = rebar_state:get(State, erl_opts, []),
+    StrippedOpts = filter_src_dirs(ErlOpts),
+    case rebar_dir:extra_src_dirs(State) of
+        [] -> rebar_state:set(State, erl_opts, [{src_dirs, ["test"]}|StrippedOpts]);
+        _  -> rebar_state:set(State, erl_opts, StrippedOpts)
+    end.
+
+filter_src_dirs(ErlOpts) ->
+    lists:filter(fun({src_dirs, _}) -> false; (_) -> true end, ErlOpts).
+
+test_set(Apps, all) -> set_apps(Apps, []);
+test_set(_Apps, Suites) -> set_suites(Suites, []).
 
 set_apps([], Acc) -> lists:reverse(Acc);
 set_apps([App|Rest], Acc) ->


### PR DESCRIPTION
adding it results in ct test suites being compiled before they're
properly copied so changes made to suites between runs are not
reflected if a run fails before test dirs are copied