### PR TITLE
fix for overrides in plugins, simpler plugin state handling

### DIFF
--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -67,6 +67,7 @@ run_hooks(Dir, Type, Command, State) ->
                 _ ->
                     []
             end,
+
     Env = create_env(State),
     lists:foreach(fun({_, C, _}=Hook) when C =:= Command ->
                           apply_hook(Dir, Env, Hook);

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -93,9 +93,7 @@ handle_plugin(Profile, Plugin, State, Upgrade) ->
 build_plugin(AppInfo, Apps, State) ->
     Providers = rebar_state:providers(State),
     Providers1 = rebar_state:providers(rebar_app_info:state(AppInfo)),
-    AppDir = rebar_app_info:dir(AppInfo),
-    C = rebar_config:consult(AppDir),
-    S = rebar_state:new(rebar_state:all_deps(rebar_state:new(), Apps), C, AppDir),
+    S = rebar_state:all_deps(rebar_app_info:state_or_new(State, AppInfo), Apps),
     rebar_prv_compile:compile(S, Providers++Providers1, AppInfo).
 
 plugin_providers({Plugin, _, _, _}) when is_atom(Plugin) ->


### PR DESCRIPTION
This change ensures the State created in `install_deps` for the app is used when building the app if it is a plugin.