### PR TITLE
Fix plugin upgrade when plugin mentioned only by its name

### DIFF
--- a/src/rebar_prv_plugins_upgrade.erl
+++ b/src/rebar_prv_plugins_upgrade.erl
@@ -97,7 +97,10 @@ find(Plugin, [Plugin1 | Plugins]) when is_tuple(Plugin1) ->
             Plugin1;
         false ->
             find(Plugin, Plugins)
-    end.
+    end;
+find(Plugin, [_Plugin | Plugins]) ->
+    find(Plugin, Plugins).
+
 
 build_plugin(AppInfo, Apps, State) ->
     Providers = rebar_state:providers(State),


### PR DESCRIPTION
```
λ cat ~/.config/rebar3/rebar.config
{plugins, [rebar3_hex]}.
```
```
λ grep plugins rebar.config
{plugins, [rebar3_live]}.
```
```
λ env DEBUG=1 rebar3 plugins upgrade rebar3_hex
===> Load global config file /Users/mao/.config/rebar3/rebar.config
===> Uncaught error in rebar_core. Run with DEBUG=1 to see stacktrace
===> Uncaught error: function_clause
===> Stack trace to the error location: [{rebar_prv_plugins_upgrade,
                                                 find,
                                                 [rebar3_hex,[rebar3_live]],
                                                 [{file,
                                                   "/Volumes/Private/src/rebar3/_build/default/lib/rebar/src/rebar_prv_plugins_upgrade.erl"},
                                                  {line,90}]},
                                                {rebar_prv_plugins_upgrade,
                                                 '-find_plugin/3-fun-0-',3,
                                                 [{file,
                                                   "/Volumes/Private/src/rebar3/_build/default/lib/rebar/src/rebar_prv_plugins_upgrade.erl"},
                                                  {line,82}]},
                                                {ec_lists,search,2,
                                                 [{file,
                                                   "/Volumes/Private/src/rebar3/_build/default/lib/erlware_commons/src/ec_lists.erl"},
                                                  {line,29}]},
                                                {rebar_prv_plugins_upgrade,
                                                 upgrade,2,
                                                 [{file,
                                                   "/Volumes/Private/src/rebar3/_build/default/lib/rebar/src/rebar_prv_plugins_upgrade.erl"},
                                                  {line,53}]},
                                                {rebar_core,do,2,
                                                 [{file,
                                                   "/Volumes/Private/src/rebar3/_build/default/lib/rebar/src/rebar_core.erl"},
                                                  {line,124}]},
                                                {rebar_prv_do,do_tasks,2,
                                                 [{file,
                                                   "/Volumes/Private/src/rebar3/_build/default/lib/rebar/src/rebar_prv_do.erl"},
                                                  {line,68}]},
                                                {rebar_core,do,2,
                                                 [{file,
                                                   "/Volumes/Private/src/rebar3/_build/default/lib/rebar/src/rebar_core.erl"},
                                                  {line,124}]},
                                                {rebar3,main,1,
                                                 [{file,
                                                   "/Volumes/Private/src/rebar3/_build/default/lib/rebar/src/rebar3.erl"},
                                                  {line,47}]}]
===> When submitting a bug report, please include the output of `rebar3 report "your command"`
```
```
Rebar3 report
 version 3.0.0-beta-1
 generated at 2015-07-24T07:32:02+00:00
=================
Please submit this along with your issue at https://github.com/rebar/rebar3/issues (and feel free to edit out private information, if any)
-----------------
Task: pluginsupgraderebar3_hex
Entered as:
  pluginsupgraderebar3_hex
-----------------
Operating System: x86_64-apple-darwin13.4.0
ERTS: Erlang/OTP 17 [erts-6.4] [source] [64-bit] [smp:4:4] [async-threads:0] [hipe] [kernel-poll:false] [dtrace]
Root Directory: /usr/local/Cellar/erlang/17.5/lib/erlang
Library directory: /usr/local/Cellar/erlang/17.5/lib/erlang/lib
-----------------
Loaded Applications:
bbmustache: 1.0.3
common_test: 1.10
compiler: 5.0.4
crypto: 3.5
erlware_commons: 0.15.0
eunit: 2.2.9
inets: 5.10.6
kernel: 3.2
providers: 1.4.1
relx: 3.4.0
sasl: 2.4.1
ssl_verify_hostname: 1.0.5
stdlib: 2.4
syntax_tools: 1.6.18
tools: 2.7.2

-----------------
Escript path: /Users/mao/.p/bin/rebar3
Providers:
  app_discovery as clean compile config cover ct cut deps dialyzer do docs edoc escriptize eunit help info install_deps key list live lock new owner pkgs publish release relup report search shell tar unlock update upgrade upgrade user version xref
```