### PR TITLE
[WIP] Add tests for mixed deps installs

### DIFF
--- a/test/mock_git_resource.erl
+++ b/test/mock_git_resource.erl
@@ -20,7 +20,8 @@ mock() -> mock([]).
             | {override_vsn, [{App, Vsn}]}
             | {deps, [{App, [Dep]}]},
     App :: string(),
-    Dep :: {App, string(), {git, string()} | {git, string(), term()}},
+    Dep :: {App, string(), {git, string()} | {git, string(), term()}}
+         | {pkg, App, term()},
     Vsn :: string().
 mock(Opts) ->
     meck:new(?MOD, [no_link]),
@@ -46,8 +47,8 @@ mock_lock(_) ->
             case Git of
                 {git, Url, {tag, Ref}} -> {git, Url, {ref, Ref}};
                 {git, Url, {ref, Ref}} -> {git, Url, {ref, Ref}};
-                {git, Url} -> {git, Url, {ref, "fake-ref"}};
-                {git, Url, _} -> {git, Url, {ref, "fake-ref"}}
+                {git, Url} -> {git, Url, {ref, "0.0.0"}};
+                {git, Url, _} -> {git, Url, {ref, "0.0.0"}}
             end
         end).
 

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -544,7 +544,8 @@ only_default_transitive_deps(Config) ->
 
     GitDeps = rebar_test_utils:expand_deps(git, [{"a", "1.0.0", []}]),
     PkgName = rebar_test_utils:create_random_name("pkg1_"),
-    mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(GitDeps)},
+    {SrcDeps, _} = rebar_test_utils:flat_deps(GitDeps),
+    mock_git_resource:mock([{deps, SrcDeps},
                             {config, [{profiles, [{test, [{deps, [list_to_atom(PkgName)]}]}]}]}]),
 
     mock_pkg_resource:mock([{pkgdeps, [{{iolist_to_binary(PkgName), <<"0.1.0">>}, []}]}]),

--- a/test/rebar_install_deps_SUITE.erl
+++ b/test/rebar_install_deps_SUITE.erl
@@ -218,10 +218,11 @@ mdeps(m_pick_source2) ->
      ["d"],
      {ok, ["b", "C", "D"]}};
 mdeps(m_pick_source3) ->
+    %% The order of declaration is important.
     {[{"b", []},
       {"B", []}],
-     ["b"],
-     {ok, ["B"]}};
+     ["B"],
+     {ok, ["b"]}};
 mdeps(m_pick_source4) ->
     {[{"B", []},
       {"b", []}],

--- a/test/rebar_install_deps_SUITE.erl
+++ b/test/rebar_install_deps_SUITE.erl
@@ -470,7 +470,7 @@ m_pkg_src_override(Config) ->
     rebar_test_utils:run_and_check(
         Config, RebarConfig, ["lock"],
         {error, {rebar_prv_install_deps,
-                 {source_dep_in_pkg, [<<"C">>,<<"b">>]}}}
+                 {package_dep_override, <<"b">>}}}
     ).
 
 run(Config) ->

--- a/test/rebar_install_deps_SUITE.erl
+++ b/test/rebar_install_deps_SUITE.erl
@@ -4,16 +4,24 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("kernel/include/file.hrl").
 
-all() -> [{group, git}, {group, pkg}].
+all() -> [{group, git}, {group, pkg}, {group, mixed}].
 
 groups() ->
-    [{all, [], [flat, pick_highest_left, pick_highest_right,
-                pick_smallest1, pick_smallest2,
-                circular1, circular2, circular_skip,
-                fail_conflict, default_profile, nondefault_profile,
-                nondefault_pick_highest]},
-     {git, [], [{group, all}]},
-     {pkg, [], [{group, all}]}].
+    [{unique, [], [flat, pick_highest_left, pick_highest_right,
+                   pick_smallest1, pick_smallest2,
+                   circular1, circular2, circular_skip,
+                   fail_conflict, default_profile, nondefault_profile,
+                   nondefault_pick_highest]},
+     {git, [], [{group, unique}]},
+     {pkg, [], [{group, unique}]},
+     {mixed, [], [
+        m_flat1, m_flat2, m_circular1, m_circular2, m_circular3,
+        m_pick_source1, m_pick_source2, m_pick_source3,
+        m_pick_source4, m_pick_source5, m_source_to_pkg,
+        m_pkg_level1, m_pkg_level2,
+        m_pkg_src_override
+     ]}
+    ].
 
 init_per_suite(Config) ->
     application:start(meck),
