### PR TITLE
don't error on upgrade if user removes top level dep

### DIFF
--- a/src/rebar_prv_upgrade.erl
+++ b/src/rebar_prv_upgrade.erl
@@ -100,7 +100,8 @@ prepare_locks([Name|Names], Deps, Locks, Unlocks) ->
         {_, _, 0} = Lock ->
             case rebar_utils:tup_find(AtomName, Deps) of
                 false ->
-                    ?PRV_ERROR({unknown_dependency, Name});
+                    ?WARN("Dependency ~s has been removed and will not be upgraded", [Name]),
+                    prepare_locks(Names, Deps, Locks, Unlocks);
                 Dep ->
                     {Source, NewLocks, NewUnlocks} = prepare_lock(Dep, Lock, Locks),
                     prepare_locks(Names, Deps, NewLocks,


### PR DESCRIPTION
Adds a useful warning and no longer errors out when the user removes a top level dep and then runs `upgrade`. Fix for https://github.com/rebar/rebar3/issues/729