### PR TITLE
add 'bare compile' provider, for starters for use by mix

### DIFF
--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -36,6 +36,7 @@
 
         {providers, [rebar_prv_app_discovery,
                      rebar_prv_as,
+                     rebar_prv_bare_compile,
                      rebar_prv_clean,
                      rebar_prv_common_test,
                      rebar_prv_compile,

--- a/src/rebar_prv_bare_compile.erl
+++ b/src/rebar_prv_bare_compile.erl
@@ -1,0 +1,42 @@
+-module(rebar_prv_bare_compile).
+
+-behaviour(provider).
+
+-export([init/1,
+         do/1,
+         format_error/1]).
+
+-include_lib("providers/include/providers.hrl").
+-include("rebar.hrl").
+
+-define(PROVIDER, compile).
+-define(NAMESPACE, bare).
+-define(DEPS, [{default, app_discovery}]).
+
+%% ===================================================================
+%% Public API
+%% ===================================================================
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
+                                                               {module, ?MODULE},
+                                                               {namespace, ?NAMESPACE},
+                                                               {bare, false},
+                                                               {deps, ?DEPS},
+                                                               {example, ""},
+                                                               {short_desc, ""},
+                                                               {desc, ""},
+                                                               {opts, []}])),
+    {ok, State1}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    [AppInfo] = rebar_state:project_apps(State),
+    AppInfo1 = rebar_app_info:out_dir(AppInfo, rebar_dir:get_cwd()),
+    rebar_prv_compile:compile(State, AppInfo1),
+    {ok, State}.
+
+-spec format_error(any()) -> iolist().
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).

--- a/src/rebar_prv_bare_compile.erl
+++ b/src/rebar_prv_bare_compile.erl
@@ -19,22 +19,35 @@
 
 -spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
 init(State) ->
-    State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
-                                                               {module, ?MODULE},
-                                                               {namespace, ?NAMESPACE},
-                                                               {bare, false},
-                                                               {deps, ?DEPS},
-                                                               {example, ""},
-                                                               {short_desc, ""},
-                                                               {desc, ""},
-                                                               {opts, []}])),
+    State1 =
+        rebar_state:add_provider(State,
+                                providers:create([{name, ?PROVIDER},
+                                                  {module, ?MODULE},
+                                                  {namespace, ?NAMESPACE},
+                                                  {bare, false},
+                                                  {deps, ?DEPS},
+                                                  {example, ""},
+                                                  {short_desc, ""},
+                                                  {desc, ""},
+                                                  {opts, [{paths, $p, "paths", string, "Wildcard path of ebin directories to add to code path"}]}])),
     {ok, State1}.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+    OrigPath = code:get_path(),
+
+    %% Add code paths from --paths to the beginning of the code path
+    {RawOpts, _} = rebar_state:command_parsed_args(State),
+    Paths = proplists:get_value(paths, RawOpts),
+    CodePaths = filelib:wildcard(Paths),
+    code:add_pathsa(CodePaths),
+
     [AppInfo] = rebar_state:project_apps(State),
     AppInfo1 = rebar_app_info:out_dir(AppInfo, rebar_dir:get_cwd()),
     rebar_prv_compile:compile(State, AppInfo1),
+
+    rebar_utils:cleanup_code_path(OrigPath),
+
     {ok, State}.
 
 -spec format_error(any()) -> iolist().

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -6,7 +6,8 @@
          do/1,
          format_error/1]).
 
--export([compile/3]).
+-export([compile/2,
+         compile/3]).
 
 -include_lib("providers/include/providers.hrl").
 -include("rebar.hrl").
@@ -80,6 +81,9 @@ build_app(State, Providers, AppInfo) ->
     OutDir = rebar_app_info:out_dir(AppInfo),
     copy_app_dirs(AppInfo, AppDir, OutDir),
     compile(State, Providers, AppInfo).
+
+compile(State, AppInfo) ->
+    compile(State, rebar_state:providers(State), AppInfo).
 
 compile(State, Providers, AppInfo) ->
     ?INFO("Compiling ~s", [rebar_app_info:name(AppInfo)]),

--- a/src/rebar_prv_escriptize.erl
+++ b/src/rebar_prv_escriptize.erl
@@ -107,7 +107,7 @@ escriptize(State0, App) ->
     ExtraFiles = usort(InclBeams ++ InclExtra),
     Files = get_nonempty(EbinFiles ++ ExtraFiles),
 
-    DefaultEmuArgs = ?FMT("%%! -escript main ~s -pa ~s/~s/ebin\n",
+    DefaultEmuArgs = ?FMT("%%! -escript main ~s -pz ~s/~s/ebin\n",
                           [AppNameStr, AppNameStr, AppNameStr]),
     EscriptSections =
         [ {shebang,

--- a/src/rebar_prv_local_install.erl
+++ b/src/rebar_prv_local_install.erl
@@ -60,7 +60,7 @@ format_error(Reason) ->
 bin_contents(OutputDir) ->
     <<"#!/usr/bin/env sh
 
-erl -pa ", (ec_cnv:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A0  -noshell -boot start_clean -s rebar3 main -extra \"$@\"
+erl -pz ", (ec_cnv:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A0  -noshell -boot start_clean -s rebar3 main -extra \"$@\"
 ">>.
 
 extract_escript(State, ScriptPath) ->

--- a/src/rebar_prv_local_install.erl
+++ b/src/rebar_prv_local_install.erl
@@ -58,8 +58,7 @@ format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
 bin_contents(OutputDir) ->
-    <<"
-#!/usr/bin/env sh
+    <<"#!/usr/bin/env sh
 
 erl -pa ", (ec_cnv:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A0  -noshell -boot start_clean -s rebar3 main -extra \"$@\"
 ">>.


### PR DESCRIPTION
For https://github.com/rebar/rebar3/issues/671

Example:

```
rebar3 bare compile
```

Note you'll need to set `ERL_LIBS` for any dependencies needing for compilation and plugins still go to `_build/default/plugins`.