@@ -26,19 +34,33 @@ init_per_group(git, Config) ->
     [{deps_type, git} | Config];
 init_per_group(pkg, Config) ->
     [{deps_type, pkg} | Config];
+init_per_group(mixed, Config) ->
+    [{deps_type, mixed} | Config];
 init_per_group(_, Config) ->
     Config.
 
 end_per_group(_, Config) ->
     Config.
 
-init_per_testcase(Case, Config) ->
+init_per_testcase(Case, Config) when is_atom(Case) ->
+    DepsType = ?config(deps_type, Config),
+    init_per_testcase({DepsType, Case}, Config);
+init_per_testcase({mixed, Case}, Config) ->
+    {Deps, Warnings, Expect} = mdeps(Case),
+    Expected = case Expect of
+        {ok, List} -> {ok, format_expected_mdeps(List)};
+        Other -> Other
+    end,
+    mock_warnings(),
+    [{expect, Expected},
+     {warnings, format_expected_mixed_warnings(Warnings)}
+    | setup_project(Case, Config, rebar_test_utils:expand_deps(mixed, Deps))];
+init_per_testcase({DepsType, Case}, Config) ->
     {Deps, Warnings, Expect} = deps(Case),
     Expected = case Expect of
         {ok, List} -> {ok, format_expected_deps(List)};
         Other -> Other
     end,
-    DepsType = ?config(deps_type, Config),
     mock_warnings(),
     [{expect, Expected},
      {warnings, Warnings}
@@ -53,6 +75,32 @@ format_expected_deps(Deps) ->
         {N,V} -> [{dep, N, V}, {lock, N, V}];
         N -> [{dep, N}, {lock, N}]
     end || Dep <- Deps]).
