### PR TITLE
Global plugin bug

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -285,6 +285,7 @@ get_deps() ->
     case file:consult("rebar.lock") of
         {ok, [[]]} ->
             %% Something went wrong in a previous build, lock file shouldn't be empty
+            io:format("Empty list in lock file, deleting rebar.lock~n"),
             ok = file:delete("rebar.lock"),
             {ok, Config} = file:consult("rebar.config"),
             proplists:get_value(deps, Config);

--- a/bootstrap
+++ b/bootstrap
@@ -61,8 +61,12 @@ main(_Args) ->
     end.
 
 fetch_and_compile({Name, ErlFirstFiles}, Deps) ->
-    {Name, _, Repo} = lists:keyfind(Name, 1, Deps),
-    ok = fetch(Repo, Name),
+    case lists:keyfind(Name, 1, Deps) of
+        {Name, Vsn} ->
+            ok = fetch({pkg, atom_to_binary(Name, utf8), list_to_binary(Vsn)}, Name);
+        {Name, _, Source} ->
+            ok = fetch(Source, Name)
+    end,
     compile(Name, ErlFirstFiles).
 
 fetch({pkg, Name, Vsn}, App) ->
@@ -279,6 +283,11 @@ write_windows_scripts() ->
 
 get_deps() ->
     case file:consult("rebar.lock") of
+        {ok, [[]]} ->
+            %% Something went wrong in a previous build, lock file shouldn't be empty
+            ok = file:delete("rebar.lock"),
+            {ok, Config} = file:consult("rebar.config"),
+            proplists:get_value(deps, Config);
         {ok, [Deps]} ->
             [{binary_to_atom(Name, utf8), "", Source} || {Name, Source, _Level} <- Deps];
         _ ->

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -289,7 +289,13 @@ apply_profiles(State, Profile) when not is_list(Profile) ->
 apply_profiles(State, [default]) ->
     State;
 apply_profiles(State=#state_t{default = Defaults, current_profiles=CurrentProfiles}, Profiles) ->
-    AppliedProfiles = deduplicate(CurrentProfiles ++ Profiles),
+    AppliedProfiles = case Profiles of
+                          [global | _] ->
+                              Profiles;
+                          _ ->
+                              deduplicate(CurrentProfiles ++ Profiles)
+                      end,
+
     ConfigProfiles = rebar_state:get(State, profiles, []),
 
     NewOpts =

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -290,6 +290,9 @@ apply_profiles(State, [default]) ->
     State;
 apply_profiles(State=#state_t{default = Defaults, current_profiles=CurrentProfiles}, Profiles) ->
     AppliedProfiles = case Profiles of
+                          %% Head of list global profile is special, only for use by rebar3
+                          %% It does not clash if a user does `rebar3 as global...` but when
+                          %% it is the head we must make sure not to prepend `default`
                           [global | _] ->
                               Profiles;
                           _ ->


### PR DESCRIPTION
Fixes https://github.com/rebar/rebar3/issues/608

Plugins installing plugins got wonky because of profile application changing the global profile to default/global.

Also threw in a fix for if a previous bootstrap goes bad and writes an empty lock file because you screw something up so it doesn't find deps (I did).