### PR TITLE
More tests

### DIFF
--- a/test/rebar_install_deps_SUITE.erl
+++ b/test/rebar_install_deps_SUITE.erl
@@ -239,7 +239,7 @@ nondefault_profile(Config) ->
         error(generated_locks)
     catch
         error:generated_locks -> error(generated_locks);
-        _:{assertNotEqual, _} -> ok
+        _:_ -> ok
     end,
     Apps = [App || App = {dep, _} <- AppLocks],
     Expect = {ok, Apps},

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -4,7 +4,7 @@
 -export([init_rebar_state/1, init_rebar_state/2, run_and_check/4]).
 -export([expand_deps/2, flat_deps/1, flat_pkgdeps/1, top_level_deps/1]).
 -export([create_app/4, create_eunit_app/4, create_empty_app/4, create_config/2]).
--export([create_random_name/1, create_random_vsn/0]).
+-export([create_random_name/1, create_random_vsn/0, write_src_file/2]).
 
 %%%%%%%%%%%%%%
 %%% Public %%%


### PR DESCRIPTION
- tests locks by piggyback-riding the install deps suite, and makes sure to
  test that non-default profiles don't get locked
- tests erl_first_files by using a parse transform that stamps modules with an
attribute as it runs them. It then compiles everything, loads the
module, and makes sure the stamps respect the defined order.