### PR TITLE
Add proxy support to bootstrap and rebar3. Enhancement #561.

### DIFF
--- a/THANKS
+++ b/THANKS
@@ -134,3 +134,4 @@ Martin Karlsson
 Pierre Fenoll
 David Kubecka
 Stefan Grundmann
+Carlos Eduardo de Paula

--- a/bootstrap
+++ b/bootstrap
@@ -123,8 +123,6 @@ setHttpcOptions() ->
             Opts2 = Opts1
     end,
 
-    io:format("Opts: ~p~n", [Opts2]),
-
     case Opts2 of
         [] ->
             ok;

--- a/bootstrap
+++ b/bootstrap
@@ -94,7 +94,7 @@ request(Url) ->
             Error
     end.
 
-get_http_var() ->
+get_rebar_config() ->
     {ok, [[Home]]} = init:get_argument(home),
     ConfDir = filename:join(Home, ".config/rebar3"),
     case file:consult(filename:join(ConfDir, "rebar.config")) of
@@ -104,12 +104,12 @@ get_http_var() ->
             []
     end.
 
-get_http(Scheme) ->
-    proplists:get_value(Scheme, get_http_var(), []).
+get_http_vars(Scheme) ->
+    proplists:get_value(Scheme, get_rebar_config(), []).
 
 set_httpc_options() ->
-    set_httpc_options(https_proxy, get_http(https_proxy)),
-    set_httpc_options(proxy, get_http(http_proxy)).
+    set_httpc_options(https_proxy, get_http_vars(https_proxy)),
+    set_httpc_options(proxy, get_http_vars(http_proxy)).
 
 set_httpc_options(_, []) ->
     ok;

--- a/bootstrap
+++ b/bootstrap
@@ -82,6 +82,7 @@ extract(Binary) ->
     {ok, Contents}.
 
 request(Url) ->
+    setHttpcOptions(),
     case httpc:request(get, {Url, []},
                        [{relaxed, true}],
                        [{body_format, binary}]) of
@@ -89,6 +90,47 @@ request(Url) ->
             {ok, Body};
         Error ->
             Error
+    end.
+
+setHttpcOptions() ->
+    %% Get http_proxy and https_proxy environment variables
+    case os:getenv("http_proxy") of
+        false ->
+            Http = "";
+        Http ->
+            Http
+    end,
+    case os:getenv("https_proxy") of
+        false ->
+            Https = "";
+        Https ->
+            Https
+    end,
+
+    %% Parse the variables to extract host and port
+    Opts = [],
+    case http_uri:parse(Http) of
+        {ok,{_, [], Host, Port, _, []}} ->
+            Opts1 = Opts ++ [{proxy, {{Host, Port}, []}}];
+        {error, _} ->
+            Opts1 = Opts
+    end,
+
+    case http_uri:parse(Https) of
+        {ok,{_, [], Host2, Port2, _, []}} ->
+            Opts2 = Opts1 ++ [{https_proxy, {{Host2, Port2}, []}}];
+        {error, _} ->
+            Opts2 = Opts1
+    end,
+
+    io:format("Opts: ~p~n", [Opts2]),
+
+    case Opts2 of
+        [] ->
+            ok;
+        _ ->
+            httpc:set_options(Opts2),
+            ok
     end.
 
 compile(App, FirstFiles) ->

--- a/bootstrap
+++ b/bootstrap
@@ -9,6 +9,8 @@ main(_Args) ->
     application:start(public_key),
     application:start(ssl),
     inets:start(),
+    inets:start(httpc, [{profile, rebar}]),
+    set_httpc_options(),
 
     %% Fetch and build deps required to build rebar3
     BaseDeps = [{providers, []}
@@ -82,10 +84,10 @@ extract(Binary) ->
     {ok, Contents}.
 
 request(Url) ->
-    set_httpc_options(),
     case httpc:request(get, {Url, []},
                        [{relaxed, true}],
-                       [{body_format, binary}]) of
+                       [{body_format, binary}],
+                       rebar) of
         {ok, {{_Version, 200, _Reason}, _Headers, Body}} ->
             {ok, Body};
         Error ->
@@ -114,7 +116,7 @@ set_httpc_options(_, []) ->
 
 set_httpc_options(Scheme, Proxy) ->
     {ok, {_, _, Host, Port, _, _}} = http_uri:parse(Proxy),
