### PR TITLE
Use raw bytestream when writing files

### DIFF
--- a/src/rebar_file_utils.erl
+++ b/src/rebar_file_utils.erl
@@ -201,9 +201,9 @@ write_file_if_contents_differ(Filename, Bytes) ->
         {ok, ToWrite} ->
             ok;
         {ok,  _} ->
-            file:write_file(Filename, ToWrite);
+            file:write_file(Filename, ToWrite, [raw]);
         {error,  _} ->
-            file:write_file(Filename, ToWrite)
+            file:write_file(Filename, ToWrite, [raw])
     end.
 
 %% returns an os appropriate tmpdir given a path


### PR DESCRIPTION
This patch forces write_file_if_contents_differ/2 to use raw bytes as
when writing files. This fixes an issue where UTF-8 characters are
processed and written back as ISO-8859-1 into the file, which makes it
impossible to use UTF-8 characters in .app.src files.

Supercedes https://github.com/rebar/rebar3/pull/618