### PR TITLE
symlink ct test dirs rather than copy

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -299,8 +299,10 @@ copy(State, Dir) ->
                 true  -> remove_links(Target);
                 false -> ok
             end,
-            ok = ec_file:copy(From, Target, [recursive]),
-            Target
+            case rebar_file_utils:symlink_or_copy(From, Target) of
+               exists -> Target;
+               ok     -> Target
+            end
     end.
 
 compile_dir(State, Dir) ->


### PR DESCRIPTION
fixes issue with persistent compilation errors for files in `./test`