-    httpc:set_options([{Scheme, {{Host, Port}, []}}]).
+    httpc:set_options([{Scheme, {{Host, Port}, []}}], rebar).
 
 compile(App, FirstFiles) ->
     Dir = filename:join(filename:absname("_build/default/lib/"), App),

--- a/bootstrap
+++ b/bootstrap
@@ -103,7 +103,7 @@ get_http_var() ->
     end.
 
 get_http(Scheme) ->
-    proplists:get_value(Scheme, get_http_var(), "").
+    proplists:get_value(Scheme, get_http_var(), []).
 
 set_httpc_options() ->
     set_httpc_options(https_proxy, get_http(https_proxy)),

--- a/bootstrap
+++ b/bootstrap
@@ -82,7 +82,7 @@ extract(Binary) ->
     {ok, Contents}.
 
 request(Url) ->
-    setHttpcOptions(),
+    set_httpc_options(),
     case httpc:request(get, {Url, []},
                        [{relaxed, true}],
                        [{body_format, binary}]) of
@@ -92,44 +92,29 @@ request(Url) ->
             Error
     end.
 
-setHttpcOptions() ->
-    %% Get http_proxy and https_proxy environment variables
-    case os:getenv("http_proxy") of
-        false ->
-            Http = "";
-        Http ->
-            Http
-    end,
-    case os:getenv("https_proxy") of
-        false ->
-            Https = "";
-        Https ->
-            Https
-    end,
-
-    %% Parse the variables to extract host and port
-    Opts = [],
-    case http_uri:parse(Http) of
-        {ok,{_, [], Host, Port, _, []}} ->
-            Opts1 = Opts ++ [{proxy, {{Host, Port}, []}}];
-        {error, _} ->
-            Opts1 = Opts
-    end,
-
-    case http_uri:parse(Https) of
-        {ok,{_, [], Host2, Port2, _, []}} ->
-            Opts2 = Opts1 ++ [{https_proxy, {{Host2, Port2}, []}}];
-        {error, _} ->
-            Opts2 = Opts1
-    end,
-
-    case Opts2 of
-        [] ->
-            ok;
+get_http_var() ->
+    {ok, [[Home]]} = init:get_argument(home),
+    ConfDir = filename:join(Home, ".config/rebar3"),
+    case file:consult(filename:join(ConfDir, "rebar.config")) of
+        {ok, Config} ->
+            Config;
         _ ->
-            httpc:set_options(Opts2),
-            ok
+            []
     end.
+
+get_http(Scheme) ->
+    proplists:get_value(Scheme, get_http_var(), "").
+
+set_httpc_options() ->
+    set_httpc_options(https_proxy, get_http(https_proxy)),
+    set_httpc_options(proxy, get_http(http_proxy)).
+
+set_httpc_options(_, []) ->
+    ok;
+
+set_httpc_options(Scheme, Proxy) ->
+    {ok, {_, _, Host, Port, _, _}} = http_uri:parse(Proxy),
+    httpc:set_options([{Scheme, {{Host, Port}, []}}]).
 
 compile(App, FirstFiles) ->
     Dir = filename:join(filename:absname("_build/default/lib/"), App),

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -273,5 +273,6 @@ start_and_load_apps() ->
     application:start(public_key),
     application:start(ssl),
     inets:start(),
-    inets:start(httpc),
+    inets:start(httpc, [{profile, rebar}]),
     rebar_utils:set_httpc_options().
+

--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -273,13 +273,5 @@ start_and_load_apps() ->
     application:start(public_key),
     application:start(ssl),
     inets:start(),
-    inets:start(httpc, [{profile, hex}]),
-    http_opts().
-
-http_opts() ->
-    Opts = [{max_sessions, 4},
-            {max_keep_alive_length, 4},
-            {keep_alive_timeout, 120000},
-            {max_pipeline_length, 4},
-            {pipeline_timeout, 60000}],
-    httpc:set_options(Opts, hex).
+    inets:start(httpc),
+    rebar_utils:set_httpc_options().

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -95,7 +95,8 @@ make_vsn(_) ->
 request(Url, ETag) ->
     case httpc:request(get, {Url, [{"if-none-match", ETag} || ETag =/= false]},
                        [{relaxed, true}],
-                       [{body_format, binary}]) of
+                       [{body_format, binary}],
+                       rebar) of
         {ok, {{_Version, 200, _Reason}, Headers, Body}} ->
             ?DEBUG("Successfully downloaded ~s", [Url]),
             {"etag", ETag1} = lists:keyfind("etag", 1, Headers),

