### PR TITLE
catch error if config can't be parsed into dict to print error message

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -120,8 +120,7 @@ init_config() ->
                  ConfigFile ->
                      rebar_config:consult_file(ConfigFile)
              end,
-
-    Config1 = rebar_config:merge_locks(Config, rebar_config:consult_file(?LOCK_FILE)),
+    Config1 = rebar_config:merge_locks(Config, rebar_config:consult_lock_file(?LOCK_FILE)),
 
     %% If $HOME/.config/rebar3/config exists load and use as global config
     GlobalConfigFile = rebar_dir:global_config(),
@@ -129,7 +128,8 @@ init_config() ->
                 true ->
                     ?DEBUG("Load global config file ~p",
                            [GlobalConfigFile]),
-                    GlobalConfig = rebar_state:new(rebar_config:consult_file(GlobalConfigFile)),
+                    GlobalConfigTerms = rebar_config:consult_file(GlobalConfigFile),
+                    GlobalConfig = rebar_state:new(GlobalConfigTerms),
 
                     %% We don't want to worry about global plugin install state effecting later
                     %% usage. So we throw away the global profile state used for plugin install.

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -203,7 +203,7 @@ consult_app_file(Filename) ->
                 false ->
                     file:consult(Filename);
                 true ->
-                    {ok, rebar_config:consult_file(Filename)}
+                    {ok, rebar_config:consult_app_file(Filename)}
             end
     end.
 

--- a/test/rebar_deps_SUITE.erl
+++ b/test/rebar_deps_SUITE.erl
@@ -215,7 +215,7 @@ newly_added_dep(Config) ->
     {ok, RebarConfig2} = file:consult(rebar_test_utils:create_config(AppDir, [{deps, TopDeps2}])),
     LockFile = filename:join(AppDir, "rebar.lock"),
     RebarConfig3 = rebar_config:merge_locks(RebarConfig2,
-                                           rebar_config:consult_file(LockFile)),
+                                           rebar_config:consult_lock_file(LockFile)),
 
     %% a should now be installed and c should not change
     rebar_test_utils:run_and_check(

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -164,7 +164,7 @@ check_results(AppDir, Expected) ->
     GlobalPluginDirs = filelib:wildcard(filename:join([AppDir, "global", "plugins"])),
     CheckoutsDir = filename:join([AppDir, "_checkouts"]),
     LockFile = filename:join([AppDir, "rebar.lock"]),
-    Locks = lists:flatten(rebar_config:consult_file(LockFile)),
+    Locks = lists:flatten(rebar_config:consult_lock_file(LockFile)),
 
     InvalidApps = rebar_app_discover:find_apps(BuildDirs, invalid),
     ValidApps = rebar_app_discover:find_apps(BuildDirs, valid),


### PR DESCRIPTION
If a list that can't be parsed into a dict is used in the config file right now it throws a worthless error message.

Ultimately we should probably do a top level check to try to help even more with what is wrong, but not sure how we want to do that yet.

I guess we'll have to write our own initial check when reading in the file that checks each top level tuple to see if it is a key-value pair and nothing else?