### PR TITLE
Allow hooks to modify State

### DIFF
--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -10,33 +10,34 @@
                    atom() | {atom(), atom()} | string(),
                    [providers:t()], rebar_state:t()) -> ok.
 run_all_hooks(Dir, Type, Command, Providers, State) ->
-    run_provider_hooks(Dir, Type, Command, Providers, State),
-    run_hooks(Dir, Type, Command, State).
+    {ok, State1} = run_provider_hooks(Dir, Type, Command, Providers, State),
+    run_hooks(Dir, Type, Command, State1),
+    {ok, State1}.
 
 run_provider_hooks(Dir, Type, Command, Providers, State) ->
     case rebar_state:get(State, provider_hooks, []) of
         [] ->
-            ok;
+            {ok, State};
         AllHooks ->
             TypeHooks = proplists:get_value(Type, AllHooks, []),
             run_provider_hooks(Dir, Type, Command, Providers, TypeHooks, State)
     end.
 
-run_provider_hooks(_Dir, _Type, _Command, _Providers, [], _State) ->
-    ok;
+run_provider_hooks(_Dir, _Type, _Command, _Providers, [], State) ->
+    {ok, State};
 run_provider_hooks(Dir, Type, Command, Providers, TypeHooks, State) ->
     PluginDepsPaths = rebar_state:code_paths(State, all_plugin_deps),
     code:add_pathsa(PluginDepsPaths),
     Providers1 = rebar_state:providers(State),
     State1 = rebar_state:providers(rebar_state:dir(State, Dir), Providers++Providers1),
     HookProviders = proplists:get_all_values(Command, TypeHooks),
-
     case rebar_core:do(HookProviders, State1) of
         {error, ProviderName} ->
             ?DEBUG(format_error({bad_provider, Type, Command, ProviderName}), []),
             throw(?PRV_ERROR({bad_provider, Type, Command, ProviderName}));
-        {ok, _} ->
-            rebar_utils:remove_from_code_path(PluginDepsPaths)
+        {ok, State2} ->
+            rebar_utils:remove_from_code_path(PluginDepsPaths),
+            {ok, State2}
     end.
 
 format_error({bad_provider, Type, Command, {Name, Namespace}}) ->

--- a/src/rebar_prv_clean.erl
+++ b/src/rebar_prv_clean.erl
@@ -50,11 +50,9 @@ do(State) ->
     clean_apps(EmptyState, Providers, DepApps),
 
     Cwd = rebar_dir:get_cwd(),
-    rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
-    clean_apps(State, Providers, ProjectApps),
-    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State),
-
-    {ok, State}.
+    {ok, State1} = rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
+    clean_apps(State1, Providers, ProjectApps),
+    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State1).
 
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->
@@ -70,9 +68,10 @@ clean_apps(State, Providers, Apps) ->
                           S = rebar_app_info:state_or_new(State, AppInfo),
 
                           ?INFO("Cleaning out ~s...", [rebar_app_info:name(AppInfo)]),
-                          rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER, Providers, S),
-                          rebar_erlc_compiler:clean(State, rebar_app_info:out_dir(AppInfo)),
-                          rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, S)
+                          {ok, S1} = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER, Providers, S),
+                          rebar_erlc_compiler:clean(S1, rebar_app_info:out_dir(AppInfo)),
+                          rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, S1),
+                          ok
                   end, Apps).
 
 handle_args(State) ->

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -43,20 +43,20 @@ do(State) ->
     %% Run ct provider prehooks
     Providers = rebar_state:providers(State),
     Cwd = rebar_dir:get_cwd(),
-    rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
+    {ok, State1} = rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
 
-    try run_test(State) of
-        {ok, State1} = Result ->
+    try run_test(State1) of
+        {ok, State2} = Result ->
             %% Run ct provider posthooks
-            rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State1),
-            rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
+            {ok, State3} = rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State2),
+            rebar_utils:cleanup_code_path(rebar_state:code_paths(State3, default)),
             Result;
         ?PRV_ERROR(_) = Error ->
-            rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
+            rebar_utils:cleanup_code_path(rebar_state:code_paths(State1, default)),
             Error
     catch
         throw:{error, Reason} ->
-            rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
+            rebar_utils:cleanup_code_path(rebar_state:code_paths(State1, default)),
             ?PRV_ERROR(Reason)
     end.
 

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -52,21 +52,22 @@ do(State) ->
     {ok, ProjectApps1} = rebar_digraph:compile_order(ProjectApps),
 
     %% Run top level hooks *before* project apps compiled but *after* deps are
-    rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
+    {ok, State1} = rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
 
