### PR TITLE
keep plugins in path after compile provider run

### DIFF
--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -63,7 +63,8 @@ do(State) ->
     rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State2),
     has_all_artifacts(State3),
 
-    rebar_utils:cleanup_code_path(rebar_state:code_paths(State3, default)),
+    rebar_utils:cleanup_code_path(rebar_state:code_paths(State3, default)
+                                 ++ rebar_state:code_paths(State, all_plugin_deps)),
 
     {ok, State3}.
 


### PR DESCRIPTION
Need to ensure all plugins are in the code path after a compile provider run. Before this fix depending on when a plugin provider was added and if there were hooks declared (hooks also remove paths after running) would cause providers that run post compile to become undefined.