### PR TITLE
set default providers before installing plugins

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -98,10 +98,9 @@ run_aux(State, RawArgs) ->
                             filename:join(filename:absname(rebar_state:dir(State2)), BaseDir)),
 
     {ok, Providers} = application:get_env(rebar, providers),
-    State4 = rebar_plugins:install(State3),
-
     %% Providers can modify profiles stored in opts, so set default after initializing providers
-    State5 = rebar_state:create_logic_providers(Providers, State4),
+    State4 = rebar_state:create_logic_providers(Providers, State3),
+    State5 = rebar_plugins:install(State4),
     State6 = rebar_state:default(State5, rebar_state:opts(State5)),
 
     {Task, Args} = parse_args(RawArgs),

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -60,7 +60,7 @@ handle_plugin(Profile, Plugin, State) ->
         code:add_pathsa(CodePaths),
 
         %% Build plugin and its deps
-        [build_plugin(AppInfo) || AppInfo <- ToBuild],
+        [build_plugin(AppInfo, Apps, State) || AppInfo <- ToBuild],
 
         %% Add newly built deps and plugin to code path
         State3 = rebar_state:update_all_plugin_deps(State2, Apps),
@@ -78,11 +78,12 @@ handle_plugin(Profile, Plugin, State) ->
             {[], State}
     end.
 
-build_plugin(AppInfo) ->
+build_plugin(AppInfo, Apps, State) ->
+    Providers = rebar_state:providers(State),
     AppDir = rebar_app_info:dir(AppInfo),
     C = rebar_config:consult(AppDir),
-    S = rebar_state:new(rebar_state:new(), C, AppDir),
-    rebar_prv_compile:compile(S, [], AppInfo).
+    S = rebar_state:new(rebar_state:all_deps(rebar_state:new(), Apps), C, AppDir),
+    rebar_prv_compile:compile(S, Providers, AppInfo).
 
 plugin_providers({Plugin, _, _, _}) when is_atom(Plugin) ->
     validate_plugin(Plugin);


### PR DESCRIPTION
This is useful for plugins that themselves or dependencies that use provider hooks. Since a builtin provider will never rely on a plugin it is smart to set those up first so they are available for plugins when they compile.