### PR TITLE
Changed cases on robocopy so it uses variables in a better way

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -155,17 +155,17 @@ mv(Source, Dest) ->
                                       [{use_stdout, false}, abort_on_error]),
             ok;
         {win32, _} ->
-            case filelib:is_dir(Source) of
-                true ->
-                    Cmd = ?FMT("robocopy /move /s \"~s\" \"~s\" 1> nul",
-                             [filename:nativename(Source),
-                              filename:nativename(Dest)]);
-                false ->
-                    Cmd = ?FMT("robocopy /move /s \"~s\" \"~s\" \"~s\" 1> nul",
-                             [filename:nativename(filename:dirname(Source)),
-                              filename:nativename(Dest),
-                              filename:basename(Source)])
-            end,
+            Cmd = case filelib:is_dir(Source) of
+                      true ->
+                          ?FMT("robocopy /move /s \"~s\" \"~s\" 1> nul",
+                               [filename:nativename(Source),
+                                filename:nativename(Dest)]);
+                      false ->
+                          ?FMT("robocopy /move /s \"~s\" \"~s\" \"~s\" 1> nul",
+                               [filename:nativename(filename:dirname(Source)),
+                                filename:nativename(Dest),
+                                filename:basename(Source)])
+                  end,
             Res = rebar_utils:sh(Cmd,
                         [{use_stdout, false}, return_on_error]),
             case win32_ok(Res) of
@@ -257,17 +257,17 @@ delete_each_dir_win32([Dir | Rest]) ->
 xcopy_win32(Source,Dest)->
     %% "xcopy \"~s\" \"~s\" /q /y /e 2> nul", Chanegd to robocopy to
     %% handle long names. May have issues with older windows.
-    case filelib:is_dir(Source) of
-        true ->
-            Cmd = ?FMT("robocopy \"~s\" \"~s\" /e /is 1> nul",
-                     [filename:nativename(Source),
-                      filename:nativename(Dest)]);
-        false ->
-            Cmd = ?FMT("robocopy \"~s\" \"~s\" \"~s\" /e /is 1> nul",
-                     [filename:nativename(filename:dirname(Source)),
-                      filename:nativename(Dest),
-                      filename:basename(Source)])
-    end,
+    Cmd = case filelib:is_dir(Source) of
+              true ->
+                  ?FMT("robocopy \"~s\" \"~s\" /e /is 1> nul",
+                       [filename:nativename(Source),
+                        filename:nativename(Dest)]);
+              false ->
+                  ?FMT("robocopy \"~s\" \"~s\" \"~s\" /e /is 1> nul",
+                       [filename:nativename(filename:dirname(Source)),
+                        filename:nativename(Dest),
+                        filename:basename(Source)])
+          end,
     Res = rebar_utils:sh(Cmd,
                 [{use_stdout, false}, return_on_error]),
     case win32_ok(Res) of


### PR DESCRIPTION
Changed so that we don't use variables that are declared inside a case outside that case. 