### PR TITLE
Evaluate .erlang file in user's home

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -86,6 +86,7 @@ shell(State) ->
     setup_name(State),
     setup_paths(State),
     setup_shell(),
+    eval_dot_erlang(),
     %% apps must be started after the change in shell because otherwise
     %% their application masters never gets the new group leader (held in
     %% their internal state)
@@ -126,6 +127,9 @@ setup_shell() ->
             ?DEBUG("Logger changes failed for ~p:~p (~p)", [E,R,erlang:get_stacktrace()]),
             hope_for_best
     end.
+
+eval_dot_erlang() ->
+    catch c:erlangrc().
 
 setup_paths(State) ->
     %% Add deps to path


### PR DESCRIPTION
The file is always evaluated when booting rebar3, but we call it for
sure a second time (if present) to behave like a shell would be expected
to.

This would fix https://github.com/rebar/rebar3/issues/564 but @leoliu can confirm if it would really make sense
to run the .erlang file evaluation a second time, but in the right context