### PR TITLE
add tree option to deps command that prints pkg deps tree

### DIFF
--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -61,7 +61,7 @@ merge_deps(AppInfo, State) ->
     State1 = lists:foldl(fun(Profile, StateAcc) ->
                                  AppProfDeps = rebar_state:get(AppState, {deps, Profile}, []),
                                  TopLevelProfDeps = rebar_state:get(StateAcc, {deps, Profile}, []),
-                                 ProfDeps2 = dedup(rebar_utils:tup_umerge(
+                                 ProfDeps2 = rebar_utils:tup_dedup(rebar_utils:tup_umerge(
                                                      rebar_utils:tup_sort(TopLevelProfDeps)
                                                      ,rebar_utils:tup_sort(AppProfDeps))),
                                  rebar_state:set(StateAcc, {deps, Profile}, ProfDeps2)
@@ -155,11 +155,6 @@ create_app_info(AppDir, AppFile) ->
                     false
             end,
     rebar_app_info:dir(rebar_app_info:valid(AppInfo1, Valid), AppDir).
-
-dedup([]) -> [];
-dedup([A]) -> [A];
-dedup([H,H|T]) -> dedup([H|T]);
-dedup([H|T]) -> [H|dedup(T)].
 
 %% Read in and parse the .app file if it is availabe. Do the same for
 %% the .app.src file if it exists.

--- a/src/rebar_prv_deps.erl
+++ b/src/rebar_prv_deps.erl
@@ -24,7 +24,7 @@ init(State) ->
                     {short_desc, "List dependencies"},
                     {desc, "List dependencies. Those not matching lock files "
                            "are followed by an asterisk (*)."},
-                    {opts, [{tree, $t, "tree", undefined, "Display dependencies in tree format."}]}])),
+                    {opts, [{tree, $t, "tree", undefined, "Display package dependencies in tree format (git and hg deps not supported)."}]}])),
     {ok, State1}.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -36,6 +36,7 @@
 -include_lib("providers/include/providers.hrl").
 
 -export([handle_deps_as_profile/4,
+         parse_deps/5,
          find_cycles/1,
          cull_compile/2]).
 
@@ -122,7 +123,6 @@ handle_deps_as_profile(Profile, State, Deps, Upgrade) ->
     Locks = [],
     Level = 0,
     DepsDir = profile_dep_dir(State, Profile),
-
     {SrcDeps, PkgDeps} = parse_deps(DepsDir, Deps, State, Locks, Level),
     AllSrcProfileDeps = [{Profile, SrcDeps, Locks, Level}],
     AllPkgProfileDeps = [{Profile, Locks, PkgDeps, Level}],
@@ -511,7 +511,7 @@ parse_dep({Name, Vsn}, {SrcDepsAcc, PkgDepsAcc}, DepsDir, IsLock, State) when is
             {SrcDepsAcc, [parse_goal(ec_cnv:to_binary(Name)
                                     ,ec_cnv:to_binary(Vsn)) | PkgDepsAcc]}
     end;
-parse_dep(Name, {SrcDepsAcc, PkgDepsAcc}, DepsDir, IsLock, State) when is_atom(Name) ->
+parse_dep(Name, {SrcDepsAcc, PkgDepsAcc}, DepsDir, IsLock, State) when is_atom(Name); is_binary(Name) ->
     %% Unversioned package dependency
     {PkgName, PkgVsn} = get_package(ec_cnv:to_binary(Name), State),
     CheckoutsDir = ec_cnv:to_list(rebar_dir:checkouts_dir(State, Name)),

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -54,6 +54,8 @@
          expand_env_variable/3,
          get_arch/0,
          wordsize/0,
+         deps_to_binary/1,
+         tup_dedup/1,
          tup_umerge/2,
          tup_sort/1,
          tup_find/2,
@@ -235,6 +237,30 @@ erl_opts(Config) ->
 %% note: this does not handle the case where you have an argument that
 %%  was enclosed in quotes and might have commas but should not be split.
 args_to_tasks(Args) -> new_task(Args, []).
+
+deps_to_binary([]) ->
+    [];
+deps_to_binary([{Name, _, Source} | T]) ->
+    [{ec_cnv:to_binary(Name), Source} | deps_to_binary(T)];
+deps_to_binary([{Name, Source} | T]) ->
+    [{ec_cnv:to_binary(Name), Source} | deps_to_binary(T)];
+deps_to_binary([Name | T]) ->
+    [ec_cnv:to_binary(Name) | deps_to_binary(T)].
+
+tup_dedup([]) ->
+    [];
+tup_dedup([A]) ->
+    [A];
+tup_dedup([A,B|T]) when element(1, A) =:= element(1, B) ->
+    tup_dedup([A | T]);
+tup_dedup([A,B|T]) when element(1, A) =:= B ->
+    tup_dedup([A | T]);
+tup_dedup([A,B|T]) when A =:= element(1, B) ->
+    tup_dedup([A | T]);
+tup_dedup([A,A|T]) ->
+    [A|tup_dedup(T)];
+tup_dedup([A|T]) ->
+    [A|tup_dedup(T)].
 
 %% Sort the list in proplist-order, meaning that `{a,b}' and `{a,c}'
 %% both compare as usual, and `a' and `b' do the same, but `a' and `{a,b}' will


### PR DESCRIPTION
If a digraph is passed to `cull_deps` it keeps track of the solution which can be printed out with `rebar3 deps -t`.

Additionally, to make this possible without duplicates, there are some fixes for unneeded duplicates in deps list that gets passed around, which caused no issues for install because it had a proper order but wasted resources and caused issues with `deps -t`.