-    ProjectApps2 = build_apps(State, Providers, ProjectApps1),
-    State2 = rebar_state:project_apps(State, ProjectApps2),
+    ProjectApps2 = build_apps(State1, Providers, ProjectApps1),
+    State2 = rebar_state:project_apps(State1, ProjectApps2),
 
     ProjAppsPaths = [filename:join(rebar_app_info:out_dir(X), "ebin") || X <- ProjectApps2],
     State3 = rebar_state:code_paths(State2, all_deps, DepsPaths ++ ProjAppsPaths),
 
-    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State2),
-    has_all_artifacts(State3),
+    {ok, State4} = rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State3),
 
-    rebar_utils:cleanup_code_path(rebar_state:code_paths(State3, default)
-                                 ++ rebar_state:code_paths(State, all_plugin_deps)),
+    has_all_artifacts(State4),
 
-    {ok, State3}.
+    rebar_utils:cleanup_code_path(rebar_state:code_paths(State4, default)
+                                 ++ rebar_state:code_paths(State4, all_plugin_deps)),
+
+    {ok, State4}.
 
 -spec format_error(any()) -> iolist().
 format_error({missing_artifact, File}) ->
@@ -89,13 +90,13 @@ build_app(State, Providers, AppInfo) ->
 compile(State, Providers, AppInfo) ->
     ?INFO("Compiling ~s", [rebar_app_info:name(AppInfo)]),
     AppDir = rebar_app_info:dir(AppInfo),
-    rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER,  Providers, State),
-
-    rebar_erlc_compiler:compile(State, ec_cnv:to_list(rebar_app_info:out_dir(AppInfo))),
-    case rebar_otp_app:compile(State, AppInfo) of
+    {ok, State1} = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER, Providers, State),
+    rebar_erlc_compiler:compile(State1, ec_cnv:to_list(rebar_app_info:out_dir(AppInfo))),
+    case rebar_otp_app:compile(State1, AppInfo) of
         {ok, AppInfo1} ->
-            rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, State),
-            has_all_artifacts(State),
+            State2 = rebar_state:project_apps(State1, [AppInfo1]),
+            {ok, State3} = rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, State2),
+            has_all_artifacts(State3),
             AppInfo1;
         Error ->
             throw(Error)

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -42,22 +42,22 @@ do(State) ->
     %% Run eunit provider prehooks
     Providers = rebar_state:providers(State),
     Cwd = rebar_dir:get_cwd(),
-    rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
+    {ok, State1} = rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
 
-    case prepare_tests(State) of
+    case prepare_tests(State1) of
         {ok, Tests} ->
-            case do_tests(State, Tests) of
-                {ok, State1} ->
+            case do_tests(State1, Tests) of
+                {ok, State2} ->
                     %% Run eunit provider posthooks
-                    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State1),
-                    rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
-                    {ok, State1};
+                    {ok, State3} = rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State2),
+                    rebar_utils:cleanup_code_path(rebar_state:code_paths(State3, default)),
+                    {ok, State3};
                 Error ->
-                    rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
+                    rebar_utils:cleanup_code_path(rebar_state:code_paths(State1, default)),
                     Error
             end;
         Error ->
-            rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
+            rebar_utils:cleanup_code_path(rebar_state:code_paths(State1, default)),
             Error
     end.
 

--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -23,9 +23,9 @@ do(Module, Command, Provider, State) ->
     AllOptions = string:join([Command | Options], " "),
     Cwd = rebar_state:dir(State),
     Providers = rebar_state:providers(State),
-    rebar_hooks:run_all_hooks(Cwd, pre, Provider, Providers, State),
+    {ok, State1} = rebar_hooks:run_all_hooks(Cwd, pre, Provider, Providers, State),
     try
-        case rebar_state:get(State, relx, []) of
+        case rebar_state:get(State1, relx, []) of
             [] ->
                 relx:main([{lib_dirs, LibDirs}
                           ,{caller, api} | output_dir(OutputDir, Options)], AllOptions);
@@ -35,8 +35,7 @@ do(Module, Command, Provider, State) ->
                           ,{config, Config1}
                           ,{caller, api} | output_dir(OutputDir, Options)], AllOptions)
         end,
-        rebar_hooks:run_all_hooks(Cwd, post, Provider, Providers, State),
-        {ok, State}
+        rebar_hooks:run_all_hooks(Cwd, post, Provider, Providers, State1)
     catch
         throw:T ->
             {error, {Module, T}}


### PR DESCRIPTION
Implements what we discussed in #680 

1. umbrella project
 1. top-level hooks run before and after the entire provider; these may impact the state of the full provider
 2. per-app hooks run before and after the compile/clean/whatever for the app only; no impact on state
 3. per-dep hooks run before and after the compile/clean/whatever step for the dep only; these only impact the local state for the dep
2. single app project 
  1. per-app hooks run before and after the compile/clean/whatever for the app only; no impact on state
  2. per-dep hooks run before and after the compile/clean/whatever step for the dep only; these only 
