### PR TITLE
Enable lock provider as a user command

### DIFF
--- a/src/rebar_prv_lock.erl
+++ b/src/rebar_prv_lock.erl
@@ -19,11 +19,11 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, false},
+                                                               {bare, true},
                                                                {deps, ?DEPS},
-                                                               {example, ""},
-                                                               {short_desc, "Locks dependencies."},
-                                                               {desc, "Locks dependencies"},
+                                                               {example, "rebar3 lock"},
+                                                               {short_desc, "Fetch and locks dependencies."},
+                                                               {desc, "Fetch and locks dependencies"},
                                                                {opts, []}])),
     {ok, State1}.
 


### PR DESCRIPTION
Some user may want to fetch and lock dependancies in a first time, before compiling. 