### PR TITLE
support updating of per app info by hooks

### DIFF
--- a/src/rebar_prv_clean.erl
+++ b/src/rebar_prv_clean.erl
@@ -62,13 +62,13 @@ format_error(Reason) ->
 %% ===================================================================
 
 clean_apps(State, Providers, Apps) ->
-    lists:foreach(fun(AppInfo) ->
-                          ?INFO("Cleaning out ~s...", [rebar_app_info:name(AppInfo)]),
-                          AppDir = rebar_app_info:dir(AppInfo),
-                          rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER, Providers, AppInfo, State),
-                          rebar_erlc_compiler:clean(State, rebar_app_info:out_dir(AppInfo)),
-                          rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo, State)
-                  end, Apps).
+    [begin
+         ?INFO("Cleaning out ~s...", [rebar_app_info:name(AppInfo)]),
+         AppDir = rebar_app_info:dir(AppInfo),
+         AppInfo1 = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER, Providers, AppInfo, State),
+         rebar_erlc_compiler:clean(State, rebar_app_info:out_dir(AppInfo1)),
+         rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo1, State)
+     end || AppInfo <- Apps].
 
 handle_args(State) ->
     {Args, _} = rebar_state:command_parsed_args(State),

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -84,14 +84,14 @@ build_app(State, Providers, AppInfo) ->
 compile(State, Providers, AppInfo) ->
     ?INFO("Compiling ~s", [rebar_app_info:name(AppInfo)]),
     AppDir = rebar_app_info:dir(AppInfo),
-    rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER,  Providers, AppInfo, State),
+    AppInfo1 = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER,  Providers, AppInfo, State),
 
-    rebar_erlc_compiler:compile(AppInfo),
-    case rebar_otp_app:compile(State, AppInfo) of
-        {ok, AppInfo1} ->
-            rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo, State),
-            has_all_artifacts(AppInfo1),
-            AppInfo1;
+    rebar_erlc_compiler:compile(AppInfo1),
+    case rebar_otp_app:compile(State, AppInfo1) of
+        {ok, AppInfo2} ->
+            AppInfo3 = rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo2, State),
+            has_all_artifacts(AppInfo3),
+            AppInfo3;
         Error ->
             throw(Error)
     end.

--- a/src/rebar_prv_plugins.erl
+++ b/src/rebar_prv_plugins.erl
@@ -34,7 +34,7 @@ do(State) ->
     GlobalConfigFile = rebar_dir:global_config(),
     GlobalConfig = rebar_state:new(rebar_config:consult_file(GlobalConfigFile)),
     GlobalPlugins = rebar_state:get(GlobalConfig, plugins, []),
-    GlobalPluginsDir = filename:join(rebar_dir:global_cache_dir(State), "plugins"),
+    GlobalPluginsDir = filename:join(rebar_dir:global_cache_dir(rebar_state:opts(State)), "plugins"),
     display_plugins("Global plugins", GlobalPluginsDir, GlobalPlugins),
 
     Plugins = rebar_state:get(State, plugins, []),

--- a/test/rebar_plugins_SUITE.erl
+++ b/test/rebar_plugins_SUITE.erl
@@ -9,6 +9,7 @@
          compile_plugins/1,
          compile_global_plugins/1,
          complex_plugins/1,
+         list/1,
          upgrade/1]).
 
 -include_lib("common_test/include/ct.hrl").
@@ -31,7 +32,7 @@ end_per_testcase(_, _Config) ->
     catch meck:unload().
 
 all() ->
-    [compile_plugins, compile_global_plugins, complex_plugins, upgrade].
+    [compile_plugins, compile_global_plugins, complex_plugins, list, upgrade].
 
 %% Tests that compiling a project installs and compiles the plugins of deps
 compile_plugins(Config) ->
@@ -162,6 +163,12 @@ complex_plugins(Config) ->
      ),
 
     meck:unload(rebar_dir).
+
+list(Config) ->
+    rebar_test_utils:run_and_check(
+        Config, [], ["plugins", "list"],
+        {ok, []}
+     ).
 
 upgrade(Config) ->
     AppDir = ?config(apps, Config),


### PR DESCRIPTION
This patch allows for a hook to update the opts of an appinfo record, hopefully being enough for what @Licenser wants in https://github.com/rebar/rebar3/issues/670

An example would be a provider that you define in `provider_hooks` to run before `compile` which adds to `erl_opts`:

```
do(State) ->
  AppInfo = rebar_state:current_app(State),
  ErlOpts = rebar_app_info:get(AppInfo, erl_opts, []),
  AppInfo1 = rebar_app_info:set(AppInfo, erl_opts, [{d, 'SOME_DEFINE'} | ErlOpts]),
  {ok, rebar_state:current_app(State, AppInfo1)}.
```

