### PR TITLE
only run clean hooks once

### DIFF
--- a/src/rebar_prv_clean.erl
+++ b/src/rebar_prv_clean.erl
@@ -67,8 +67,13 @@ format_error(Reason) ->
 clean_apps(State, Providers, Apps) ->
     lists:foreach(fun(AppInfo) ->
                           AppDir = rebar_app_info:dir(AppInfo),
-                          C = rebar_config:consult(AppDir),
-                          S = rebar_state:new(State, C, AppDir),
+                          S = case rebar_app_info:state(AppInfo) of
+                                  undefined ->
+                                      C = rebar_config:consult(AppDir),
+                                      rebar_state:new(State, C, AppDir);
+                                  AppState ->
+                                      AppState
+                              end,
 
                           ?INFO("Cleaning out ~s...", [rebar_app_info:name(AppInfo)]),
                           %% Legacy hook support


### PR DESCRIPTION
Same that had to be done for the compile provider. Clearly we need to abstract this. I'll work on that when I have time tomorrow. But this fixes https://github.com/rebar/rebar3/issues/459