### PR TITLE
keep all_deps list in state created for building deps

### DIFF
--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -41,10 +41,12 @@ do(State) ->
     Deps = rebar_state:deps_to_build(State),
     Cwd = rebar_state:dir(State),
 
-    %% Need to allow global config vars used on deps
-    %% Right now no way to differeniate and just give deps a new state
+    %% Need to allow global config vars used on deps.
+    %% Right now no way to differeniate and just give deps a new state.
+    %% But need an account of "all deps" for some hooks to use.
     EmptyState = rebar_state:new(),
-    build_apps(EmptyState, Providers, Deps),
+    build_apps(rebar_state:all_deps(EmptyState,
+                                   rebar_state:all_deps(State)), Providers, Deps),
 
     {ok, ProjectApps1} = rebar_digraph:compile_order(ProjectApps),
 
@@ -76,7 +78,8 @@ build_app(State, Providers, AppInfo) ->
     copy_app_dirs(State, AppDir, OutDir),
 
     S = rebar_app_info:state_or_new(State, AppInfo),
-    compile(S, Providers, AppInfo).
+    S1 = rebar_state:all_deps(S, rebar_state:all_deps(State)),
+    compile(S1, Providers, AppInfo).
 
 compile(State, Providers, AppInfo) ->
     ?INFO("Compiling ~s", [rebar_app_info:name(AppInfo)]),

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -72,7 +72,7 @@ do(State) ->
             end;
         Name ->
             AllApps = rebar_state:all_deps(State)++rebar_state:project_apps(State),
-            AppInfo = rebar_app_utils:find(Name, AllApps),
+            {ok, AppInfo} = rebar_app_utils:find(ec_cnv:to_binary(Name), AllApps),
             escriptize(State, AppInfo)
     end.
 
@@ -83,6 +83,7 @@ escriptize(State0, App) ->
     %% Get the output filename for the escript -- this may include dirs
     Filename = filename:join([rebar_dir:base_dir(State0), "bin",
                               rebar_state:get(State0, escript_name, AppName)]),
+    ?DEBUG("Creating escript file ~s", [Filename]),
     ok = filelib:ensure_dir(Filename),
     State = rebar_state:escript_path(State0, Filename),
 


### PR DESCRIPTION
I don't really like it. I feel we are getting more and more one off "save this state here" spots that may bite us later. We may want to look at splitting state into 2 types, 1 that is the constant changing state we are currently storing in `app_info` as well and another that is higher project stuff like `all_deps`.

This change is necessary so a dep that builds itself into an escript is still able to.