### PR TITLE
Revert "disable ctrl-c interrupt in shell for escript"

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
        {relx,            "3.0.0"}]}.
 
 {escript_name, rebar3}.
-{escript_emu_args, "%%! +Bc +sbtu +A0\n"}.
+{escript_emu_args, "%%! +sbtu +A0\n"}.
 %% escript_incl_extra is for internal rebar-private use only.
 %% Do not use outside rebar. Config interface is not stable.
 {escript_incl_extra, [{"_build/default/lib/relx/priv/templates/*", "."},


### PR DESCRIPTION
This reverts commit 40ee6d95e103f29c89c8a17c300c30448061c287.

You can't ctrl-c out of a running rebar3 command with this disabled, that isn't acceptable :(