### PR TITLE
Fix cover_spec options for ct

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -533,6 +533,8 @@ transform_opts([], Acc) -> Acc;
 %% drop `cover` and `verbose` so they're not passed as an option to common_test
 transform_opts([{cover, _}|Rest], Acc) ->
     transform_opts(Rest, Acc);
+transform_opts([{cover_spec, CoverSpec}|Rest], Acc) ->
+    transform_opts(Rest, [{cover, CoverSpec}|Acc]);
 transform_opts([{verbose, _}|Rest], Acc) ->
     transform_opts(Rest, Acc);
 transform_opts([{ct_hooks, CtHooks}|Rest], Acc) ->


### PR DESCRIPTION
[There is](http://www.erlang.org/doc/man/ct.html#run_test-1) only `cover` option but [rebar_prv_common_test.erl]( https://github.com/rebar/rebar3/blob/master/src/rebar_prv_common_test.erl#L464) uses `cover_spec`