### PR TITLE
Show stacktrace to errors caught in rebar3 module.

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -254,6 +254,11 @@ handle_error(Error) ->
     %% Dump this error to console
     ?ERROR("Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace", []),
     ?DEBUG("Uncaught error: ~p", [Error]),
+    case erlang:get_stacktrace() of
+        [] -> ok;
+        Trace ->
+            ?DEBUG("Stack trace to the error location: ~p", [Trace])
+    end,
     ?INFO("When submitting a bug report, please include the output of `rebar3 report \"your command\"`", []),
     erlang:halt(1).
 


### PR DESCRIPTION
In #467  rebar acted quite unfairy promising to show stacktrace if DEBUG=1 will be set. However, it didn't show one. Commit fixes this inconveniencs.