### PR TITLE
Fix for the place rebar3 shell loads config file.

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -270,7 +270,7 @@ find_config_relx(State) ->
 
 -spec consult_config(rebar_state:t(), string()) -> {ok, [tuple()]}|{error, tuple()}.
 consult_config(State, Filename) ->
-    Fullpath = filename:join(rebar_dir:root_dir(State), Filename),
+    Fullpath = filename:join(rebar_state:dir(State), Filename),
     ?DEBUG("Loading configuration from ~p", [Fullpath]),
     case rebar_file_utils:try_consult(Fullpath) of
         [T] -> T;

--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -129,6 +129,8 @@ setup_shell() ->
     end.
 
 setup_paths(State) ->
+    %% Change working directory for the project root
+    file:set_cwd(rebar_state:dir(State)),
     %% Add deps to path
     code:add_pathsa(rebar_state:code_paths(State, all_deps)),
     %% add project app test paths


### PR DESCRIPTION
Fix for the rebar3 shell command where the sys.config file (read from relx config in rebar.config) is read from the wrong root.

Previously the file was read from:

```
1> ===> Loading configuration from "/Users/carlosedp/projects/dcca-server-OTP/_build/default/lib/lager/./config/sys.config"
===> The rebar3 shell is a development tool; to deploy applications in production, consider using releases (http://www.rebar3.org/v3.0/docs/releases)
```

With the fix, the file is read from right place:
```
1> ===> Loading configuration from "/Users/carlosedp/projects/dcca-server-OTP/config/sys.config"
```
