### PR TITLE
[WIP] Ancient filesystems support

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -63,6 +63,14 @@ format_error({bad_term_file, AppFile, Reason}) ->
     io_lib:format("Error reading file ~s: ~s", [AppFile, file:format_error(Reason)]).
 
 symlink_or_copy(Source, Target) ->
+    case ec_file:exists(Source) of
+        true ->
+            do_symlink_or_copy(Source, Target);
+        false ->
+            ok
+    end.
+
+do_symlink_or_copy(Source, Target) ->
     Link = case os:type() of
                {win32, _} ->
                    Source;
@@ -231,9 +239,8 @@ reset_dir(Path) ->
       Path :: file:name(),
       Reason :: file:posix().
 touch(Path) ->
-    {ok, A} = file:read_file_info(Path),
-    ok = file:write_file_info(Path, A#file_info{mtime = calendar:local_time(),
-                                                atime = calendar:local_time()}).
+    file:change_time(Path, calendar:local_time(), calendar:local_time()).
+
 
 %% ===================================================================
 %% Internal functions

--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -151,7 +151,7 @@ mv(Source, Dest) ->
         {unix, _} ->
             EscSource = escape_path(Source),
             EscDest = escape_path(Dest),
-            {ok, []} = rebar_utils:sh(?FMT("mv ~s ~s", [EscSource, EscDest]),
+            {ok, _} = rebar_utils:sh(?FMT("mv ~s ~s", [EscSource, EscDest]),
                                       [{use_stdout, false}, abort_on_error]),
             ok;
         {win32, _} ->

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -123,7 +123,11 @@ escriptize(State0, App) ->
 
     %% Finally, update executable perms for our script
     {ok, #file_info{mode = Mode}} = file:read_file_info(Filename),
-    ok = file:change_mode(Filename, Mode bor 8#00111),
+    case file:change_mode(Filename, Mode bor 8#00111) of
+        {error, Reason} ->
+            rebar_api:warn("Failed to chmod file ~p: ~p",[Filename, Reason]);
+        _ -> ok
+    end,
     {ok, State}.
 
 -spec format_error(any()) -> iolist().


### PR DESCRIPTION
beta-1 doesn't works properly on filesystems without permissions support, symlinks and another modern stuff. This is reaction to #535. Main goal is to support vboxfs, FAT and so on.