### PR TITLE
Include subconfigs into rebar.config

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -132,7 +132,7 @@ init_config() ->
                      rebar_config:consult_file(ConfigFile)
              end,
 
-    Config1 = rebar_config:merge_locks(Config, rebar_config:consult_file(?LOCK_FILE)),
+    Config1 = rebar_config:merge_locks(Config, rebar_config:consult_file(?LOCK_FILE, [raw])),
 
     %% If $HOME/.config/rebar3/config exists load and use as global config
     GlobalConfigFile = rebar_dir:global_config(),

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -203,7 +203,7 @@ consult_app_file(Filename) ->
                 false ->
                     file:consult(Filename);
                 true ->
-                    {ok, rebar_config:consult_file(Filename)}
+                    {ok, rebar_config:consult_file(Filename, [raw])}
             end
     end.
 

--- a/test/rebar_deps_SUITE.erl
+++ b/test/rebar_deps_SUITE.erl
@@ -215,7 +215,7 @@ newly_added_dep(Config) ->
     {ok, RebarConfig2} = file:consult(rebar_test_utils:create_config(AppDir, [{deps, TopDeps2}])),
     LockFile = filename:join(AppDir, "rebar.lock"),
     RebarConfig3 = rebar_config:merge_locks(RebarConfig2,
-                                           rebar_config:consult_file(LockFile)),
+                                           rebar_config:consult_file(LockFile, [raw])),
 
     %% a should now be installed and c should not change
     rebar_test_utils:run_and_check(

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -163,7 +163,7 @@ check_results(AppDir, Expected) ->
     GlobalPluginDirs = filelib:wildcard(filename:join([AppDir, "global", "plugins"])),
     CheckoutsDir = filename:join([AppDir, "_checkouts"]),
     LockFile = filename:join([AppDir, "rebar.lock"]),
-    Locks = lists:flatten(rebar_config:consult_file(LockFile)),
+    Locks = lists:flatten(rebar_config:consult_file(LockFile,[raw])),
 
     InvalidApps = rebar_app_discover:find_apps(BuildDirs, invalid),
     ValidApps = rebar_app_discover:find_apps(BuildDirs, valid),


### PR DESCRIPTION
One of the features I really desire is to be able include subconfigs into *central* `rebar.config`. I mean something like that:

```
[vkovalev@t30nix foo]$ cat rebar.config
{include_config, "rebar.config.d/*.config"}.
{include_config, "some-platform-matchers", "rebar.config.d/specific/*.config"}
```

I've sketched up my vision of how this feature may be implemented. Now it has no tests and I am not sure it works well (however it doesn't break anything). Also it doesn't support neither platform-matchers nor wildcards. First I want to ask you what do you think? About this feature at all? About more proper ways to implement it?

- [ ] Clarify about sanity and implementation details.
- [ ] Decide whether this stuff needed inside of profile definitions, overrides, anything else?
- [ ] Implement tests.
- [ ] Implement wildcards expansion.
- [ ] Implement platform matchers.