### PR TITLE
Run agent as current process & hibernate

### DIFF
--- a/src/rebar_agent.erl
+++ b/src/rebar_agent.erl
@@ -26,11 +26,11 @@ init(State) ->
 handle_call({cmd, Command}, _From, State=#state{state=RState, cwd=Cwd}) ->
     MidState = maybe_show_warning(State),
     {Res, NewRState} = run(default, Command, RState, Cwd),
-    {reply, Res, MidState#state{state=NewRState}};
+    {reply, Res, MidState#state{state=NewRState}, hibernate};
 handle_call({cmd, Namespace, Command}, _From, State = #state{state=RState, cwd=Cwd}) ->
     MidState = maybe_show_warning(State),
     {Res, NewRState} = run(Namespace, Command, RState, Cwd),
-    {reply, Res, MidState#state{state=NewRState}};
+    {reply, Res, MidState#state{state=NewRState}, hibernate};
 handle_call(_Call, _From, State) ->
     {noreply, State}.
 


### PR DESCRIPTION
This tries to reduce memory usage when running `rebar3 shell` by running
the agent in the current process (and avoiding to copy state
cross-boundaries), and using frequent hibernation after each run to
force a full GC and compaction of the current process.