### PR TITLE
improve the rebar3 shell

### DIFF
--- a/src/r3.erl
+++ b/src/r3.erl
@@ -1,0 +1,7 @@
+%%% external alias for rebar_agent
+-module(r3).
+-export([do/1, do/2]).
+
+do(Command) -> rebar_agent:do(Command).
+
+do(Namespace, Command) -> rebar_agent:do(Namespace, Command).

--- a/src/rebar_agent.erl
+++ b/src/rebar_agent.erl
@@ -1,0 +1,71 @@
+-module(rebar_agent).
+-export([start_link/1, do/1, do/2]).
+-export([init/1,
+         handle_call/3, handle_cast/2, handle_info/2,
+         code_change/3, terminate/2]).
+
+-record(state, {state,
+                cwd}).
+
+start_link(State) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, State, []).
+
+do(Command) when is_atom(Command) ->
+    gen_server:call(?MODULE, {cmd, Command}, infinity).
+
+do(Namespace, Command) when is_atom(Namespace), is_atom(Command) ->
+    gen_server:call(?MODULE, {cmd, Namespace, Command}, infinity).
+
+init(State0) ->
+    Cwd = file:get_cwd(),
+    State = rebar_state:update_code_paths(State0, default, code:get_path()),
+    {ok, #state{state=State, cwd=Cwd}}.
+
+handle_call({cmd, Command}, _From, State=#state{state=RState, cwd=Cwd}) ->
+    Res = try
+        case file:get_cwd() of
+            Cwd ->
+                case rebar_core:process_command(RState, Command) of
+                    {ok, _} ->
+                        refresh(RState),
+                        ok;
+                    {error, Err} when is_list(Err) ->
+                        refresh(RState),
+                        {error, lists:flatten(Err)};
+                    {error, Err} ->
+                        refresh(RState),
+                        {error, Err}
+                end;
+            _ ->
+                {error, cwd_changed}
+        end
+    catch
+        Type:Reason ->
+            {error, {Type, Reason}}
+    end,
+    {reply, Res, State};
+handle_call({cmd, Namespace, Command}, From, State = #state{state=RState}) ->
+    {reply, Res, _} = handle_call({cmd, Command}, From, State#state{
+        state = rebar_state:namespace(RState, Namespace)
+    }),
+    {reply, Res, State};
+handle_call(_Call, _From, State) ->
+    {noreply, State}.
+
+handle_cast(_Cast, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+refresh(RState) ->
+    ToRefresh = rebar_state:code_paths(RState, all_deps)
+                %% make sure to never reload self; halt()s the VM
+                -- [filename:dirname(code:which(?MODULE))],
+    rebar_utils:update_code(ToRefresh).

--- a/src/rebar_prv_do.erl
+++ b/src/rebar_prv_do.erl
@@ -47,6 +47,8 @@ do_tasks([{TaskStr, Args}|Tail], State) ->
         default ->
             %% The first task we hit might be a namespace!
             case maybe_namespace(State2, Task, Args) of
+                {ok, FinalState} when Tail =:= [] ->
+                    {ok, FinalState};
                 {ok, _} ->
                     do_tasks(Tail, State);
                 {error, Reason} ->
@@ -56,6 +58,8 @@ do_tasks([{TaskStr, Args}|Tail], State) ->
             %% We're already in a non-default namespace, check the
             %% task directly.
             case rebar_core:process_command(State2, Task) of
+                {ok, FinalState} when Tail =:= [] ->
+                    {ok, FinalState};
                 {ok, _} ->
                     do_tasks(Tail, State);
                 {error, Reason} ->

--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -82,8 +82,8 @@ shell(State) ->
     setup_paths(State),
     ok = reread_config(State),
     maybe_boot_apps(State),
-    rebar_agent:start_link(State),
     setup_shell(),
+    rebar_agent:start_link(State),
     %% try to read in sys.config file
     %% this call never returns (until user quits shell)
     timer:sleep(infinity).

--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -129,7 +129,7 @@ reread_config(State) ->
     end.
 
 maybe_boot_apps(State) ->
-    case rebar_state:get(State, shell_apps, undefined) of
+    case find_apps_to_boot(State) of
         undefined ->
             %% try to read in sys.config file
             ok = reread_config(State);
@@ -138,6 +138,19 @@ maybe_boot_apps(State) ->
             load_apps(Apps),
             ok = reread_config(State),
             boot_apps(Apps)
+    end.
+
+find_apps_to_boot(State) ->
+    %% Try the shell_apps option
+    case rebar_state:get(State, shell_apps, undefined) of
+        undefined ->
+            %% Get to the relx tuple instead
+            case lists:keyfind(release, 1, rebar_state:get(State, relx, [])) of
+                {_, _, Apps} -> Apps;
+                false -> undefined
+            end;
+        Apps ->
+            Apps
     end.
 
 load_apps(Apps) ->

--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -45,14 +45,21 @@
 
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
-    State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
-                                                               {module, ?MODULE},
-                                                               {bare, false},
-                                                               {deps, ?DEPS},
-                                                               {example, "rebar3 shell"},
-                                                               {short_desc, "Run shell with project apps and deps in path."},
-                                                               {desc, info()},
-                                                               {opts, [{config, undefined, "config", string, "Path to the config file to use. Defaults to the sys_config defined for relx, if present."}]}])),
+    State1 = rebar_state:add_provider(
+            State,
+            providers:create([
+                {name, ?PROVIDER},
+                {module, ?MODULE},
+                {bare, false},
+                {deps, ?DEPS},
+                {example, "rebar3 shell"},
+                {short_desc, "Run shell with project apps and deps in path."},
+                {desc, info()},
+                {opts, [{config, undefined, "config", string,
+                         "Path to the config file to use. Defaults to the "
+                         "sys_config defined for relx, if present."}]}
+            ])
+    ),
     {ok, State1}.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