--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -95,8 +95,7 @@ make_vsn(_) ->
 request(Url, ETag) ->
     case httpc:request(get, {Url, [{"if-none-match", ETag} || ETag =/= false]},
                        [{relaxed, true}],
-                       [{body_format, binary}],
-                       hex) of
+                       [{body_format, binary}]) of
         {ok, {{_Version, 200, _Reason}, Headers, Body}} ->
             ?DEBUG("Successfully downloaded ~s", [Url]),
             {"etag", ETag1} = lists:keyfind("etag", 1, Headers),

--- a/src/rebar_prv_update.erl
+++ b/src/rebar_prv_update.erl
@@ -43,7 +43,8 @@ do(State) ->
 
         Url = rebar_state:get(State, rebar_packages_cdn, "https://s3.amazonaws.com/s3.hex.pm/registry.ets.gz"),
         {ok, _RequestId} = httpc:request(get, {Url, []},
-                                         [], [{stream, TmpFile}, {sync, true}]),
+                                         [], [{stream, TmpFile}, {sync, true}],
+                                         rebar),
         {ok, Data} = file:read_file(TmpFile),
         Unzipped = zlib:gunzip(Data),
         ok = file:write_file(HexFile, Unzipped),

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -685,4 +685,4 @@ set_httpc_options(_, []) ->
 
 set_httpc_options(Scheme, Proxy) ->
     {ok, {_, _, Host, Port, _, _}} = http_uri:parse(Proxy),
-    httpc:set_options([{Scheme, {{Host, Port}, []}}]).
+    httpc:set_options([{Scheme, {{Host, Port}, []}}], rebar).

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -677,8 +677,8 @@ get_http(Scheme) ->
     proplists:get_value(Scheme, get_http_var(), []).
 
 set_httpc_options() ->
-    set_httpc_options(https_proxy, get_http(https_proxy)),
-    set_httpc_options(proxy, get_http(http_proxy)).
+    set_httpc_options(https_proxy, get_http_vars(https_proxy)),
+    set_httpc_options(proxy, get_http_vars(http_proxy)).
 
 set_httpc_options(_, []) ->
     ok;

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -674,7 +674,7 @@ get_http_var() ->
     end.
 
 get_http(Scheme) ->
-    proplists:get_value(Scheme, get_http_var(), "").
+    proplists:get_value(Scheme, get_http_var(), []).
 
 set_httpc_options() ->
     set_httpc_options(https_proxy, get_http(https_proxy)),

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -663,18 +663,10 @@ maybe_ends_in_comma(H) ->
         _           -> false
     end.
 
-get_http_var() ->
-    {ok, [[Home]]} = init:get_argument(home),
-    ConfDir = filename:join(Home, ".config/rebar3"),
-    case file:consult(filename:join(ConfDir, "rebar.config")) of
-        {ok, Config} ->
-            Config;
-        _ ->
-            []
-    end.
-
-get_http(Scheme) ->
-    proplists:get_value(Scheme, get_http_var(), []).
+get_http_vars(Scheme) ->
+    GlobalConfigFile = rebar_dir:global_config(),
+    Config = rebar_config:consult_file(GlobalConfigFile),
+    proplists:get_value(Scheme, Config, []).
 
 set_httpc_options() ->
     set_httpc_options(https_proxy, get_http_vars(https_proxy)),

--- a/test/rebar_deps_SUITE.erl
+++ b/test/rebar_deps_SUITE.erl
@@ -50,11 +50,14 @@ init_per_testcase(http_proxy_settings, Config) ->
     ]),
     rebar_test_utils:init_rebar_state(Config);
 init_per_testcase(https_proxy_settings, Config) ->
-    {OTPVersion, _} = string:to_integer(erlang:system_info(otp_release)),
-    case OTPVersion of
-        Vsn when Vsn =< 15 ->
+    SupportsHttpsProxy = case erlang:system_info(otp_release) of
+        "R16"++_ -> true;
+        "R"++_ -> false;
+        _ -> true % 17 and up don't have a "R" in the version
+    end,
+    if not SupportsHttpsProxy ->
             {skip, https_proxy_unsupported_before_R16};
-        _ ->
+       SupportsHttpsProxy ->
             %% Create private rebar.config
             Priv = ?config(priv_dir, Config),
             GlobalDir = filename:join(Priv, "global"),


### PR DESCRIPTION
Add proxy support to bootstrap and rebar3.

Either bootstrap and rebar3 now uses environment variables http_proxy and https_proxy to fetch dependency packages and hex plugins.

Enhancement #561.