### PR TITLE
add config option artifacts

### DIFF
--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -20,19 +20,19 @@ do(State, LibDirs) ->
     %% Sort apps so we get the same merged deps config everytime
     SortedApps = rebar_utils:sort_deps(Apps),
     lists:foldl(fun(AppInfo, StateAcc) ->
-			Name = rebar_app_info:name(AppInfo),
-			case enable(State, AppInfo) of
-			    true ->
-				{AppInfo1, StateAcc1} = merge_deps(AppInfo, StateAcc),
-				OutDir = filename:join(DepsDir, Name),
-				AppInfo2 = rebar_app_info:out_dir(AppInfo1, OutDir),
-				ProjectDeps1 = lists:delete(Name, ProjectDeps),
-				rebar_state:project_apps(StateAcc1
-		 					,rebar_app_info:deps(AppInfo2, ProjectDeps1));
-			    false ->
-				?INFO("Ignoring ~s", [Name]),
-				StateAcc
-			end
+                        Name = rebar_app_info:name(AppInfo),
+                        case enable(State, AppInfo) of
+                            true ->
+                                {AppInfo1, StateAcc1} = merge_deps(AppInfo, StateAcc),
+                                OutDir = filename:join(DepsDir, Name),
+                                AppInfo2 = rebar_app_info:out_dir(AppInfo1, OutDir),
+                                ProjectDeps1 = lists:delete(Name, ProjectDeps),
+                                rebar_state:project_apps(StateAcc1
+                                                        ,rebar_app_info:deps(AppInfo2, ProjectDeps1));
+                            false ->
+                                ?INFO("Ignoring ~s", [Name]),
+                                StateAcc
+                        end
                 end, State, SortedApps).
 
 format_error({module_list, File}) ->
@@ -51,7 +51,8 @@ merge_deps(AppInfo, State) ->
                  rebar_state:apply_profiles(
                    rebar_state:new(reset_hooks(rebar_state:opts(State, Default)), C,
                                   rebar_app_info:dir(AppInfo)), CurrentProfiles), Name),
-    AppInfo1 = rebar_app_info:state(AppInfo, AppState),
+    AppState1 = rebar_state:set(AppState, artifacts, []),
+    AppInfo1 = rebar_app_info:state(AppInfo, AppState1),
 
     State1 = lists:foldl(fun(Profile, StateAcc) ->
                                  AppProfDeps = rebar_state:get(AppState, {deps, Profile}, []),
@@ -219,8 +220,8 @@ try_handle_app_src_file(_, _AppDir, Other, _Validate) ->
     throw({error, {multiple_app_files, Other}}).
 
 enable(State, AppInfo) ->
-    not lists:member(to_atom(rebar_app_info:name(AppInfo)), 
-		     rebar_state:get(State, excluded_apps, [])).
+    not lists:member(to_atom(rebar_app_info:name(AppInfo)),
+             rebar_state:get(State, excluded_apps, [])).
 
 to_atom(Bin) ->
     list_to_atom(binary_to_list(Bin)).

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -286,8 +286,9 @@ is_checkout(#app_info_t{is_checkout=IsCheckout}) ->
     IsCheckout.
 
 -spec valid(t()) -> boolean().
-valid(AppInfo=#app_info_t{valid=undefined}) ->
-    case rebar_app_utils:validate_application_info(AppInfo) of
+valid(AppInfo=#app_info_t{valid=undefined, state=State}) ->
+    case rebar_app_utils:validate_application_info(AppInfo)
+        andalso rebar_state:has_all_artifacts(State) =:= true of
         true ->
             true;
         _ ->

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -666,7 +666,8 @@ warn_skip_pkg({Name, Source}, State) ->
 
 not_needs_compile(App) ->
     not(rebar_app_info:is_checkout(App))
-        andalso rebar_app_info:valid(App).
+        andalso rebar_app_info:valid(App)
+          andalso rebar_state:has_all_artifacts(rebar_app_info:state(App)) =:= true.
 
 get_package(Dep, State) ->
     case rebar_state:registry(State) of

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -3,6 +3,8 @@
 -export([new/0, new/1, new/2, new/3,
          get/2, get/3, set/3,
 
+         has_all_artifacts/1,
+
          code_paths/2, code_paths/3, update_code_paths/3,
 
          opts/1, opts/2,
@@ -148,6 +150,23 @@ default(#state_t{default=Opts}) ->
 
 default(State, Opts) ->
     State#state_t{default=Opts}.
+
+-spec has_all_artifacts(rebar_app_info:t()) -> true | providers:error().
+has_all_artifacts(State) ->
+    Artifacts = rebar_state:get(State, artifacts, []),
+    Dir = rebar_dir:base_dir(State),
+    all(Dir, Artifacts).
+
+all(_, []) ->
+    true;
+all(Dir, [File|Artifacts]) ->
+    case filelib:is_regular(filename:join(Dir, File)) of
+        false ->
+            ?DEBUG("Missing artifact ~s", [filename:join(Dir, File)]),
+            {false, File};
+        true ->
+            all(Dir, Artifacts)
+    end.
 
 code_paths(#state_t{code_paths=CodePaths}, Key) ->
     case dict:find(Key, CodePaths) of


### PR DESCRIPTION
This commit adds the config option:

```erlang
{artifacts, [filename()]}.
```

A dep is not considered "valid" (built) until all artifacts exist, in addition to the checks already done to make sure `.app`'s list of modules matches the available beam files for the app. So if an artifact does not exist it will run the compile provider and its hooks for that dep.

The filename is relative to the `base_dir`. So for example to verify `eleveldb` has successfully run the post hook port compiler you'd add:

```erlang
{artifacts, ["lib/eleveldb/priv/eleveldb.so"]}
```

Or for `cuttlefish`'s `escriptize` post hook:

```erlang
{artifacts, ["bin/cuttlefish"]}.
```