### PR TITLE
Fixed two tests for windows 8.1 and added touch functionality

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -437,6 +437,10 @@ sh_loop(Port, Fun, Acc) ->
             sh_loop(Port, Fun, Fun(Line, Acc));
         {Port, {exit_status, 0}} ->
             {ok, lists:flatten(lists:reverse(Acc))};
+        {Port, {exit_status, 1}} ->
+            {ok, lists:flatten(lists:reverse(Acc))};
+        {Port, {exit_status, 3}} ->
+            {ok, lists:flatten(lists:reverse(Acc))};
         {Port, {exit_status, Rc}} ->
             {error, {Rc, lists:flatten(lists:reverse(Acc))}}
     end.

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -165,9 +165,10 @@ recompile_when_hrl_changes(Config) ->
     ModTime = [filelib:last_modified(filename:join([EbinDir, F]))
                || F <- Files, filename:extension(F) == ".beam"],
 
+
     timer:sleep(1000),
 
-    os:cmd("touch " ++ HeaderFile),
+    rebar_file_utils:touch(HeaderFile),
 
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name}]}),
 
@@ -276,9 +277,9 @@ delete_beam_if_source_deleted(Config) ->
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name}]}),
 
     EbinDir = filename:join([AppDir, "_build", "default", "lib", Name, "ebin"]),
-    SrcDir = filename:join([AppDir, "_build", "default", "lib", Name, "src"]),
+    _SrcDir = filename:join([AppDir, "_build", "default", "lib", Name, "src"]),
     ?assert(filelib:is_regular(filename:join(EbinDir, "not_a_real_src_" ++ Name ++ ".beam"))),
-    file:delete(filename:join(SrcDir, "not_a_real_src_" ++ Name ++ ".erl")),
+    file:delete(filename:join([AppDir, "src", "not_a_real_src_" ++ Name ++ ".erl"])),
 
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name}]}),
 
@@ -309,6 +310,7 @@ deps_in_path(Config) ->
     ?assertEqual([], [Path || Path <- code:get_path(),
                               {match, _} <- [re:run(Path, DepName)]]),
     %% Hope not to find pkg name in there
+  
     ?assertEqual([], [Path || Path <- code:get_path(),
                                  {match, _} <- [re:run(Path, PkgName)]]),
     %% Build things


### PR DESCRIPTION
Tested on windows 8.1

Issues:
resolve #493 #494 #495

Tests:
recompile_when_hrl_changes (Windows had issue with symlink)
as_multiple_profiles_multiple_tasks (Long path issue with xcopy)

Changed:
On Windows changed from xcopy to robocopy to remove the 240 char issue on paths.
Fix so that it removes directory and then copy it if it can't create symlink.

