### PR TITLE
remove `cover_print_enabled` and `cover_data_dir` config options and replace with `cover_opts`

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -83,14 +83,14 @@
 
 %% == Cover ==
 
-%% Whether to enable coverage reporting. Default is `false'
+%% Whether to enable coverage reporting where commands support cover. Default
+%% is `false'
 {cover_enabled, false}.
 
-%% Whether to print coverage report to console. Default is `false'
-{cover_print_enabled, false}.
+%% Options to pass to cover provider
+{cover_opts, [verbose]}.
 
-%% Directory to store collected cover data
-{cover_data_dir, "cover"}.
+%% == Dependencies ==
 
 %% What dependencies we have, dependencies can be of 3 forms, an application
 %% name as an atom, eg. mochiweb, a name and a version (from the .app file), or

--- a/src/rebar_prv_cover.erl
+++ b/src/rebar_prv_cover.erl
@@ -337,16 +337,24 @@ write_coverdata(State, Task) ->
             ?WARN("Cover data export failed: ~p", [Reason])
     end.
 
-verbose(State) ->
+command_line_opts(State) ->
     {Opts, _} = rebar_state:command_parsed_args(State),
-    case proplists:get_value(verbose, Opts, missing) of
-        missing -> rebar_state:get(State, cover_print_enabled, false);
-        Else -> Else
+    Opts.
+
+config_opts(State) ->
+    rebar_state:get(State, cover_opts, []).
+
+verbose(State) ->
+    Command = proplists:get_value(verbose, command_line_opts(State), undefined),
+    Config = proplists:get_value(verbose, config_opts(State), undefined),
+    case {Command, Config} of
+        {undefined, undefined} -> false;
+        {undefined, Verbose}   -> Verbose;
+        {Verbose, _}           -> Verbose
     end.
 
 cover_dir(State) ->
-    rebar_state:get(State, cover_data_dir, filename:join([rebar_dir:base_dir(State),
-                                                          "cover"])).
+    filename:join([rebar_dir:base_dir(State), "cover"]).
 
 cover_opts(_State) ->
     [{reset, $r, "reset", boolean, help(reset)},

--- a/test/rebar_cover_SUITE.erl
+++ b/test/rebar_cover_SUITE.erl
@@ -8,7 +8,6 @@
          flag_coverdata_written/1,
          config_coverdata_written/1,
          index_written/1,
-         config_alt_coverdir/1,
          flag_verbose/1,
          config_verbose/1]).
 
@@ -31,7 +30,6 @@ init_per_testcase(_, Config) ->
 all() ->
     [flag_coverdata_written, config_coverdata_written,
      index_written,
-     config_alt_coverdir,
      flag_verbose, config_verbose].
 
 flag_coverdata_written(Config) ->
@@ -79,23 +77,6 @@ index_written(Config) ->
 
     true = filelib:is_file(filename:join([AppDir, "_build", "test", "cover", "index.html"])).
 
-config_alt_coverdir(Config) ->
-    AppDir = ?config(apps, Config),
-
-    Name = rebar_test_utils:create_random_name("cover_"),
-    Vsn = rebar_test_utils:create_random_vsn(),
-    rebar_test_utils:create_eunit_app(AppDir, Name, Vsn, [kernel, stdlib]),
-
-    CoverDir = filename:join(["coverage", "goes", "here"]),
-
-    RebarConfig = [{erl_opts, [{d, some_define}]}, {cover_data_dir, CoverDir}],
-    rebar_test_utils:run_and_check(Config,
-                                   RebarConfig,
-                                   ["do", "eunit", "--cover", ",", "cover"],
-                                   {ok, [{app, Name}]}),
-
-    true = filelib:is_file(filename:join([CoverDir, "index.html"])).
-
 flag_verbose(Config) ->
     AppDir = ?config(apps, Config),
 
@@ -118,7 +99,7 @@ config_verbose(Config) ->
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_eunit_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
-    RebarConfig = [{erl_opts, [{d, some_define}]}, {cover_print_enabled, true}],
+    RebarConfig = [{erl_opts, [{d, some_define}]}, {cover_opts, [verbose]}],
     rebar_test_utils:run_and_check(Config,
                                    RebarConfig,
                                    ["do", "eunit", "--cover", ",", "cover"],


### PR DESCRIPTION
`{cover_print_enabled, true}` dropped in favour of `{ct_opts, [verbose]}`

`{cover_data_dir, "..."}` dropped for now. can be replaced with something in `ct_opts` if anyone complains it was dropped

addresses #576 