### PR TITLE
Add functions to validate OTP release in use

### DIFF
--- a/test/rebar_utils_SUITE.erl
+++ b/test/rebar_utils_SUITE.erl
@@ -1,6 +1,8 @@
 -module(rebar_utils_SUITE).
 
 -export([all/0,
+         init_per_testcase/2,
+         end_per_testcase/2,
          groups/0,
          init_per_group/2,
          end_per_group/2,
@@ -21,12 +23,23 @@
          task_with_flag_with_trailing_comma/1,
          task_with_flag_with_commas/1,
          task_with_multiple_flags/1,
-         special_task_do/1]).
+         special_task_do/1,
+         valid_otp_version/1,
+         valid_otp_version_equal/1,
+         invalid_otp_version/1,
+         nonblacklisted_otp_version/1,
+         blacklisted_otp_version/1
+]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/file.hrl").
 
+init_per_testcase(_, Config) ->
+    rebar_test_utils:init_rebar_state(Config).
+
+end_per_testcase(_, _Config) ->
+    catch meck:unload().
 
 all() ->
     [{group, args_to_tasks}].
@@ -49,7 +62,13 @@ groups() ->
                           task_with_flag_with_trailing_comma,
                           task_with_flag_with_commas,
                           task_with_multiple_flags,
-                          special_task_do]}].
+                          special_task_do,
+                          valid_otp_version,
+                          valid_otp_version_equal,
+                          invalid_otp_version,
+                          nonblacklisted_otp_version,
+                          blacklisted_otp_version
+    ]}].
 
 init_per_group(_, Config) -> Config.
 end_per_group(_, Config) -> Config.
@@ -118,3 +137,35 @@ special_task_do(_Config) ->
                                                                         "do",
                                                                         "bar,",
                                                                         "baz"]).
+
+valid_otp_version(_Config) ->
+    meck:new(rebar_utils, [passthrough]),
+    meck:expect(rebar_utils, otp_release, fun() -> "42.4" end),
+    rebar_utils:check_min_otp_version("42.3"),
+    meck:unload(rebar_utils).
+
+valid_otp_version_equal(_Config) ->
+    meck:new(rebar_utils, [passthrough]),
+    meck:expect(rebar_utils, otp_release, fun() -> "42.3" end),
+    rebar_utils:check_min_otp_version("42.3"),
+    meck:unload(rebar_utils).
+
+invalid_otp_version(_Config) ->
+    meck:new(rebar_utils, [passthrough]),
+    meck:expect(rebar_utils, otp_release, fun() -> "17.4" end),
+    ?assertException(throw, rebar_abort, rebar_utils:check_min_otp_version("42.3")),
+    meck:unload(rebar_utils).
+
+nonblacklisted_otp_version(_Config) ->
+    meck:new(rebar_utils, [passthrough]),
+    meck:expect(rebar_utils, otp_release, fun() -> "42.4" end),
+    rebar_utils:check_blacklisted_otp_versions(["1\\.2", "42\\.3"]),
+    meck:unload(rebar_utils).
+
+blacklisted_otp_version(_Config) ->
+    meck:new(rebar_utils, [passthrough]),
+    meck:expect(rebar_utils, otp_release, fun() -> "42.4" end),
+    ?assertException(throw, rebar_abort, rebar_utils:check_blacklisted_otp_versions(["1\\.2", "42\\.[1-4]"])),
+    meck:unload(rebar_utils).
+
+


### PR DESCRIPTION
In the spirit of Original Rebar's "require_min_otp_vsn", this adds
rebar_utils:check_min_otp_version/1 (taking a string containing the
minimum version) and rebar_utils:check_blacklisted_otp_versions/1
(taking a list of regular expression strings), as well as tests in
rebar_utils_SUITE. They're currently only called by the tests-
how/where to best place calls to them from non-test code needs to be
determined (at which point two corresponding rebar.config keys can be
supported). For example, the version probably shouldn't be enforced when
just running "rebar3 help".

Motivated by Issue https://github.com/rebar/rebar3/issues/475
