### PR TITLE
Revert "don't add `{extra_src_dirs, ["test"]}` to `test` profile"

### DIFF
--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -141,7 +141,7 @@ copy_app_dirs(State, OldAppDir, AppDir) ->
             end,
 
             %% link to src_dirs to be adjacent to ebin is needed for R15 use of cover/xref
-            SrcDirs = rebar_dir:all_src_dirs(State, ["src"], ["test"]),
+            SrcDirs = rebar_dir:all_src_dirs(State, ["src"], []),
             [symlink_or_copy(OldAppDir, AppDir, Dir) || Dir <- ["priv", "include"] ++ SrcDirs];
         false ->
             ok


### PR DESCRIPTION
i'm reasonably certain that this is safe to revert (fixing #568 and #575) as it was a fix for an issue with common_test loading the wrong tests that i think was actually caused by the regression in #440 or made irrelevant by #474 

i can't reproduce the common_test problem either way