### PR TITLE
Make test on windows green.

### DIFF
--- a/src/rebar_agent.erl
+++ b/src/rebar_agent.erl
@@ -20,7 +20,7 @@ do(Namespace, Command) when is_atom(Namespace), is_atom(Command) ->
     gen_server:call(?MODULE, {cmd, Namespace, Command}, infinity).
 
 init(State) ->
-    {ok, Cwd} = file:get_cwd(),
+    Cwd = rebar_dir:get_cwd(),
     {ok, #state{state=State, cwd=Cwd}}.
 
 handle_call({cmd, Command}, _From, State=#state{state=RState, cwd=Cwd}) ->
@@ -48,8 +48,8 @@ terminate(_Reason, _State) ->
 
 run(Namespace, Command, RState, Cwd) ->
     try
-        case file:get_cwd() of
-            {ok, Cwd} ->
+        case rebar_dir:get_cwd() of
+            Cwd ->
                 Args = [atom_to_list(Namespace), atom_to_list(Command)],
                 CmdState0 = refresh_state(RState, Cwd),
                 CmdState1 = rebar_state:set(CmdState0, task, atom_to_list(Command)),

--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -100,7 +100,11 @@ local_cache_dir(Dir) ->
 
 get_cwd() ->
     {ok, Dir} = file:get_cwd(),
-    Dir.
+    %% On windows cwd may return capital letter for drive,
+    %% for example C:/foobar. But as said in http://www.erlang.org/doc/man/filename.html#join-1
+    %% filename:join/1,2 anyway will convert drive-letter to lowercase, so we have to "internalize"
+    %% cwd as soon as it possible.
+    filename:join([Dir]).
 
 template_globals(State) ->
     filename:join([global_config_dir(State), "templates", "globals"]).

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -120,20 +120,23 @@ mv(Source, Dest) ->
                                       [{use_stdout, false}, abort_on_error]),
             ok;
         {win32, _} ->
-            {ok, R} = rebar_utils:sh(
-                        ?FMT("move /y \"~s\" \"~s\" 1> nul",
+            Res = rebar_utils:sh(
+                        ?FMT("robocopy /move /e \"~s\" \"~s\" 1> nul",
                              [filename:nativename(Source),
                               filename:nativename(Dest)]),
                         [{use_stdout, false}, return_on_error]),
-            case R of
-                [] ->
-                    ok;
-                _ ->
+            case win32_robocopy_ok(Res) of
+                true -> ok;
+                false ->
                     {error, lists:flatten(
                               io_lib:format("Failed to move ~s to ~s~n",
                                             [Source, Dest]))}
             end
     end.
+
+win32_robocopy_ok({ok, _}) -> true;
+win32_robocopy_ok({error, {Rc, _}}) when Rc<9, Rc==16 -> true;
+win32_robocopy_ok(_) -> false.
 
 delete_each([]) ->
     ok;

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -109,7 +109,7 @@ download(Dir, {git, Url, Rev}, _State) ->
     rebar_utils:sh(?FMT("git checkout -q ~s", [Rev]), [{cd, Dir}]).
 
 make_vsn(Dir) ->
-    {ok, Cwd} = file:get_cwd(),
+    Cwd = rebar_dir:get_cwd(),
     try
         ok = file:set_cwd(Dir),
         {Vsn, RawRef, RawCount} = collect_default_refcount(),

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -347,17 +347,15 @@ reduce_path(Acc, [Component|Rest]) -> reduce_path([Component|Acc], Rest).
 
 
 remove_links(Path) ->
-	IsDir = ec_file:is_dir(Path),
+    IsDir = ec_file:is_dir(Path),
     case ec_file:is_symlink(Path) of
         true when IsDir ->
             delete_dir_link(Path);
-        true ->
-            file:delete(Path);
-        false ->
-            ec_file:is_dir(Path) andalso
+        false when IsDir ->
                 lists:foreach(fun(ChildPath) ->
                                       remove_links(ChildPath)
-                              end, sub_dirs(Path))
+                              end, dir_entries(Path));
+        _ -> file:delete(Path)
     end.
 
 delete_dir_link(Path) ->
@@ -366,7 +364,7 @@ delete_dir_link(Path) ->
 		{win32, _} -> file:del_dir(Path)
 	end.
 
-sub_dirs(Path) ->
+dir_entries(Path) ->
     {ok, SubDirs} = file:list_dir(Path),
     [filename:join(Path, SubDir) || SubDir <- SubDirs].
 

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -97,8 +97,7 @@ do(State) ->
 %% Dialyzer gets default plt location wrong way by peeking HOME environment
 %% variable which usually is not defined on Windows.
 maybe_fix_env() ->
-    {ok, [[HomePath]]} = init:get_argument(home),
-    os:putenv("DIALYZER_PLT", filename:join(HomePath, ".dialyzer_plt")).
+    os:putenv("DIALYZER_PLT", filename:join(rebar_dir:home_dir(), ".dialyzer_plt")).
 
 -spec format_error(any()) -> iolist().
 format_error({error_processing_apps, Error}) ->

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -72,6 +72,7 @@ short_desc() ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+    maybe_fix_env(),
     ?INFO("Dialyzer starting, this may take a while...", []),
     code:add_pathsa(rebar_state:code_paths(State, all_deps)),
     Plt = get_plt(State),
@@ -90,6 +91,14 @@ do(State) ->
     after
         rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default))
     end.
