### PR TITLE
hooks/artifacts are always run/resolved from an app unless at top of umbrella

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -29,17 +29,17 @@
 
 -spec base_dir(rebar_state:t()) -> file:filename_all().
 base_dir(State) ->
-    profile_dir(State, rebar_state:current_profiles(State)).
+    profile_dir(rebar_state:opts(State), rebar_state:current_profiles(State)).
 
--spec profile_dir(rebar_state:t(), [atom()]) -> file:filename_all().
-profile_dir(State, Profiles) ->
+-spec profile_dir(rebar_dict(), [atom()]) -> file:filename_all().
+profile_dir(Opts, Profiles) ->
     {BaseDir, ProfilesStrings} = case [ec_cnv:to_list(P) || P <- Profiles] of
-        ["global" | _] -> {?MODULE:global_cache_dir(State), [""]};
-        ["bootstrap", "default"] -> {rebar_state:get(State, base_dir, ?DEFAULT_BASE_DIR), ["default"]};
-        ["default"] -> {rebar_state:get(State, base_dir, ?DEFAULT_BASE_DIR), ["default"]};
+        ["global" | _] -> {?MODULE:global_cache_dir(Opts), [""]};
+        ["bootstrap", "default"] -> {rebar_opts:get(Opts, base_dir, ?DEFAULT_BASE_DIR), ["default"]};
+        ["default"] -> {rebar_opts:get(Opts, base_dir, ?DEFAULT_BASE_DIR), ["default"]};
         %% drop `default` from the profile dir if it's implicit and reverse order
         %%  of profiles to match order passed to `as`
-        ["default"|Rest] -> {rebar_state:get(State, base_dir, ?DEFAULT_BASE_DIR), Rest}
+        ["default"|Rest] -> {rebar_opts:get(Opts, base_dir, ?DEFAULT_BASE_DIR), Rest}
     end,
     ProfilesDir = string:join(ProfilesStrings, "+"),
     filename:join(BaseDir, ProfilesDir).
@@ -91,9 +91,9 @@ global_config() ->
     Home = home_dir(),
     filename:join([Home, ".config", "rebar3", "rebar.config"]).
 
-global_cache_dir(State) ->
+global_cache_dir(Opts) ->
     Home = home_dir(),
-    rebar_state:get(State, global_rebar_dir, filename:join([Home, ".cache", "rebar3"])).
+    rebar_opts:get(Opts, global_rebar_dir, filename:join([Home, ".cache", "rebar3"])).
 
 local_cache_dir(Dir) ->
     filename:join(Dir, ".rebar3").

--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -111,7 +111,7 @@ create_env(State, Opts) ->
      {"REBAR_CHECKOUTS_DIR",     filename:absname(rebar_dir:checkouts_dir(State))},
      {"REBAR_PLUGINS_DIR",       filename:absname(rebar_dir:plugins_dir(State))},
      {"REBAR_GLOBAL_CONFIG_DIR", filename:absname(rebar_dir:global_config_dir(State))},
-     {"REBAR_GLOBAL_CACHE_DIR",  filename:absname(rebar_dir:global_cache_dir(State))},
+     {"REBAR_GLOBAL_CACHE_DIR",  filename:absname(rebar_dir:global_cache_dir(Opts))},
      {"REBAR_TEMPLATE_DIR",      filename:absname(rebar_dir:template_dir(State))},
      {"REBAR_APP_DIRS",          join_dirs(BaseDir, rebar_dir:lib_dirs(State))},
      {"REBAR_SRC_DIRS",          join_dirs(BaseDir, rebar_dir:all_src_dirs(Opts))},

--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -60,7 +60,7 @@ deps(Name, Vsn, State) ->
     end.
 
 registry_dir(State) ->
