### PR TITLE
run pre and post hooks for release and tar providers

### DIFF
--- a/src/rebar_prv_release.erl
+++ b/src/rebar_prv_release.erl
@@ -40,6 +40,9 @@ do(State) ->
                                    [?DEFAULT_CHECKOUTS_DIR, DepsDir | ProjectAppDirs]),
     OutputDir = filename:join(rebar_dir:base_dir(State), ?DEFAULT_RELEASE_DIR),
     AllOptions = string:join(["release" | Options], " "),
+    Cwd = rebar_state:dir(State),
+    Providers = rebar_state:providers(State),
+    rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
     try
         case rebar_state:get(State, relx, []) of
             [] ->
@@ -52,6 +55,7 @@ do(State) ->
                           ,{output_dir, OutputDir}
                           ,{caller, Caller}], AllOptions)
         end,
+        rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State),
         {ok, State}
     catch
         throw:T ->

--- a/src/rebar_prv_tar.erl
+++ b/src/rebar_prv_tar.erl
@@ -40,6 +40,9 @@ do(State) ->
                                    [?DEFAULT_CHECKOUTS_DIR, DepsDir | ProjectAppDirs]),
     OutputDir = filename:join(rebar_dir:base_dir(State), ?DEFAULT_RELEASE_DIR),
     AllOptions = string:join(["release", "tar" | Options], " "),
+    Cwd = rebar_state:dir(State),
+    Providers = rebar_state:providers(State),
+    rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
     case rebar_state:get(State, relx, []) of
         [] ->
             relx:main([{lib_dirs, LibDirs}
@@ -51,6 +54,7 @@ do(State) ->
                       ,{output_dir, OutputDir}
                       ,{caller, Caller}], AllOptions)
     end,
+    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State),
     {ok, State}.
 
 -spec format_error(any()) -> iolist().


### PR DESCRIPTION
Useful for running plugins like cuttlefish that need to run after release creation.