+
+%% This is used to workaround dialyzer quirk discussed here
+%% https://github.com/rebar/rebar3/pull/489#issuecomment-107953541
+%% Dialyzer gets default plt location wrong way by peeking HOME environment
+%% variable which usually is not defined on Windows.
+maybe_fix_env() ->
+    {ok, [[HomePath]]} = init:get_argument(home),
+    os:putenv("DIALYZER_PLT", filename:join(HomePath, ".dialyzer_plt")).
 
 -spec format_error(any()) -> iolist().
 format_error({error_processing_apps, Error}) ->

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -163,9 +163,10 @@ recompile_when_hrl_changes(Config) ->
     ModTime = [filelib:last_modified(filename:join([EbinDir, F]))
                || F <- Files, filename:extension(F) == ".beam"],
 
+
     timer:sleep(1000),
 
-    os:cmd("touch " ++ HeaderFile),
+    rebar_file_utils:touch(HeaderFile),
 
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name}]}),
 
@@ -274,9 +275,9 @@ delete_beam_if_source_deleted(Config) ->
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name}]}),
 
     EbinDir = filename:join([AppDir, "_build", "default", "lib", Name, "ebin"]),
-    SrcDir = filename:join([AppDir, "_build", "default", "lib", Name, "src"]),
+    _SrcDir = filename:join([AppDir, "_build", "default", "lib", Name, "src"]),
     ?assert(filelib:is_regular(filename:join(EbinDir, "not_a_real_src_" ++ Name ++ ".beam"))),
-    file:delete(filename:join(SrcDir, "not_a_real_src_" ++ Name ++ ".erl")),
+    file:delete(filename:join([AppDir, "src", "not_a_real_src_" ++ Name ++ ".erl"])),
 
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name}]}),
 
@@ -307,6 +308,7 @@ deps_in_path(Config) ->
     ?assertEqual([], [Path || Path <- code:get_path(),
                               {match, _} <- [re:run(Path, DepName)]]),
     %% Hope not to find pkg name in there
+  
     ?assertEqual([], [Path || Path <- code:get_path(),
                                  {match, _} <- [re:run(Path, PkgName)]]),
     %% Build things

--- a/test/rebar_hooks_SUITE.erl
+++ b/test/rebar_hooks_SUITE.erl
@@ -114,7 +114,7 @@ run_hooks_for_plugins(Config) ->
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
     PluginName = rebar_test_utils:create_random_name("plugin1_"),