-    CacheDir = rebar_dir:global_cache_dir(State),
+    CacheDir = rebar_dir:global_cache_dir(rebar_state:opts(State)),
     case rebar_state:get(State, rebar_packages_cdn, ?DEFAULT_CDN) of
         ?DEFAULT_CDN ->
             RegistryDir = filename:join([CacheDir, "hex", "default"]),

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -225,7 +225,7 @@ update_dep(AppInfo, Profile, Level, Deps, Apps, State, Upgrade, Seen, Locks) ->
 
 profile_dep_dir(State, Profile) ->
     case Profile of
-        default -> filename:join([rebar_dir:profile_dir(State, [default]), rebar_state:get(State, deps_dir, ?DEFAULT_DEPS_DIR)]);
+        default -> filename:join([rebar_dir:profile_dir(rebar_state:opts(State), [default]), rebar_state:get(State, deps_dir, ?DEFAULT_DEPS_DIR)]);
         _ -> rebar_dir:deps_dir(State)
     end.
 

--- a/src/rebar_templater.erl
+++ b/src/rebar_templater.erl
@@ -27,7 +27,8 @@
 -module(rebar_templater).
 
 -export([new/4,
-         list_templates/1]).
+         list_templates/1,
+         render/2]).
 
 
 -include("rebar.hrl").

--- a/test/rebar_hooks_SUITE.erl
+++ b/test/rebar_hooks_SUITE.erl
@@ -43,7 +43,12 @@ build_and_clean_app(Config) ->
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
     rebar_test_utils:run_and_check(Config, [], ["compile"], {ok, [{app, Name, valid}]}),
-    rebar_test_utils:run_and_check(Config, [{provider_hooks, [{post, [{compile, clean}]}]}],
+    RConfFile =
+        rebar_test_utils:create_config(AppDir,
+                                       [{provider_hooks, [{post, [{compile, clean}]}]}]),
+    {ok, RConf} = file:consult(RConfFile),
+
+    rebar_test_utils:run_and_check(Config, RConf,
                                   ["compile"], {ok, [{app, Name, invalid}]}).
 
 escriptize_artifacts(Config) ->
@@ -53,7 +58,7 @@ escriptize_artifacts(Config) ->
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
-    Artifact = "bin/"++Name,
+    Artifact = "{{profile_dir}}/bin/"++Name,
     RConfFile =
         rebar_test_utils:create_config(AppDir,
                                        [
@@ -69,9 +74,18 @@ escriptize_artifacts(Config) ->
           {missing_artifact, Artifact}}} ->
             ok
     end,
-    rebar_test_utils:run_and_check(Config, RConf++[{provider_hooks, [{post, [{compile, escriptize}]}]}],
+    RConfFile1 =
+        rebar_test_utils:create_config(AppDir,
+                                       [
+                                       {escript_name, list_to_atom(Name)}
+                                       ,{artifacts, [Artifact]}
+                                       ,{provider_hooks, [{post, [{compile, escriptize}]}]}
+                                       ]),
+    {ok, RConf1} = file:consult(RConfFile1),
+
+    rebar_test_utils:run_and_check(Config, RConf1,
                                   ["compile"], {ok, [{app, Name, valid}
-                                                    ,{file, filename:join([AppDir, "_build/default/", Artifact])}]}).
+                                                    ,{file, filename:join([AppDir, "_build/default/bin", Name])}]}).
 
 run_hooks_once(Config) ->
     AppDir = ?config(apps, Config),


### PR DESCRIPTION
All hooks will be run as part of the `app_info` set of hooks, in `compile` for example: https://github.com/rebar/rebar3/blob/master/src/rebar_prv_compile.erl#L87 and artifacts will be found relative to an app's output directory, except in the case of being defined in the rebar.config at the top level of an umbrella project. In that case artifacts will be resolved from `profile_dir` (eg `_build/default/`) and hooks will be run from the top level before any part of a provider is run, like https://github.com/rebar/rebar3/blob/master/src/rebar_prv_compile.erl#L49

Additionally 3 variable can be used in the artifacts string: `base_dir`, `profile_dir` or `out_dir` -- `out_dir` is the default path to start finding artifacts but I figured it would be nice to let it be explicit as well, example: `{artifacts, ["{{out_dir}}/priv/eleveldb.so"]}.`