+
+format_expected_mdeps(Deps) ->
+    %% for mixed deps, lowercase is a package, uppercase is source.
+    %% We can't check which was used from the dep, but the lock contains
+    %% the type and we can use that information.
+    lists:append([
+    case Dep of
+        {N,V} when hd(N) >= $a, hd(N) =< $z ->
+             UN = string:to_upper(N),
+             [{dep, UN, V}, {lock, pkg, UN, V}];
+        {N,V} when hd(N) >= $A, hd(N) =< $Z ->
+             [{dep, N, V}, {lock, src, N, V}];
+        N when hd(N) >= $a, hd(N) =< $z ->
+             UN = string:to_upper(N),
+             [{dep, UN}, {lock, pkg, UN, "0.0.0"}];
+        N when hd(N) >= $A, hd(N) =< $Z ->
+             [{dep, N}, {lock, src, N, "0.0.0"}]
+    end || Dep <- Deps]).
+
+format_expected_mixed_warnings(Warnings) ->
+    [case W of
+        {N, Vsn} when hd(N) >= $a, hd(N) =< $z -> {pkg, string:to_upper(N), Vsn};
+        {N, Vsn} when hd(N) >= $A, hd(N) =< $Z -> {src, N, Vsn};
+        N when hd(N) >= $a, hd(N) =< $z -> {pkg, string:to_upper(N), "0.0.0"};
+        N when hd(N) >= $A, hd(N) =< $Z -> {src, N, "0.0.0"}
+     end || W <- Warnings].
 
 %% format:
 %% {Spec,
@@ -131,6 +179,78 @@ deps(nondefault_pick_highest) ->
     %% This is all handled in setup_project
     {[],[],{ok,[]}}.
 
+%% format:
+%% Same as `deps/1' except "A" is a source dep
+%% and "a" is a package dep.
+mdeps(m_flat1) ->
+    {[{"c", []},
+      {"B", []}],
+     [],
+     {ok, ["B","c"]}};
+mdeps(m_flat2) ->
+    {[{"B", []},
+      {"c", []}],
+     [],
+     {ok, ["B","c"]}};
+mdeps(m_circular1) ->
+    {[{"b", [{"a",[]}]}], % "A" is the top app
+     [],
+     {error, {rebar_prv_install_deps, {cycles, [[<<"A">>,<<"B">>]]}}}};
+mdeps(m_circular2) ->
+    {[{"B", [{"c", [{"b", []}]}]}],
+     [],
+     {error, {rebar_prv_install_deps, {cycles, [[<<"B">>,<<"C">>]]}}}};
+mdeps(m_circular3) ->
+    %% Spot the circular dep due to being to low in the deps tree
+    %% but as a source dep, taking precedence over packages
+    {[{"B", [{"C", "2", [{"B", []}]}]},
+      {"c", "1", [{"d",[]}]}],
+     [],
+     {error, {rebar_prv_install_deps, {cycles, [[<<"B">>,<<"C">>]]}}}};
+mdeps(m_pick_source1) ->
+    {[{"B", [{"D", []}]},
+      {"c", [{"d", []}]}],
+     ["d"],
+     {ok, ["B", "c", "D"]}};
+mdeps(m_pick_source2) ->
+    {[{"b", [{"d", []}]},
+      {"C", [{"D", []}]}],
+     ["d"],
+     {ok, ["b", "C", "D"]}};
+mdeps(m_pick_source3) ->
+    {[{"b", []},
+      {"B", []}],
+     ["b"],
+     {ok, ["B"]}};
+mdeps(m_pick_source4) ->
+    {[{"B", []},
+      {"b", []}],
+     ["b"],
+     {ok, ["B"]}};
+mdeps(m_pick_source5) ->
+    {[{"B", [{"d", []}]},
+      {"C", [{"D", []}]}],
+     ["d"],
+     {ok, ["B", "C", "D"]}};
+mdeps(m_source_to_pkg) ->
+    {[{"B", [{"c",[{"d", []}]}]}],
+     [],
+     {ok, ["B", "c", "d"]}};
+mdeps(m_pkg_level1) ->
+    {[{"B", [{"D", [{"e", "2", []}]}]},
+      {"C", [{"e", "1", []}]}],
+     [{"e","2"}],
+     {ok, ["B","C","D",{"e","1"}]}};
+mdeps(m_pkg_level2) ->
+    {[{"B", [{"e", "1", []}]},
+      {"C", [{"D", [{"e", "2", []}]}]}],
+     [{"e","2"}],
+     {ok, ["B","C","D",{"e","1"}]}};
+mdeps(m_pkg_src_override) ->
+    %% This is all handled in setup_project
+    {[],[],{ok,[]}}.
+
+
 setup_project(fail_conflict, Config0, Deps) ->
     DepsType = ?config(deps_type, Config0),
     Config = rebar_test_utils:init_rebar_state(
@@ -142,12 +262,9 @@ setup_project(fail_conflict, Config0, Deps) ->
     TopDeps = rebar_test_utils:top_level_deps(Deps),
     RebarConf = rebar_test_utils:create_config(AppDir, [{deps, TopDeps},
                                                         {deps_error_on_conflict, true}]),
-    case DepsType of
-        git ->
-            mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(Deps)}]);
-        pkg ->
-            mock_pkg_resource:mock([{pkgdeps, rebar_test_utils:flat_pkgdeps(Deps)}])
-    end,
+    {SrcDeps, PkgDeps} = rebar_test_utils:flat_deps(Deps),
+    mock_git_resource:mock([{deps, SrcDeps}]),
+    mock_pkg_resource:mock([{pkgdeps, PkgDeps}]),
     [{rebarconfig, RebarConf} | Config];
 setup_project(nondefault_profile, Config0, Deps) ->
     DepsType = ?config(deps_type, Config0),
@@ -161,12 +278,9 @@ setup_project(nondefault_profile, Config0, Deps) ->
     RebarConf = rebar_test_utils:create_config(AppDir, [{profiles, [
                                                             {nondef, [{deps, TopDeps}]}
                                                        ]}]),
-    case DepsType of
-        git ->
-            mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(Deps)}]);
-        pkg ->
-            mock_pkg_resource:mock([{pkgdeps, rebar_test_utils:flat_pkgdeps(Deps)}])
-    end,
+    {SrcDeps, PkgDeps} = rebar_test_utils:flat_deps(Deps),
+    mock_git_resource:mock([{deps, SrcDeps}]),
+    mock_pkg_resource:mock([{pkgdeps, PkgDeps}]),
     [{rebarconfig, RebarConf} | Config];
 setup_project(nondefault_pick_highest, Config0, _) ->
     DepsType = ?config(deps_type, Config0),
@@ -187,14 +301,29 @@ setup_project(nondefault_pick_highest, Config0, _) ->
     ),
     case DepsType of
         git ->
-            mock_git_resource:mock(
-                [{deps, rebar_test_utils:flat_deps(DefaultDeps ++ ProfileDeps)}]
-            );
+            {SrcDeps, _} = rebar_test_utils:flat_deps(DefaultDeps++ProfileDeps),
+            mock_git_resource:mock([{deps, SrcDeps}]);
         pkg ->
-            mock_pkg_resource:mock(
-                [{pkgdeps, rebar_test_utils:flat_pkgdeps(DefaultDeps ++ ProfileDeps)}]
-            )
+            {_, PkgDeps} = rebar_test_utils:flat_deps(DefaultDeps++ProfileDeps),
+            mock_pkg_resource:mock([{pkgdeps, PkgDeps}])
     end,
+    [{rebarconfig, RebarConf} | Config];
+setup_project(m_pkg_src_override, Config0, _) ->
+    Config = rebar_test_utils:init_rebar_state(Config0, "m_pkg_src_override_mixed_"),
+    AppDir = ?config(apps, Config),
+    rebar_test_utils:create_app(AppDir, "A", "0.0.0", [kernel, stdlib]),
+    DefaultDeps = rebar_test_utils:expand_deps(mixed, [{"b", [{"c", []}]}]),
+    OverrideDeps = rebar_test_utils:expand_deps(mixed, [{"C", []}]),
+    DefaultTop = rebar_test_utils:top_level_deps(DefaultDeps),
+    OverrideTop = rebar_test_utils:top_level_deps(OverrideDeps),
+    RebarConf = rebar_test_utils:create_config(
+            AppDir,
+            [{deps, DefaultTop},
+             {overrides, [{override, b, [{deps, OverrideTop}]}]}]
+    ),
+    {SrcDeps,PkgDeps} = rebar_test_utils:flat_deps(DefaultDeps++OverrideDeps),
+    mock_git_resource:mock([{deps, SrcDeps}]),
+    mock_pkg_resource:mock([{pkgdeps, PkgDeps}]),
     [{rebarconfig, RebarConf} | Config];
 setup_project(Case, Config0, Deps) ->
     DepsType = ?config(deps_type, Config0),
@@ -206,12 +335,9 @@ setup_project(Case, Config0, Deps) ->
     rebar_test_utils:create_app(AppDir, "A", "0.0.0", [kernel, stdlib]),
     TopDeps = rebar_test_utils:top_level_deps(Deps),
     RebarConf = rebar_test_utils:create_config(AppDir, [{deps, TopDeps}]),
-    case DepsType of
-        git ->
-            mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(Deps)}]);
-        pkg ->
-            mock_pkg_resource:mock([{pkgdeps, rebar_test_utils:flat_pkgdeps(Deps)}])
-    end,
+    {SrcDeps, PkgDeps} = rebar_test_utils:flat_deps(Deps),
+    mock_git_resource:mock([{deps, SrcDeps}]),
+    mock_pkg_resource:mock([{pkgdeps, PkgDeps}]),
     [{rebarconfig, RebarConf} | Config].
 
 mock_warnings() ->
@@ -319,6 +445,33 @@ nondefault_pick_highest(Config) ->
         {ok, [{dep, "B"}, {lock, "B"}, {lock, "C", "1"}, {dep, "C", "2"}], "nondef"}
     ).
 
+m_flat1(Config) -> run(Config).
+m_flat2(Config) -> run(Config).
+m_circular1(Config) -> run(Config).
+m_circular2(Config) -> run(Config).
+m_circular3(Config) -> run(Config).
+m_pick_source1(Config) -> run(Config).
+m_pick_source2(Config) -> run(Config).
+m_pick_source3(Config) -> run(Config).
+m_pick_source4(Config) -> run(Config).
+m_pick_source5(Config) -> run(Config).
+m_source_to_pkg(Config) -> run(Config).
+m_pkg_level1(Config) -> run(Config).
+m_pkg_level2(Config) -> run(Config).
+
+
+m_pkg_src_override(Config) ->
+    %% Detect the invalid override where a package dep's are overriden
+    %% with source dependencies. We only test with overrides because
+    %% we trust the package index to be correct there and not introduce
+    %% that kind of error.
+    {ok, RebarConfig} = file:consult(?config(rebarconfig, Config)),
+    rebar_test_utils:run_and_check(
+        Config, RebarConfig, ["lock"],
+        {error, {rebar_prv_install_deps,
+                 {source_dep_in_pkg, [<<"C">>,<<"b">>]}}}
+    ).
+
 run(Config) ->
     {ok, RebarConfig} = file:consult(?config(rebarconfig, Config)),
     rebar_test_utils:run_and_check(
@@ -336,6 +489,10 @@ error_calls() ->
 
 check_warnings(_, [], _) ->
     ok;
+check_warnings(Warns, [{Type, Name, Vsn} | Rest], mixed) ->
+    ct:pal("Checking for warning ~p in ~p", [{Name,Vsn},Warns]),
+    ?assert(in_warnings(Type, Warns, Name, Vsn)),
+    check_warnings(Warns, Rest, mixed);
 check_warnings(Warns, [{Name, Vsn} | Rest], Type) ->
     ct:pal("Checking for warning ~p in ~p", [{Name,Vsn},Warns]),
     ?assert(in_warnings(Type, Warns, Name, Vsn)),

--- a/test/rebar_plugins_SUITE.erl
+++ b/test/rebar_plugins_SUITE.erl
@@ -45,7 +45,8 @@ compile_plugins(Config) ->
     PluginName = rebar_test_utils:create_random_name("plugin1_"),
 
     Plugins = rebar_test_utils:expand_deps(git, [{PluginName, Vsn, []}]),
-    mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(Plugins)}]),
+    {SrcDeps, _} = rebar_test_utils:flat_deps(Plugins),
+    mock_git_resource:mock([{deps, SrcDeps}]),
 
     mock_pkg_resource:mock([{pkgdeps, [{{list_to_binary(DepName), list_to_binary(Vsn)}, []}]},
                             {config, [{plugins, [
@@ -137,7 +138,8 @@ complex_plugins(Config) ->
     Deps = rebar_test_utils:expand_deps(git, [{PluginName, Vsn2, [{DepName2, Vsn,
                                                                   [{DepName3, Vsn, []}]}]}
                                              ,{DepName, Vsn, []}]),
-    mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(Deps)}]),
+    {SrcDeps, _} = rebar_test_utils:flat_deps(Deps),
+    mock_git_resource:mock([{deps, SrcDeps}]),
 
     RConfFile =
         rebar_test_utils:create_config(AppDir,

--- a/test/rebar_profiles_SUITE.erl
+++ b/test/rebar_profiles_SUITE.erl
@@ -57,7 +57,8 @@ profile_new_key(Config) ->
 
     AllDeps = rebar_test_utils:expand_deps(git, [{"a", "1.0.0", []}
                                                 ,{"b", "1.0.0", []}]),
-    mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(AllDeps)}]),
+    {SrcDeps, []} = rebar_test_utils:flat_deps(AllDeps),
+    mock_git_resource:mock([{deps, SrcDeps}]),
 
     Name = rebar_test_utils:create_random_name("profile_new_key_"),
     Vsn = rebar_test_utils:create_random_vsn(),
@@ -82,7 +83,8 @@ profile_merge_keys(Config) ->
     AllDeps = rebar_test_utils:expand_deps(git, [{"a", "1.0.0", []}
                                                 ,{"b", "1.0.0", []}
                                                 ,{"b", "2.0.0", []}]),
-    mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(AllDeps)}]),
+    {SrcDeps, []} = rebar_test_utils:flat_deps(AllDeps),
+    mock_git_resource:mock([{deps, SrcDeps}]),
 
     Name = rebar_test_utils:create_random_name("profile_new_key_"),
     Vsn = rebar_test_utils:create_random_vsn(),
@@ -111,7 +113,8 @@ explicit_profile_deduplicate_deps(Config) ->
                                                 ,{"a", "2.0.0", []}
                                                 ,{"b", "1.0.0", []}
                                                 ,{"b", "2.0.0", []}]),
-    mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(AllDeps)}]),
+    {SrcDeps, []} = rebar_test_utils:flat_deps(AllDeps),
+    mock_git_resource:mock([{deps, SrcDeps}]),
 
     Name = rebar_test_utils:create_random_name("explicit_profile_deduplicate_deps_"),
     Vsn = rebar_test_utils:create_random_vsn(),
@@ -141,7 +144,8 @@ implicit_profile_deduplicate_deps(Config) ->
                                                 ,{"a", "2.0.0", []}
                                                 ,{"b", "1.0.0", []}
                                                 ,{"b", "2.0.0", []}]),
-    mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(AllDeps)}]),
+    {SrcDeps, []} = rebar_test_utils:flat_deps(AllDeps),
+    mock_git_resource:mock([{deps, SrcDeps}]),
 
     Name = rebar_test_utils:create_random_name("implicit_profile_deduplicate_deps_"),
     Vsn = rebar_test_utils:create_random_vsn(),
@@ -169,7 +173,8 @@ all_deps_code_paths(Config) ->
 
     AllDeps = rebar_test_utils:expand_deps(git, [{"a", "1.0.0", []}
                                                 ,{"b", "2.0.0", []}]),
-    mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(AllDeps)}]),
+    {SrcDeps, []} = rebar_test_utils:flat_deps(AllDeps),
+    mock_git_resource:mock([{deps, SrcDeps}]),
 
     Name = rebar_test_utils:create_random_name("all_deps_code_paths"),
     Vsn = rebar_test_utils:create_random_vsn(),

--- a/test/rebar_upgrade_SUITE.erl
+++ b/test/rebar_upgrade_SUITE.erl
@@ -425,17 +425,21 @@ upgrades(compile_upgrade_parity) ->
 
 mock_deps(git, Deps, Upgrades) ->
     catch mock_git_resource:unmock(),
-    mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(Deps)}, {upgrade, Upgrades}]);
+    {SrcDeps, _} = rebar_test_utils:flat_deps(Deps),
+    mock_git_resource:mock([{deps, SrcDeps}, {upgrade, Upgrades}]);
 mock_deps(pkg, Deps, Upgrades) ->
     catch mock_pkg_resource:unmock(),
-    mock_pkg_resource:mock([{pkgdeps, rebar_test_utils:flat_pkgdeps(Deps)}, {upgrade, Upgrades}]).
+    {_, PkgDeps} = rebar_test_utils:flat_deps(Deps),
+    mock_pkg_resource:mock([{pkgdeps, PkgDeps}, {upgrade, Upgrades}]).
 
 mock_deps(git, OldDeps, Deps, Upgrades) ->
     catch mock_git_resource:unmock(),
-    mock_git_resource:mock([{deps, rebar_test_utils:flat_deps(Deps++OldDeps)}, {upgrade, Upgrades}]);
+    {SrcDeps, _} = rebar_test_utils:flat_deps(Deps++OldDeps),
+    mock_git_resource:mock([{deps, SrcDeps}, {upgrade, Upgrades}]);
 mock_deps(pkg, OldDeps, Deps, Upgrades) ->
     catch mock_pkg_resource:unmock(),
-    mock_pkg_resource:mock([{pkgdeps, rebar_test_utils:flat_pkgdeps(Deps++OldDeps)}, {upgrade, Upgrades}]).
+    {_, PkgDeps} = rebar_test_utils:flat_deps(Deps++OldDeps),
+    mock_pkg_resource:mock([{pkgdeps, PkgDeps}, {upgrade, Upgrades}]).
 
 normalize_unlocks({App, Locks}) ->
     {iolist_to_binary(App),


### PR DESCRIPTION
Requires a rework of other test suites using the same dep-handling
mechanism.

Will be useful to find issues with mixed dependencies.

Currently:
- missing warnings when a pkg dep is skipped because of a source dep
- if a pkg dep and a src dep of the same name are used at the top-level, we apparently keep them in an order that disregards "source always wins". May not be a bug?
- overriden source dep onto a package is silently ignored rather than erroring out.