-    mock_git_resource:mock([{config, [{pre_hooks, [{compile, "touch randomfile"}]}]}]),
+    mock_git_resource:mock([{config, [{pre_hooks, [{compile, "echo whatsup > randomfile"}]}]}]),
 
     RConfFile = rebar_test_utils:create_config(AppDir,
                                                [{plugins, [

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -105,12 +105,12 @@ create_config(AppDir, Contents) ->
 
 %% @doc Util to create a random variation of a given name.
 create_random_name(Name) ->
-    random:seed(os:timestamp()),
+    random:seed(erlang:now()),
     Name ++ erlang:integer_to_list(random:uniform(1000000)).
 
 %% @doc Util to create a random variation of a given version.
 create_random_vsn() ->
-    random:seed(os:timestamp()),
+    random:seed(erlang:now()),
     lists:flatten([erlang:integer_to_list(random:uniform(100)),
                    ".", erlang:integer_to_list(random:uniform(100)),
                    ".", erlang:integer_to_list(random:uniform(100))]).

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -105,7 +105,8 @@ create_config(AppDir, Contents) ->
 
 %% @doc Util to create a random variation of a given name.
 create_random_name(Name) ->
-    random:seed(erlang:now()),
+    <<A:32, B:32, C:32>> = crypto:rand_bytes(12),
+    random:seed({A,B,C}),
     Name ++ erlang:integer_to_list(random:uniform(1000000)).
 
 %% @doc Util to create a random variation of a given version.

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -105,16 +105,21 @@ create_config(AppDir, Contents) ->
 
 %% @doc Util to create a random variation of a given name.
 create_random_name(Name) ->
-    <<A:32, B:32, C:32>> = crypto:rand_bytes(12),
-    random:seed({A,B,C}),
+    random_seed(),
     Name ++ erlang:integer_to_list(random:uniform(1000000)).
 
 %% @doc Util to create a random variation of a given version.
 create_random_vsn() ->
-    random:seed(erlang:now()),
+    random_seed(),
     lists:flatten([erlang:integer_to_list(random:uniform(100)),
                    ".", erlang:integer_to_list(random:uniform(100)),
                    ".", erlang:integer_to_list(random:uniform(100))]).
+
+random_seed() ->
+    <<A:32, B:32, C:32>> = crypto:rand_bytes(12),
+    random:seed({A,B,C}).
+
+
 
 expand_deps(_, []) -> [];
 expand_deps(git, [{Name, Deps} | Rest]) ->

--- a/test/rebar_utils_SUITE.erl
+++ b/test/rebar_utils_SUITE.erl
@@ -22,7 +22,7 @@
          task_with_flag_with_commas/1,
          task_with_multiple_flags/1,
          special_task_do/1,
-         sh_don_not_miss_messages/1]).
+         sh_does_not_miss_messages/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -31,7 +31,7 @@
 
 all() ->
     [{group, args_to_tasks},
-     sh_don_not_miss_messages].
+     sh_does_not_miss_messages].
 
 groups() ->
     [{args_to_tasks, [], [empty_arglist,
@@ -120,7 +120,7 @@ special_task_do(_Config) ->
                                                                         "do",
                                                                         "bar,",
                                                                         "baz"]).
-sh_don_not_miss_messages(_Config) ->
+sh_does_not_miss_messages(_Config) ->
     Source = "~nmain(_) ->~n io:format(\"donotmissme\").~n",
     file:write_file("do_not_miss_messages", io_lib:format(Source,[])),
     {ok, "donotmissme"} = rebar_utils:sh("escript do_not_miss_messages", []),

--- a/test/rebar_utils_SUITE.erl
+++ b/test/rebar_utils_SUITE.erl
@@ -21,7 +21,8 @@
          task_with_flag_with_trailing_comma/1,
          task_with_flag_with_commas/1,
          task_with_multiple_flags/1,
-         special_task_do/1]).
+         special_task_do/1,
+         sh_don_not_miss_messages/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -29,7 +30,8 @@
 
 
 all() ->
-    [{group, args_to_tasks}].
+    [{group, args_to_tasks},
+     sh_don_not_miss_messages].
 
 groups() ->
     [{args_to_tasks, [], [empty_arglist,
@@ -118,3 +120,14 @@ special_task_do(_Config) ->
                                                                         "do",
                                                                         "bar,",
                                                                         "baz"]).
+sh_don_not_miss_messages(_Config) ->
+    Source = "~nmain(_) ->~n io:format(\"donotmissme\").~n",
+    file:write_file("do_not_miss_messages", io_lib:format(Source,[])),
+    {ok, "donotmissme"} = rebar_utils:sh("escript do_not_miss_messages", []),
+    AnyMessageRemained =
+        receive
+            What -> What
+        after 100 ->
+            false
+        end,
+    AnyMessageRemained = false.


### PR DESCRIPTION
1. First issue I've encountered when using rebar3 on windows was something like #395. Just try to run `rebar3 ct` in rebar's own project directory. Command will truncate all files in `test` dir and fail. Issue is in how `rebar_prv_common_test` dealing with symlinks.
2. Fix issue with dependencies downloading and long file names.
3. Fix dialyzer provider.
4. Fix issue with duplicating common test runs for single-project application.
5. Fix funky issue with `rebar_ct_SUITE:multi_app_default_dir/1` caused by seeding random generator with os:timestamp().

[![Windows build status](https://ci.appveyor.com/api/projects/status/twlj92ewp0l5sr85/branch/windows-ct-fix?svg=true)](https://ci.appveyor.com/project/kovyl2404/rebar3)