### PR TITLE
don't store deps list with duplicate in state

### DIFF
--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -26,12 +26,13 @@ do(State, LibDirs) ->
     State1 = lists:foldl(fun(Profile, StateAcc) ->
                                  ProfileDeps = rebar_state:get(StateAcc, {deps, Profile}, []),
                                  ProfileDeps2 = rebar_utils:tup_dedup(rebar_utils:tup_sort(ProfileDeps)),
+                                 StateAcc1 = rebar_state:set(StateAcc, {deps, Profile}, ProfileDeps2),
                                  ParsedDeps = parse_profile_deps(Profile
                                                                 ,TopLevelApp
                                                                 ,ProfileDeps2
-                                                                ,StateAcc
-                                                                ,StateAcc),
-                                 rebar_state:set(StateAcc, {parsed_deps, Profile}, ParsedDeps)
+                                                                ,StateAcc1
+                                                                ,StateAcc1),
+                                 rebar_state:set(StateAcc1, {parsed_deps, Profile}, ParsedDeps)
                          end, State, lists:reverse(CurrentProfiles)),
 
     %% Handle sub project apps deps
@@ -109,7 +110,8 @@ handle_profile(Profile, Name, AppState, State) ->
     %% to be included in the parsed deps
     NewDeps = ProfileDeps2 -- TopLevelProfileDeps,
     ParsedDeps = parse_profile_deps(Profile, Name, NewDeps, AppState, State1),
-    rebar_state:set(State1, {parsed_deps, Profile}, TopParsedDeps++ParsedDeps).
+    State2 = rebar_state:set(State1, {deps, Profile}, ProfileDeps2),
+    rebar_state:set(State2, {parsed_deps, Profile}, TopParsedDeps++ParsedDeps).
 
 parse_profile_deps(Profile, Name, Deps, AppState, State) ->
     DepsDir = rebar_prv_install_deps:profile_dep_dir(State, Profile),

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -78,11 +78,7 @@ new() ->
 -spec new(list()) -> t().
 new(Config) when is_list(Config) ->
     BaseState = base_state(),
-    Deps = proplists:get_value(deps, Config, []),
-    Plugins = proplists:get_value(plugins, Config, []),
-    Terms = [{{deps, default}, Deps}, {{plugins, default}, Plugins} | Config],
-    true = rebar_config:verify_config_format(Terms),
-    Opts = dict:from_list(Terms),
+    Opts = base_opts(Config),
     BaseState#state_t { dir = rebar_dir:get_cwd(),
                         default = Opts,
                         opts = Opts }.
@@ -91,12 +87,7 @@ new(Config) when is_list(Config) ->
 new(Profile, Config) when is_atom(Profile)
                         , is_list(Config) ->
     BaseState = base_state(),
-    Deps = proplists:get_value(deps, Config, []),
-
-    Plugins = proplists:get_value(plugins, Config, []),
-    Terms = [{{deps, default}, Deps}, {{plugins, default}, Plugins} | Config],
-    true = rebar_config:verify_config_format(Terms),
-    Opts = dict:from_list(Terms),
+    Opts = base_opts(Config),
     BaseState#state_t { dir = rebar_dir:get_cwd(),
                         current_profiles = [Profile],
                         default = Opts,
@@ -119,11 +110,7 @@ new(ParentState, Config, Dir) ->
                         true = rebar_config:verify_config_format(Terms),
                         dict:from_list(Terms);
                     _ ->
-                        D = proplists:get_value(deps, Config, []),
-                        Plugins = proplists:get_value(plugins, Config, []),
-                        Terms = [{{deps, default}, D}, {{plugins, default}, Plugins} | Config],
-                        true = rebar_config:verify_config_format(Terms),
-                        dict:from_list(Terms)
+                       base_opts(Config)
                 end,
 
     NewOpts = merge_opts(LocalOpts, Opts),
@@ -140,6 +127,13 @@ base_state() ->
             Resources
     end,
     #state_t{resources=Resources}.
+
+base_opts(Config) ->
+    Deps = proplists:get_value(deps, Config, []),
+    Plugins = proplists:get_value(plugins, Config, []),
+    Terms = [{{deps, default}, Deps}, {{plugins, default}, Plugins} | Config],
+    true = rebar_config:verify_config_format(Terms),
+    dict:from_list(Terms).
 
 get(State, Key) ->
     {ok, Value} = dict:find(Key, State#state_t.opts),


### PR DESCRIPTION
The issue was that deps were being set in the state before dedup, which meant the non-locked dep was in the list before the locked entry. Now we replace the deps entry with the updated value.

Fixes https://github.com/rebar/rebar3/issues/725