### PR TITLE
keep correct Level for pkg deps of scm deps

### DIFF
--- a/src/rebar_digraph.erl
+++ b/src/rebar_digraph.erl
@@ -2,7 +2,7 @@
 
 -export([compile_order/1
         ,restore_graph/1
-        ,cull_deps/2
+        ,cull_deps/3
         ,subgraph/2
         ,format_error/1]).
 
@@ -68,12 +68,12 @@ restore_graph({Vs, Es}) ->
 %% Pick packages to fullfill dependencies
 %% The first dep while traversing the graph is chosen and any conflicting
 %% dep encountered later on is ignored.
-cull_deps(Graph, Vertices) ->
+cull_deps(Graph, Vertices, Level) ->
     cull_deps(Graph,
               Vertices,
-              1,
+              Level+1,
               lists:foldl(fun({Key, _}, Levels) ->
-                                  dict:store(Key, 0, Levels)
+                                  dict:store(Key, Level, Levels)
                           end, dict:new(), Vertices),
               lists:foldl(fun({Key, _}=N, Solution) ->
                                   dict:store(Key, N, Solution)


### PR DESCRIPTION
This is a fix for https://github.com/rebar/rebar3/issues/674

The issue was that all the "collected" package deps, whether from parsing `rebar.config` at the top level or parsing the `rebar.config` of a git dep would end up being considered at level 0. This patch stores the actual Level with the package deps so the lock file is correct.