### PR TITLE
Use the same dialyzer rebar.config options as rebar 

### DIFF
--- a/test/rebar_dialyzer_SUITE.erl
+++ b/test/rebar_dialyzer_SUITE.erl
@@ -25,15 +25,16 @@ end_per_suite(_Config) ->
 init_per_testcase(Testcase, Config) ->
     PrivDir = ?config(priv_dir, Config),
     Prefix = ec_cnv:to_list(Testcase),
-    Plt = filename:join(PrivDir,  Prefix ++ ".project.plt"),
-    BasePlt = Prefix ++ "base.plt",
-    RebarConfig = [{dialyzer_plt, Plt},
-                   {dialyzer_base_plt, BasePlt},
-                   {dialyzer_base_plt_dir, PrivDir},
-                   {dialyzer_base_plt_apps, [erts]}],
-    [{plt, Plt},
-     {base_plt, filename:join(PrivDir, BasePlt)},
-     {rebar_config, RebarConfig} |
+    BasePrefix = Prefix ++ "_base",
+    Opts = [{plt_prefix, Prefix},
+            {plt_location, PrivDir},
+            {base_plt_prefix, BasePrefix},
+            {base_plt_location, PrivDir},
+            {base_plt_apps, [erts]}],
+    Suffix = "_" ++ rebar_utils:otp_release() ++ "_plt",
+    [{plt, filename:join(PrivDir, Prefix ++ Suffix)},
+     {base_plt, filename:join(PrivDir, BasePrefix ++ Suffix)},
+     {rebar_config, [{dialyzer, Opts}]} |
      rebar_test_utils:init_rebar_state(Config)].
 
 all() ->


### PR DESCRIPTION
* All configuration is moved to `{dialyzer, PropList}`
* `dialyzer_warnings` renamed `warnings`
* `dialyzer_plt_warnings` renamed `get_warnings`
* `dialyzer_plt_apps` renamed `plt_extra_apps`
* `dialyzer_plt_dir` renamed `plt_location`
* `{plt_location, local}` uses profile base directory
* `dialyzer_plt` removed
* `dialyzer_plt_prefix` sets prefix of PLT name (default "rebar3")
* `dialyzer_base_plt_apps` renamed `base_plt_apps`
* `dialyzer_base_plt_dir` renamed `base_plt_location`
* `{base_plt_location, global}` uses rebar3's global cache directory
* `dialyzer_base_plt` removed
* `base_plt_prefix` sets prefix of PLT name (default  "rebar3")

PLT files are always named `<prefix>_<otp_version>_plt` to match rebar.
`plt_prefix` and `base_plt_prefix` are not available in rebar, where the
prefix is always set to the project's top level application.