### PR TITLE
OTP apps show proper output

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -85,8 +85,11 @@ format_error(Reason) ->
 shell(State) ->
     setup_name(State),
     setup_paths(State),
-    maybe_boot_apps(State),
     setup_shell(),
+    %% apps must be started after the change in shell because otherwise
+    %% their application masters never gets the new group leader (held in
+    %% their internal state)
+    maybe_boot_apps(State),
     rebar_agent:start_link(State),
     %% this call never returns (until user quits shell)
     timer:sleep(infinity).


### PR DESCRIPTION
Whenever the old shell got killed and an app got loaded prior, the whole
thing would silently drop output as the old 'user' process was replaced
while application master processes would keep the old one's pid in
their internal state.

To work around this limitation, make sure the apps are booted only after
the shell is replaced so that only the new `user` pid is used.