### PR TITLE
update plugin template to separate plugin init and providers

### DIFF
--- a/priv/templates/plugin.erl
+++ b/priv/templates/plugin.erl
@@ -1,33 +1,8 @@
 -module('{{name}}').
--behaviour(provider).
 
--export([init/1, do/1, format_error/1]).
+-export([init/1]).
 
--define(PROVIDER, '{{name}}').
--define(DEPS, [app_discovery]).
-
-%% ===================================================================
-%% Public API
-%% ===================================================================
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
-    Provider = providers:create([
-            {name, ?PROVIDER},            % The 'user friendly' name of the task
-            {module, ?MODULE},            % The module implementation of the task
-            {bare, true},                 % The task can be run by the user, always true
-            {deps, ?DEPS},                % The list of dependencies
-            {example, "rebar3 {{name}}"}, % How to use the plugin
-            {opts, []},                   % list of options understood by the plugin
-            {short_desc, "{{desc}}"},
-            {desc, "{{desc}}"}
-    ]),
-    {ok, rebar_state:add_provider(State, Provider)}.
-
-
--spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
-do(State) ->
-    {ok, State}.
-
--spec format_error(any()) ->  iolist().
-format_error(Reason) ->
-    io_lib:format("~p", [Reason]).
+    {ok, State1} = '{{name}}_prv':init(State),
+    {ok, State1}.

--- a/priv/templates/plugin.template
+++ b/priv/templates/plugin.template
@@ -4,6 +4,7 @@
     {desc, "A rebar plugin", "Short description of the plugin's purpose"}
 ]}.
 {template, "plugin.erl", "{{name}}/src/{{name}}.erl"}.
+{template, "provider.erl", "{{name}}/src/prv_{{name}}_prv.erl"}.
 {template, "otp_lib.app.src", "{{name}}/src/{{name}}.app.src"}.
 {template, "rebar.config", "{{name}}/rebar.config"}.
 {template, "gitignore", "{{name}}/.gitignore"}.

--- a/priv/templates/provider.erl
+++ b/priv/templates/provider.erl
@@ -1,0 +1,32 @@
+-module('{{name}}_prv').
+
+-export([init/1, do/1, format_error/1]).
+
+-define(PROVIDER, '{{name}}').
+-define(DEPS, [app_discovery]).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    Provider = providers:create([
+            {name, ?PROVIDER},            % The 'user friendly' name of the task
+            {module, ?MODULE},            % The module implementation of the task
+            {bare, true},                 % The task can be run by the user, always true
+            {deps, ?DEPS},                % The list of dependencies
+            {example, "rebar3 {{name}}"}, % How to use the plugin
+            {opts, []},                   % list of options understood by the plugin
+            {short_desc, "{{desc}}"},
+            {desc, "{{desc}}"}
+    ]),
+    {ok, rebar_state:add_provider(State, Provider)}.
+
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    {ok, State}.
+
+-spec format_error(any()) ->  iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).


### PR DESCRIPTION
I think this makes it less confusing to start from a plugin template and implement a plugin with multiple providers.