### PR TITLE
Do not ignore default test dirs location when suite option specified.

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -211,11 +211,9 @@ discover_tests(State, Opts) ->
 
 discover_dirs_and_suites(State, Opts) ->
     case {proplists:get_value(dir, Opts), proplists:get_value(suite, Opts)} of
-        %% no dirs or suites defined, try using `$APP/test` and `$ROOT/test`
+        %% no dirs defined, try using `$APP/test` and `$ROOT/test`
         %%  as suites
-        {undefined, undefined} -> test_dirs(State, Opts);
-        %% no dirs defined
-        {undefined, _} -> Opts;
+        {undefined, _} -> test_dirs(State, Opts);
         %% no suites defined
         {_, undefined} -> Opts;
         %% a single dir defined, this is ok


### PR DESCRIPTION
Now ct provider can use default test dir locations if [otherwise is not said](https://github.com/rebar/rebar3/blob/master/src/rebar_prv_common_test.erl#L216). My suggestion is still to use default test dir location even if `suite` option is set. Now this condition has [own clause](https://github.com/rebar/rebar3/blob/master/src/rebar_prv_common_test.erl#L218) which I just want to delete. Any considerations not to do this? If there are not, I will write test for this case.