### PR TITLE
fix bareness issues

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
          {branch, "master"}}},
        {providers, "",
         {git, "https://github.com/tsloughter/providers.git",
-         {tag, "v1.3.1"}}},
+         {tag, "v1.4.0"}}},
        {relx, "",
         {git, "https://github.com/erlware/relx.git",
          {branch, "master"}}},

--- a/rebar.lock
+++ b/rebar.lock
@@ -4,7 +4,7 @@
   0},
  {<<"providers">>,
   {git,"https://github.com/tsloughter/providers.git",
-       {ref,"7563ba7e916d5a35972b25b3aa1945ffe0a8e7a5"}},
+       {ref,"adc0af0a3f5de2049419a753777686b94f4e2c90"}},
   0},
  {<<"mustache">>,
   {git,"https://github.com/soranoba/mustache.git",

--- a/src/rebar_prv_app_discovery.erl
+++ b/src/rebar_prv_app_discovery.erl
@@ -23,7 +23,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, true},
+                                                               {bare, false},
                                                                {deps, ?DEPS},
                                                                {example, ""},
                                                                {short_desc, ""},

--- a/src/rebar_prv_as.erl
+++ b/src/rebar_prv_as.erl
@@ -22,7 +22,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 as <profile1>,<profile2>,... <task1>, <task2>, ..."},
                                                                {short_desc, "Higher order provider for running multiple tasks in a sequence as a certain profiles."},

--- a/src/rebar_prv_clean.erl
+++ b/src/rebar_prv_clean.erl
@@ -22,7 +22,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 clean"},
                                                                {short_desc, "Remove compiled beam files from apps."},

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -25,7 +25,7 @@ init(State) ->
     Provider = providers:create([{name, ?PROVIDER},
                                  {module, ?MODULE},
                                  {deps, ?DEPS},
-                                 {bare, false},
+                                 {bare, true},
                                  {example, "rebar3 ct"},
                                  {short_desc, "Run Common Tests."},
                                  {desc, "Run Common Tests."},

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -21,7 +21,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 compile"},
                                                                {short_desc, "Compile apps .app.src and .erl files."},

--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -25,7 +25,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 cover"},
                                                                {short_desc, "Perform coverage analysis."},

--- a/src/rebar_prv_deps.erl
+++ b/src/rebar_prv_deps.erl
@@ -18,7 +18,7 @@ init(State) ->
             providers:create([
                     {name, ?PROVIDER},
                     {module, ?MODULE},
-                    {bare, false},
+                    {bare, true},
                     {deps, ?DEPS},
                     {example, "rebar3 deps"},
                     {short_desc, "List dependencies"},

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -25,7 +25,7 @@ init(State) ->
             {succ_typings, $s, "succ-typings", boolean, "Enable success typing analysis. Default: true"}],
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 dialyzer"},
                                                                {short_desc, short_desc()},

--- a/src/rebar_prv_do.erl
+++ b/src/rebar_prv_do.erl
@@ -23,7 +23,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 do <task1>, <task2>, ..."},
                                                                {short_desc, "Higher order provider for running multiple tasks in a sequence."},

--- a/src/rebar_prv_edoc.erl
+++ b/src/rebar_prv_edoc.erl
@@ -19,7 +19,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 edoc"},
                                                                {short_desc, "Generate documentation using edoc."},

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -47,7 +47,7 @@ init(State) ->
     Provider = providers:create([
                                 {name, ?PROVIDER},
                                 {module, ?MODULE},
-                                {bare, false},
+                                {bare, true},
                                 {deps, ?DEPS},
                                 {example, "rebar3 escriptize"},
                                 {opts, []},

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -24,7 +24,7 @@ init(State) ->
     Provider = providers:create([{name, ?PROVIDER},
                                  {module, ?MODULE},
                                  {deps, ?DEPS},
-                                 {bare, false},
+                                 {bare, true},
                                  {example, "rebar3 eunit"},
                                  {short_desc, "Run EUnit Tests."},
                                  {desc, "Run EUnit Tests."},

--- a/src/rebar_prv_help.erl
+++ b/src/rebar_prv_help.erl
@@ -22,7 +22,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 help <task>"},
                                                                {short_desc, "Display a list of tasks or help for a given task or subtask."},

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -58,7 +58,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, true},
+                                                               {bare, false},
                                                                {deps, ?DEPS},
                                                                {example, undefined},
                                                                {short_desc, ""},

--- a/src/rebar_prv_lock.erl
+++ b/src/rebar_prv_lock.erl
@@ -19,7 +19,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, true},
+                                                               {bare, false},
                                                                {deps, ?DEPS},
                                                                {example, ""},
                                                                {short_desc, "Locks dependencies."},

--- a/src/rebar_prv_new.erl
+++ b/src/rebar_prv_new.erl
@@ -20,7 +20,7 @@ init(State) ->
     Provider = providers:create([
         {name, ?PROVIDER},
         {module, ?MODULE},
-        {bare, false},
+        {bare, true},
         {deps, ?DEPS},
         {example, "rebar3 new <template>"},
         {short_desc, "Create new project from templates."},

--- a/src/rebar_prv_packages.erl
+++ b/src/rebar_prv_packages.erl
@@ -17,7 +17,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 pkgs"},
                                                                {short_desc, "List available packages."},

--- a/src/rebar_prv_release.erl
+++ b/src/rebar_prv_release.erl
@@ -22,7 +22,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 release"},
                                                                {short_desc, "Build release of project."},

--- a/src/rebar_prv_report.erl
+++ b/src/rebar_prv_report.erl
@@ -23,7 +23,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 report \"<task>\""},
                                                                {short_desc, "Provide a crash report to be sent to the rebar3 issues page."},

--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -50,7 +50,7 @@ init(State) ->
             providers:create([
                 {name, ?PROVIDER},
                 {module, ?MODULE},
-                {bare, false},
+                {bare, true},
                 {deps, ?DEPS},
                 {example, "rebar3 shell"},
                 {short_desc, "Run shell with project apps and deps in path."},

--- a/src/rebar_prv_tar.erl
+++ b/src/rebar_prv_tar.erl
@@ -22,7 +22,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 tar"},
                                                                {short_desc, "Tar archive of release built of project."},

--- a/src/rebar_prv_unlock.erl
+++ b/src/rebar_prv_unlock.erl
@@ -22,7 +22,7 @@ init(State) ->
         State,
         providers:create([{name, ?PROVIDER},
                           {module, ?MODULE},
-                          {bare, false},
+                          {bare, true},
                           {deps, ?DEPS},
                           {example, ""},
                           {short_desc, "Unlock dependencies."},

--- a/src/rebar_prv_update.erl
+++ b/src/rebar_prv_update.erl
@@ -23,7 +23,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 update"},
                                                                {short_desc, "Update package index."},

--- a/src/rebar_prv_upgrade.erl
+++ b/src/rebar_prv_upgrade.erl
@@ -28,7 +28,7 @@ init(State) ->
         rebar_state:add_provider(State,
                                  providers:create([{name, ?PROVIDER},
                                                    {module, ?MODULE},
-                                                   {bare, false},
+                                                   {bare, true},
                                                    {deps, ?DEPS},
                                                    {example, "rebar3 upgrade [cowboy[,ranch]]"},
                                                    {short_desc, "Upgrade dependencies."},

--- a/src/rebar_prv_version.erl
+++ b/src/rebar_prv_version.erl
@@ -22,7 +22,7 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
                                                                {example, "rebar3 version"},
                                                                {short_desc, "Print version for rebar and current Erlang."},

--- a/src/rebar_prv_xref.erl
+++ b/src/rebar_prv_xref.erl
@@ -27,7 +27,7 @@ init(State) ->
     Provider = providers:create([{name, ?PROVIDER},
                                  {module, ?MODULE},
                                  {deps, ?DEPS},
-                                 {bare, false},
+                                 {bare, true},
                                  {example, "rebar3 xref"},
                                  {short_desc, short_desc()},
                                  {desc, desc()}]),


### PR DESCRIPTION
- Crashes in providers lib when no providers in a namespace are bare
- Making sure bareness matches semantics; i.e. a bare provider is
  visible, a non-bare provider is hidden.

Fixes https://github.com/rebar/rebar3/issues/484 -- Depends on https://github.com/tsloughter/providers/pull/8 after which I can amend this PR.