### PR TITLE
use ~ts for unicode output and reset encoding to latin1

### DIFF
--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -55,20 +55,21 @@ print_deps_tree(SrcDeps, Verbose, State) ->
             print_children("", lists:keysort(1, Children++ProjectAppNames), D, Verbose);
         error ->
             print_children("", lists:keysort(1, ProjectAppNames), D, Verbose)
-    end.
+    end,
+    io:setopts([{encoding, latin1}]).
 
 print_children(_, [], _, _) ->
     ok;
 print_children(Prefix, [{Name, Vsn, Source} | Rest], Dict, Verbose) ->
     Prefix1 = case Rest of
                   [] ->
-                      io:format("~s└─ ", [Prefix]),
+                      io:format("~ts└─ ", [Prefix]),
                       [Prefix, "   "];
                   _ ->
-                      io:format("~s├─ ", [Prefix]),
+                      io:format("~ts├─ ", [Prefix]),
                       [Prefix, "│  "]
               end,
-    io:format("~s─~s (~s)~n", [Name, Vsn, type(Source, Verbose)]),
+    io:format("~ts─~ts (~ts)~n", [Name, Vsn, type(Source, Verbose)]),
     case dict:find(Name, Dict) of
         {ok, Children} ->
             print_children(Prefix1, lists:keysort(1, Children), Dict, Verbose),


### PR DESCRIPTION
I added the reset to latin1 and changed the format sequence to `~ts` which works for me, just `~s` doesn't work for me.