### PR TITLE
use full path of apps for priv files included in escript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_deploy: "rm -rf !(rebar3)"
 deploy:
   on:
     branch: master
-    condition: $TRAVIS_OTP_RELEASE = R15B03
+    condition: $TRAVIS_OTP_RELEASE = R16B03-1
   provider: s3
   access_key_id: AKIAJAPYAQEFYCYSNL7Q
   secret_access_key:

--- a/rebar.config
+++ b/rebar.config
@@ -12,9 +12,8 @@
 {escript_emu_args, "%%! +sbtu +A0\n"}.
 %% escript_incl_extra is for internal rebar-private use only.
 %% Do not use outside rebar. Config interface is not stable.
-{escript_incl_extra, [{"_build/default/lib/relx/priv/templates/*", "."},
-                      {"priv/templates/*", "."},
-                      {"rebar/include/*", "."}]}.
+{escript_incl_extra, [{"relx/priv/templates/*", "_build/default/lib/"},
+                      {"rebar/priv/templates/*", "_build/default/lib/"}]}.
 
 {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
             no_debug_info,


### PR DESCRIPTION
Fix for https://github.com/rebar/rebar3/issues/794

But we can no longer build the escript for uploading to s3 with R15B03 because of a bug in filelib.