### PR TITLE
print help for namespaces

### DIFF
--- a/src/rebar_prv_do.erl
+++ b/src/rebar_prv_do.erl
@@ -33,8 +33,16 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    Tasks = rebar_utils:args_to_tasks(rebar_state:command_args(State)),
-    do_tasks(Tasks, State).
+    case rebar_utils:args_to_tasks(rebar_state:command_args(State)) of
+        [] ->
+            AllProviders = rebar_state:providers(State),
+            Namespace = rebar_state:namespace(State),
+            Providers = providers:get_providers_by_namespace(Namespace, AllProviders),
+            providers:help(Providers),
+            {ok, State};
+        Tasks ->
+            do_tasks(Tasks, State)
+    end.
 
 do_tasks([], State) ->
     {ok, State};

--- a/src/rebar_prv_help.erl
+++ b/src/rebar_prv_help.erl
@@ -65,7 +65,13 @@ task_help(Namespace, Name, State) ->
     Providers = rebar_state:providers(State),
     case providers:get_provider(Name, Providers, Namespace) of
         not_found ->
-            {error, io_lib:format("Unknown task ~p", [Name])};
+            case providers:get_providers_by_namespace(Name, Providers) of
+                [] ->
+                    {error, io_lib:format("Unknown task ~p", [Name])};
+                NSProviders ->
+                    providers:help(NSProviders),
+                    {ok, State}
+            end;
         Provider ->
             providers:help(Provider),
             {ok, State}


### PR DESCRIPTION
Add ssupport for printing help of all a namespaces' tasks

```
λ rebar3 pc      

pc <task>:
  clean          clean the results of port compilation
  compile        perform port compilation
```

And:

```
λ rebar3 help pc      

pc <task>:
  clean          clean the results of port compilation
  compile        perform port compilation
```