### PR TITLE
Tree provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ locations ([hex.pm](http://hex.pm), git, hg, and so on).
 | report     | Report on environment and versions for bug reports |
 | shell      | Run shell with project apps in path |
 | tar        | Package release into tarball |
+| tree       | Print dependency tree |
 | unlock     | Unlock dependencies |
 | update     | Update package index |
 | upgrade    | Fetch latest version of dep |

--- a/priv/shell-completion/bash/rebar3
+++ b/priv/shell-completion/bash/rebar3
@@ -15,6 +15,7 @@ _rebar3()
             compile \
             cover \
             ct \
+            deps \
             dialyzer \
             do \
             edoc \
@@ -29,6 +30,7 @@ _rebar3()
             report \
             shell \
             tar \
+            tree \
             unlock \
             update \
             upgrade \
@@ -77,6 +79,8 @@ _rebar3()
             --basic_html \
             --ct_hooks \
             --verbose"
+    elif [[ ${prev} == deps ]] ; then
+        :
     elif [[ ${prev} == dialyzer ]] ; then
         sopts="-u -s"
         lopts="--update-plt --succ-typings"
@@ -168,6 +172,9 @@ _rebar3()
             --system_libs \
             --version \
             --root"
+    elif [[ ${prev} == tree ]] ; then
+        sopts="-v"
+        lopts="--verbose"
     elif [[ ${prev} == update ]] ; then
         :
     elif [[ ${prev} == upgrade ]] ; then

--- a/priv/shell-completion/fish/rebar3.fish
+++ b/priv/shell-completion/fish/rebar3.fish
@@ -50,6 +50,7 @@ end
 ## report            Provide a crash report to be sent to the rebar3 issues page.
 ## shell             Run shell with project apps and deps in path.
 ## tar               Tar archive of release built of project.
+## tree              Print dependency tree.
 ## unlock            Unlock dependencies.
 ## update            Update package index.
 ## upgrade           Upgrade dependencies.
@@ -149,6 +150,10 @@ complete -f -c 'rebar3' -n '__fish_rebar3_using_command tar' -l system_libs     
 complete -f -c 'rebar3' -n '__fish_rebar3_using_command tar' -l version            -d "Print relx version"
 complete -f -c 'rebar3' -n '__fish_rebar3_using_command tar' -s r -l root          -d "The project root directory"
 
+complete -f -c 'rebar3' -n '__fish_rebar3_needs_command' -a tree -d "Print depdency tree."
+
+complete -f -c 'rebar3' -n '__fish_rebar3_needs_command tree' -s v -l verbose  -d "Print repo and branch/tag/ref for git and hg deps."
+
 complete -f -c 'rebar3' -n '__fish_rebar3_needs_command' -a unlock -d "Unlock dependencies."
 
 complete -f -c 'rebar3' -n '__fish_rebar3_needs_command' -a update -d "Update package index."
@@ -158,4 +163,3 @@ complete -f -c 'rebar3' -n '__fish_rebar3_needs_command' -a upgrade -d "Upgrade 
 complete -f -c 'rebar3' -n '__fish_rebar3_needs_command' -a version -d "Print version for rebar and current Erlang."
 
 complete -f -c 'rebar3' -n '__fish_rebar3_needs_command' -a xref -d "Run cross reference analysis."
-

--- a/priv/shell-completion/zsh/_rebar3
+++ b/priv/shell-completion/zsh/_rebar3
@@ -191,6 +191,11 @@ _rebar3 () {
                         '(-r --root)'{-r,--root}'[The project root directory]:system libs:_files -/' \
                     && ret=0
                 ;;
+                (tree)
+                    _arguments \
+                        '(-v --verbose)'{-v,--verbose}'[Print repo and branch/tag/ref for git and hg deps]' \
+                    && ret=0
+                ;;
                 (unlock)
                     _arguments \
                         '*: :_rebar3_list_deps' \
@@ -236,6 +241,7 @@ _rebar3_tasks() {
         'report:Provide a crash report to be sent to the rebar3 issues page.'
         'shell:Run shell with project apps and deps in path.'
         'tar:Tar archive of release built of project.'
+        'tree:Print dependency tree.'
         'unlock:Unlock dependencies.'
         'update:Update package index.'
         'upgrade:Upgrade dependencies.'

--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -23,7 +23,7 @@
                   erlware_commons,
                   providers,
                   bbmustache,
-		  ssl_verify_hostname,
+          ssl_verify_hostname,
                   relx,
                   inets]},
   {env, [
@@ -41,6 +41,7 @@
                      rebar_prv_compile,
                      rebar_prv_cover,
                      rebar_prv_deps,
+                     rebar_prv_deps_tree,
                      rebar_prv_dialyzer,
                      rebar_prv_do,
                      rebar_prv_edoc,

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -17,6 +17,8 @@
          app_file/2,
          app_details/1,
          app_details/2,
+         parent/1,
+         parent/2,
          original_vsn/1,
          original_vsn/2,
          ebin_dir/1,
@@ -54,6 +56,7 @@
                      app_file           :: file:filename_all() | undefined,
                      config             :: rebar_state:t() | undefined,
                      original_vsn       :: binary() | string() | undefined,
+                     parent             :: binary() | root,
                      app_details=[]     :: list(),
                      applications=[]    :: list(),
                      deps=[]            :: list(),
@@ -202,6 +205,13 @@ app_details(#app_info_t{app_details=AppDetails}) ->
 -spec app_details(t(), list()) -> t().
 app_details(AppInfo=#app_info_t{}, AppDetails) ->
     AppInfo#app_info_t{app_details=AppDetails}.
+
+parent(#app_info_t{parent=Parent}) ->
+    Parent.
+
+-spec parent(t(), binary() | root) -> t().
+parent(AppInfo=#app_info_t{}, Parent) ->
+    AppInfo#app_info_t{parent=Parent}.
 
 -spec original_vsn(t()) -> string().
 original_vsn(#app_info_t{original_vsn=Vsn}) ->

--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -1,0 +1,79 @@
+-module(rebar_prv_deps_tree).
+
+-behaviour(provider).
+
+-export([init/1,
+         do/1,
+         format_error/1]).
+
+-include("rebar.hrl").
+
+-define(PROVIDER, tree).
+-define(DEPS, [lock]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    State1 = rebar_state:add_provider(
+               State,
+               providers:create([{name, ?PROVIDER},
+                                 {module, ?MODULE},
+                                 {bare, true},
+                                 {deps, ?DEPS},
+                                 {example, "rebar3 tree"},
+                                 {short_desc, "Print dependency tree."},
+                                 {desc, ""},
+                                 {opts, [{verbose, $v, "verbose", undefined, "Print repo and branch/tag/ref for git and hg deps"}]}])),
+    {ok, State1}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    {Args, _} = rebar_state:command_parsed_args(State),
+    Verbose = proplists:get_value(verbose, Args, false),
+    print_deps_tree(rebar_state:all_deps(State), Verbose),
+    {ok, State}.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+%% Internal functions
+
+print_deps_tree(SrcDeps, Verbose) ->
+    D = lists:foldl(fun(App, Dict) ->
+                            Name = rebar_app_info:name(App),
+                            Vsn = rebar_app_info:original_vsn(App),
+                            Source  = rebar_app_info:source(App),
+                            Parent = rebar_app_info:parent(App),
+                            dict:append_list(Parent, [{Name, Vsn, Source}], Dict)
+                    end, dict:new(), SrcDeps),
+    case dict:find(root, D) of
+        {ok, Children} ->
+            print_children(-1, lists:keysort(1, Children), D, Verbose);
+        error ->
+            none
+    end.
+
+print_children(_, [], _, _) ->
+    ok;
+print_children(Indent, [{Name, Vsn, Source} | Rest], Dict, Verbose) ->
+
+    [io:format("|  ") || _ <- lists:seq(0, Indent, 2)],
+    io:format("|- "),
+    io:format("~s-~s (~s)~n", [Name, Vsn, type(Source, Verbose)]),
+    case dict:find(Name, Dict) of
+        {ok, Children} ->
+            print_children(Indent+2, lists:keysort(1, Children), Dict, Verbose),
+            print_children(Indent, Rest, Dict, Verbose);
+        error ->
+            print_children(Indent, Rest, Dict, Verbose)
+    end.
+
+type(Source, Verbose) when is_tuple(Source) ->
+    case {element(1, Source), Verbose} of
+        {pkg, _} ->
+            "hex package";
+        {Other, false} ->
+            io_lib:format("~s repo", [Other]);
+        {_, true} ->
+            io_lib:format("~s", [element(2, Source)])
+    end.


### PR DESCRIPTION
This requires https://github.com/rebar/rebar3/pull/706 be merged first.

The change for this PR is the addition of the `tree` provider. I split it out from `deps` because it depends on the dependencies getting installed and and `deps` does not. So the `-t` option is removed from `deps`.

Example output on the project `project-fifo/howl`:

```
|- clique-0.0.0+build.140.ref8067df5 (git repo)
|- cowboy-1.0.1 (git repo)
|  |- cowlib-1.0.0 (git repo)
|  |- ranch-1.0.0 (git repo)
|- cuttlefish-0.0.0+build.479.reff5f6fdc (git repo)
|  |- getopt-0.4.3 (git repo)
|  |- neotoma-0.0.0+build.125.ref760928e (git repo)
|- edown-0.2.4+build.98.refb7c8eb0 (git repo)
|- eper-0.87.0 (git repo)
|- fifo_spec-0.1.17 (git repo)
|  |- fifo_dt-0.1.48 (git repo)
|  |  |- riak_dt-0.0.0+build.307.reff7981d4 (git repo)
|- fifo_utils-0.1.12 (git repo)
|- folsom_ddb-0.1.14 (hex package)
|  |- ddb_client-0.1.6 (hex package)
|- jsx-1.4.3 (git repo)
|- jsxd-0.1.10 (hex package)
|- lager-2.0.3 (git repo)
|  |- goldrush-0.1.6 (git repo)
|- lager_watchdog-0.1.8 (git repo)
|- libsnarl-0.3.21 (git repo)
|  |- oauth2-0.6.0 (git repo)
|- mdns_server_lib-0.1.19 (git repo)
|  |- mdns_server-0.1.1 (hex package)
|- msgpack-0.2.3 (git repo)
|- recon-2.2.1 (git repo)
|- riak_core-0.0.0+build.1758.refaf8cc7b (git repo)
|  |- basho_stats-1.0.3 (git repo)
|  |- chash-0.1.1 (git repo)
|  |- eleveldb-0.0.0+build.494.refa36dbd6 (git repo)
|  |- exometer_core-0.0.0+build.19.refb47a5d6 (git repo)
|  |  |- folsom-0.0.0+build.292.ref7294452 (git repo)
|  |  |  |- bear-0.0.0+build.11.refda820a1 (git repo)
|  |  |- parse_trans-0.0.0+build.106.ref82cc002 (git repo)
|  |  |- setup-0.0.0+build.79.ref51ee7c9 (git repo)
|  |- pbkdf2-0.0.0+build.2676.ref7076584 (git repo)
|  |- poolboy-0.0.0+build.124.ref8bb45fb (git repo)
|  |- riak_sysmon-2.0.0 (git repo)
|- riak_ensemble-0.0.0+build.113.refe0652c6 (git repo)
|- wiggle-0.6.2 (git repo)
|  |- cowboy_oauth-0.2.3 (git repo)
|  |  |- erlydtl-0.0.0+build.757.reff8602ca (git repo)
|  |  |  |- eunit_formatters-0.0.0+build.32.ref2c73eb6 (git repo)
|  |  |- merl-1 (git repo)
|  |- dqe-0.1.10 (hex package)
|  |  |- dflow-0.1.3 (hex package)
|  |  |- dproto-0.1.7 (hex package)
|  |  |- mmath-0.1.6 (hex package)
|  |- e2qc-1.0 (git repo)
|  |- eplugin-0.1.4 (git repo)
|  |- fifo_s3-0.1.10 (git repo)
|  |  |- base16-0.0.0+build.9.ref1e9dd28 (git repo)
|  |  |- erlcloud-0.8.6 (git repo)
|  |- fqc-0.1.5 (hex package)
|  |- jesse-1.1.5 (git repo)
|  |- libchunter-0.1.38 (git repo)
|  |- libsnarlmatch-0.1.5 (hex package)
|  |- libsniffle-0.3.22 (git repo)
|  |- mdns_client_lib-0.1.24 (hex package)
|  |  |- mdns_client-0.1.3 (hex package)
|  |  |- pooler-1.4.0 (hex package)
|  |- meck-0.8.2 (git repo)
|  |- uuid-0.4.6 (git repo)
```