### PR TITLE
Tidy up "Linking.." messages during compile

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -73,7 +73,7 @@ symlink_or_copy(Source, Target) ->
         ok ->
             ok;
         {error, eexist} ->
-            ok;
+            exists;
         {error, _} ->
             case os:type() of
                 {win32, _} ->


### PR DESCRIPTION
See #634 

Linking message will only be printed the first time the link or copy
actually happens.

Note:

rebar_file_utils:symlink_or_copy will now return 'exists'
instead of ok, if it did nothing because the link exists.

Nothing was checking the return value yet, so seemed reasonable.