### PR TITLE
delete and prepend code path instead of replacing, fixes #770

### DIFF
--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -684,7 +684,12 @@ update_code(Paths) ->
                                   code:add_patha(Path),
                                   ok;
                               {ok, Modules} ->
-                                  code:replace_path(App, Path),
+                                  %% replace_path causes problems when running
+                                  %% tests in projects like erlware_commons that rebar3
+                                  %% also includes
+                                  %code:replace_path(App, Path),
+                                  code:del_path(App),
+                                  code:add_patha(Path),
                                   [begin code:purge(M), code:delete(M) end || M <- Modules]
                           end
                   end, Paths).


### PR DESCRIPTION
Related to #770 

Using `replace_path` and I see the code path has properly replaced `erlware_commons` within the code path with the correct local copy that we are attempting to run the tests of.

```
Path ["/home/tristan/Devel/erlware_commons/_build/test/lib/proper/ebin",
      "/home/tristan/.cache/rebar3/plugins/rebar3_run/ebin",
      "/home/tristan/.cache/rebar3/plugins/rebar3_hex/ebin",
      "/home/tristan/.cache/rebar3/plugins/jsx/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/ssl_verify_hostname/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/relx/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/rebar/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/providers/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/getopt/ebin",
      "/home/tristan/Devel/erlware_commons/_build/test/lib/erlware_commons/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/bbmustache/ebin",
      "/home/tristan/Devel/rebar3/rebar3",
      ".",
      ...]
```

This causes the issue seen in #770 while with this patch we get:

```
Path ["/home/tristan/Devel/erlware_commons/_build/test/lib/erlware_commons/ebin",
      "/home/tristan/Devel/erlware_commons/_build/test/lib/proper/ebin",
      "/home/tristan/.cache/rebar3/plugins/rebar3_run/ebin",
      "/home/tristan/.cache/rebar3/plugins/rebar3_hex/ebin",
      "/home/tristan/.cache/rebar3/plugins/jsx/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/ssl_verify_hostname/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/relx/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/rebar/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/providers/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/getopt/ebin",
      "/home/tristan/Devel/erlware_commons/../rebar3/rebar3/bbmustache/ebin",
      "/home/tristan/Devel/rebar3/rebar3",
      ".",
```

Which works.

This may not be the right solution, but opening this PR for discussion.