@@ -72,6 +79,18 @@ format_error(Reason) ->
 %% immediately kill the script. ctrl-g, however, works fine
 
 shell(State) ->
+    setup_paths(State),
+    ok = reread_config(State),
+    maybe_boot_apps(State),
+    setup_shell(),
+    %% try to read in sys.config file
+    %% this call never returns (until user quits shell)
+    timer:sleep(infinity).
+
+info() ->
+    "Start a shell with project and deps preloaded similar to~n'erl -pa ebin -pa deps/*/ebin'.~n".
+
+setup_shell() ->
     %% scan all processes for any with references to the old user and save them to
     %% update later
     NeedsUpdate = [Pid || Pid <- erlang:processes(),
@@ -91,18 +110,41 @@ shell(State) ->
     %% disable the simple error_logger (which may have been added multiple
     %% times). removes at most the error_logger added by init and the
     %% error_logger added by the tty handler
-    ok = remove_error_handler(3),
+    ok = remove_error_handler(3).
+
+setup_paths(State) ->
     %% Add deps to path
     code:add_pathsa(rebar_state:code_paths(State, all_deps)),
     %% add project app test paths
-    ok = add_test_paths(State),
-    %% try to read in sys.config file
-    ok = reread_config(State),
-    %% this call never returns (until user quits shell)
-    timer:sleep(infinity).
+    ok = add_test_paths(State).
 
-info() ->
-    "Start a shell with project and deps preloaded similar to~n'erl -pa ebin -pa deps/*/ebin'.~n".
+reread_config(State) ->
+    case find_config(State) of
+        no_config ->
+            ok;
+        ConfigList ->
+            _ = [application:set_env(Application, Key, Val)
+                  || {Application, Items} <- ConfigList,
+                     {Key, Val} <- Items],
+            ok
+    end.
+
+maybe_boot_apps(State) ->
+    case rebar_state:get(State, shell_apps, undefined) of
+        undefined ->
+            ok;
+        Apps ->
+            ?WARN("The rebar3 shell is a development tool; to deploy "
+                  "applications in production, consider using releases "
+                  "(http://www.rebar3.org/v3.0/docs/releases)", []),
+            Res = [application:ensure_all_started(App) || App <- Apps],
+            _ = [?INFO("Booted ~p", [App])
+                 || {ok, Booted} <- Res,
+                    App <- Booted],
+            _ = [?ERROR("Failed to boot ~p for reason ~p", [App, Reason])
+                 || {error, {App, Reason}} <- Res],
+            ok
+    end.
 
 remove_error_handler(0) ->
     ?WARN("Unable to remove simple error_logger handler", []);
@@ -124,27 +166,13 @@ wait_until_user_started(Timeout) ->
     end.
 
 add_test_paths(State) ->
-    lists:foreach(fun(App) ->
-                          AppDir = rebar_app_info:out_dir(App),
-                          %% ignore errors resulting from non-existent directories
-                          _ = code:add_path(filename:join([AppDir, "test"]))
-                  end, rebar_state:project_apps(State)),
+    _ = [begin
+            AppDir = rebar_app_info:out_dir(App),
+            %% ignore errors resulting from non-existent directories
+            _ = code:add_path(filename:join([AppDir, "test"]))
+         end || App <- rebar_state:project_apps(State)],
     _ = code:add_path(filename:join([rebar_dir:base_dir(State), "test"])),
     ok.
-
-reread_config(State) ->
-    case find_config(State) of
-        no_config ->
-            ok;
-        ConfigList ->
-            lists:foreach(fun ({Application, Items}) ->
-                                  lists:foreach(fun ({Key, Val}) ->
-                                                        application:set_env(Application, Key, Val)
-                                                end,
-                                                Items)
-                          end,
-                          ConfigList)
-    end.
 
 % First try the --config flag, then try the relx sys_config
 -spec find_config(rebar_state:t()) -> [tuple()] | no_config.

--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -237,4 +237,7 @@ find_config_relx(State) ->
 consult_config(State, Filename) ->
     Fullpath = filename:join(rebar_dir:root_dir(State), Filename),
     ?DEBUG("Loading configuration from ~p", [Fullpath]),
-    rebar_file_utils:try_consult(Fullpath).
+    case rebar_file_utils:try_consult(Fullpath) of
+        [T] -> T;
+        [] -> []
+    end.


### PR DESCRIPTION
- moved path addition, config loading and app boot to before the shell
  is available
- apps successfully booting are in an INFO message, failed to boot into
  an ERROR message
- A warning is printed when apps are booted informing to please use
  releases for actual deployment, and is omitted otherwise.
- Some minor refactorings otherwise.

I still want to figure out a good auto-included rebar3 binding for compiling and module loading within rebar3 shell itself.