### PR TITLE
Fix description in "rebar3 new"

### DIFF
--- a/src/rebar_prv_new.erl
+++ b/src/rebar_prv_new.erl
@@ -70,7 +70,7 @@ info() ->
       "Create rebar3 project based on template and vars.~n"
       "~n"
       "Valid command line options:~n"
-      "  template= [var=foo,...]~n", []).
+      "  <template> [var=foo,...]~n", []).
 
 is_forced(State) ->
     {Args, _} = rebar_state:command_parsed_args(State),


### PR DESCRIPTION
`template` is not a kv-style argument, but a plain argument. If you give `template=app` on the command line, you get "template not found."