### PR TITLE
fix leaking ets tables caused by digraphs

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -165,7 +165,8 @@ doterl_compile(Config, Dir, OutDir, MoreSources, ErlOpts) ->
     {DepErls, OtherErls} = lists:partition(
                              fun(Source) -> digraph:in_degree(G, Source) > 0 end,
                              [File || File <- NeededErlFiles, not lists:member(File, ErlFirstFiles)]),
-    DepErlsOrdered = digraph_utils:topsort(digraph_utils:subgraph(G, DepErls)),
+    SubGraph = digraph_utils:subgraph(G, DepErls),
+    DepErlsOrdered = digraph_utils:topsort(SubGraph),
     FirstErls = ErlFirstFiles ++ lists:reverse(DepErlsOrdered),
     ?DEBUG("Files to compile first: ~p", [FirstErls]),
     rebar_base_compiler:run(
@@ -177,6 +178,8 @@ doterl_compile(Config, Dir, OutDir, MoreSources, ErlOpts) ->
                          end,
               internal_erl_compile(C, Dir, S, OutDir1, ErlOpts1)
       end),
+    true = digraph:delete(SubGraph),
+    true = digraph:delete(G),
     ok.
 
 %% Get files which need to be compiled first, i.e. those specified in erl_first_files

--- a/src/rebar_prv_update.erl
+++ b/src/rebar_prv_update.erl
@@ -59,6 +59,7 @@ do(State) ->
         ok = file:write_file(HexFile, Unzipped),
         {Dict, Graph} = hex_to_graph(HexFile),
         write_registry(Dict, Graph, State),
+        true = digraph:delete(Graph),
         ok
     catch
         _E:C ->


### PR DESCRIPTION
After starting `rebar3 shell` there is a lots of `ets` tables that belongs to some digraphs. 
```
 45086           hex_registry      set   4323   243631   rebar_agent
 98335           vertices          set   3495   58249    rebar_agent
 102432          edges             set   368    11684    rebar_agent
 106529          neighbours        bag   738    16482    rebar_agent
 110626          hex_registry      set   4323   243631   rebar_agent
 114723          vertices          set   4      346      rebar_agent
 118820          edges             set   5      393      rebar_agent
 122917          neighbours        bag   12     472      rebar_agent
 135208          vertices          set   16     468      rebar_agent
 139305          edges             set   36     931      rebar_agent
 143402          neighbours        bag   74     1413     rebar_agent
 155691          vertices          set   5      355      rebar_agent
 159788          edges             set   6      407      rebar_agent
 163885          neighbours        bag   14     499      rebar_agent
 176174          vertices          set   2      609      rebar_agent
 180271          edges             set   0      305      rebar_agent
 184368          neighbours        bag   2      319      rebar_agent
 196657          vertices          set   0      305      rebar_agent
 200754          edges             set   0      305      rebar_agent
 204851          neighbours        bag   2      319      rebar_agent
 217140          vertices          set   20     3293     rebar_agent
 221237          edges             set   13     3848     rebar_agent
 225334          neighbours        bag   28     4031     rebar_agent
 290871          vertices          set   0      305      rebar_agent
 294968          edges             set   0      305      rebar_agent
 299065          neighbours        bag   2      319      rebar_agent
```
And more annoying is that they grow in number after each invocation of `rebar3:run(["compile"]).`, `rebar3:run(PreviousState, ["compile"]).` This patch limits amount of such tables to just three which corresponds to the graph stored in rebar's state.
```
 45086           hex_registry      set   4323   243631   rebar_agent
 98335           vertices          set   3495   58249    rebar_agent
 102432          edges             set   368    11684    rebar_agent
 106529          neighbours        bag   738    16482    rebar_agent
 110626          hex_registry      set   4323   243631   rebar_agent
```
There is still left two copies of `hex_registry` but I didn't found what causes it. And this patch does not fix `rebar_agent:do(compile)` each invocation of it duplicates all five tables.


