### PR TITLE
extract `retarget_path/2', `relative_path/2' and `reduce_path/1' and add tests

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -175,15 +175,15 @@ retarget_path(State, Path) ->
 %% not relative to any apps in project, check to see it's relative to
 %% project root
 retarget_path(State, Path, []) ->
-    case rebar_file_utils:relative_path(rebar_file_utils:reduce_path(Path), rebar_state:dir(State)) of
-        {ok, NewPath}         -> filename:join([base_dir(State), NewPath]);
+    case rebar_file_utils:path_from_ancestor(rebar_file_utils:canonical_path(Path), rebar_state:dir(State)) of
+        {ok, NewPath}      -> filename:join([base_dir(State), NewPath]);
         %% not relative to project root, don't modify
-        {error, not_relative} -> Path
+        {error, badparent} -> Path
     end;
 %% relative to current app, retarget to the same dir relative to
 %% the app's out_dir
 retarget_path(State, Path, [App|Rest]) ->
-    case rebar_file_utils:relative_path(rebar_file_utils:reduce_path(Path), rebar_app_info:dir(App)) of
-        {ok, NewPath}         -> filename:join([rebar_app_info:out_dir(App), NewPath]);
-        {error, not_relative} -> retarget_path(State, Path, Rest)
+    case rebar_file_utils:path_from_ancestor(rebar_file_utils:canonical_path(Path), rebar_app_info:dir(App)) of
+        {ok, NewPath}      -> filename:join([rebar_app_info:out_dir(App), NewPath]);
+        {error, badparent} -> retarget_path(State, Path, Rest)
     end.

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -5,6 +5,7 @@
 -export([default_src_dirs/1, default_extra_src_dirs/1, default_all_src_dirs/1]).
 -export([src_dirs/1, extra_src_dirs/1, all_src_dirs/1]).
 -export([profile_src_dirs/1, profile_extra_src_dirs/1, profile_all_src_dirs/1]).
+-export([retarget_path/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -13,16 +14,22 @@
 
 all() -> [default_src_dirs, default_extra_src_dirs, default_all_src_dirs,
           src_dirs, extra_src_dirs, all_src_dirs,
-          profile_src_dirs, profile_extra_src_dirs, profile_all_src_dirs].
+          profile_src_dirs, profile_extra_src_dirs, profile_all_src_dirs,
+          retarget_path].
 
 init_per_testcase(_, Config) ->
     C = rebar_test_utils:init_rebar_state(Config),
     AppDir = ?config(apps, C),
 
-    Name = rebar_test_utils:create_random_name("app1_"),
-    Vsn = rebar_test_utils:create_random_vsn(),
-    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
-    C.
+    Name1 = rebar_test_utils:create_random_name("app1_"),
+    Vsn1 = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(filename:join([AppDir,"apps",Name1]), Name1, Vsn1, [kernel, stdlib]),
+
+    Name2 = rebar_test_utils:create_random_name("app2_"),
+    Vsn2 = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(filename:join([AppDir,"apps",Name2]), Name2, Vsn2, [kernel, stdlib]),
+
+    [{app_one, Name1}, {app_two, Name2}] ++ C.
 
 end_per_testcase(_, _Config) -> ok.
 
@@ -97,3 +104,24 @@ profile_all_src_dirs(Config) ->
 
     R = lists:sort(["foo", "bar", "baz", "qux"]),
     R = lists:sort(rebar_dir:all_src_dirs(rebar_state:opts(State))).
+
+retarget_path(Config) ->
+    {ok, State} = rebar_test_utils:run_and_check(Config, [], ["compile"], return),
+
+    BaseDir = rebar_dir:base_dir(State),
+
+    Name1 = ?config(app_one, Config),
+    Name2 = ?config(app_two, Config),
+
+    ?assertEqual(filename:join([BaseDir, "lib", Name1, "test"]),
+                 rebar_dir:retarget_path(State, filename:join([rebar_dir:root_dir(State), "apps", Name1, "test"]))),
+    ?assertEqual(filename:join([BaseDir, "lib", Name2, "test"]),
+                 rebar_dir:retarget_path(State, filename:join([rebar_dir:root_dir(State), "apps", Name2, "test"]))),
+    ?assertEqual(filename:join([BaseDir, "lib", Name1, "more_test"]),
+                 rebar_dir:retarget_path(State, filename:join([rebar_dir:root_dir(State), "apps", Name1, "more_test"]))),
+    ?assertEqual(filename:join([BaseDir, "test"]),
+                 rebar_dir:retarget_path(State, filename:join([rebar_dir:root_dir(State), "test"]))),
+    ?assertEqual(filename:join([BaseDir, "some_other_dir"]),
+                 rebar_dir:retarget_path(State, filename:join([rebar_dir:root_dir(State), "some_other_dir"]))),
+    ?assertEqual("/somewhere/outside/the/project",
+                 rebar_dir:retarget_path(State, "/somewhere/outside/the/project")).

--- a/test/rebar_file_utils_SUITE.erl
+++ b/test/rebar_file_utils_SUITE.erl
@@ -11,8 +11,8 @@
          reset_nonexistent_dir/1,
          reset_empty_dir/1,
          reset_dir/1,
-         relative_path/1,
-         reduce_path/1]).
+         path_from_ancestor/1,
+         canonical_path/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -22,7 +22,7 @@
 all() ->
     [{group, tmpdir},
      {group, reset_dir},
-     relative_path, reduce_path].
+     path_from_ancestor, canonical_path].
 
 groups() ->
     [{tmpdir, [], [raw_tmpdir, empty_tmpdir, simple_tmpdir, multi_tmpdir]},
@@ -88,19 +88,19 @@ reset_dir(Config) ->
     ?assert(filelib:is_dir(TmpDir)),
     {ok, []} = file:list_dir(TmpDir).
 
-relative_path(_Config) ->
-    ?assertEqual({ok, "foo/bar/baz"}, rebar_file_utils:relative_path("/foo/bar/baz", "/")),
-    ?assertEqual({ok, "bar/baz"}, rebar_file_utils:relative_path("/foo/bar/baz", "/foo")),
-    ?assertEqual({ok, "bar"}, rebar_file_utils:relative_path("foo/bar", "foo")),
-    ?assertEqual({ok, "bar"}, rebar_file_utils:relative_path("foo/bar/", "foo/")),
-    ?assertEqual({error, not_relative}, rebar_file_utils:relative_path("/foo/bar/baz", "/qux")),
-    ?assertEqual({error, not_relative}, rebar_file_utils:relative_path("/foo/bar/baz", "/foo/bar/baz/qux")).
+path_from_ancestor(_Config) ->
+    ?assertEqual({ok, "foo/bar/baz"}, rebar_file_utils:path_from_ancestor("/foo/bar/baz", "/")),
+    ?assertEqual({ok, "bar/baz"}, rebar_file_utils:path_from_ancestor("/foo/bar/baz", "/foo")),
+    ?assertEqual({ok, "bar"}, rebar_file_utils:path_from_ancestor("foo/bar", "foo")),
+    ?assertEqual({ok, "bar"}, rebar_file_utils:path_from_ancestor("foo/bar/", "foo/")),
+    ?assertEqual({error, badparent}, rebar_file_utils:path_from_ancestor("/foo/bar/baz", "/qux")),
+    ?assertEqual({error, badparent}, rebar_file_utils:path_from_ancestor("/foo/bar/baz", "/foo/bar/baz/qux")).
 
-reduce_path(_Config) ->
-    ?assertEqual("/", rebar_file_utils:reduce_path("/")),
-    ?assertEqual("/", rebar_file_utils:reduce_path("/../../..")),
-    ?assertEqual("/foo", rebar_file_utils:reduce_path("/foo/bar/..")),
-    ?assertEqual("/foo", rebar_file_utils:reduce_path("/foo/../foo")),
-    ?assertEqual("/foo", rebar_file_utils:reduce_path("/foo/.")),
-    ?assertEqual("/foo", rebar_file_utils:reduce_path("/foo/./.")),
-    ?assertEqual("/foo/bar", rebar_file_utils:reduce_path("/foo/./bar")).
+canonical_path(_Config) ->
+    ?assertEqual("/", rebar_file_utils:canonical_path("/")),
+    ?assertEqual("/", rebar_file_utils:canonical_path("/../../..")),
+    ?assertEqual("/foo", rebar_file_utils:canonical_path("/foo/bar/..")),
+    ?assertEqual("/foo", rebar_file_utils:canonical_path("/foo/../foo")),
+    ?assertEqual("/foo", rebar_file_utils:canonical_path("/foo/.")),
+    ?assertEqual("/foo", rebar_file_utils:canonical_path("/foo/./.")),
+    ?assertEqual("/foo/bar", rebar_file_utils:canonical_path("/foo/./bar")).

--- a/test/rebar_file_utils_SUITE.erl
+++ b/test/rebar_file_utils_SUITE.erl
@@ -10,7 +10,9 @@
          multi_tmpdir/1,
          reset_nonexistent_dir/1,
          reset_empty_dir/1,
-         reset_dir/1]).
+         reset_dir/1,
+         relative_path/1,
+         reduce_path/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -19,7 +21,8 @@
 
 all() ->
     [{group, tmpdir},
-     {group, reset_dir}].
+     {group, reset_dir},
+     relative_path, reduce_path].
 
 groups() ->
     [{tmpdir, [], [raw_tmpdir, empty_tmpdir, simple_tmpdir, multi_tmpdir]},
@@ -84,3 +87,20 @@ reset_dir(Config) ->
     ok = rebar_file_utils:reset_dir(TmpDir),
     ?assert(filelib:is_dir(TmpDir)),
     {ok, []} = file:list_dir(TmpDir).
+
+relative_path(_Config) ->
+    ?assertEqual({ok, "foo/bar/baz"}, rebar_file_utils:relative_path("/foo/bar/baz", "/")),
+    ?assertEqual({ok, "bar/baz"}, rebar_file_utils:relative_path("/foo/bar/baz", "/foo")),
+    ?assertEqual({ok, "bar"}, rebar_file_utils:relative_path("foo/bar", "foo")),
+    ?assertEqual({ok, "bar"}, rebar_file_utils:relative_path("foo/bar/", "foo/")),
+    ?assertEqual({error, not_relative}, rebar_file_utils:relative_path("/foo/bar/baz", "/qux")),
+    ?assertEqual({error, not_relative}, rebar_file_utils:relative_path("/foo/bar/baz", "/foo/bar/baz/qux")).
+
+reduce_path(_Config) ->
+    ?assertEqual("/", rebar_file_utils:reduce_path("/")),
+    ?assertEqual("/", rebar_file_utils:reduce_path("/../../..")),
+    ?assertEqual("/foo", rebar_file_utils:reduce_path("/foo/bar/..")),
+    ?assertEqual("/foo", rebar_file_utils:reduce_path("/foo/../foo")),
+    ?assertEqual("/foo", rebar_file_utils:reduce_path("/foo/.")),
+    ?assertEqual("/foo", rebar_file_utils:reduce_path("/foo/./.")),
+    ?assertEqual("/foo/bar", rebar_file_utils:reduce_path("/foo/./bar")).


### PR DESCRIPTION
useful in more contexts than just rebar_prv_common_test and this allows tests

they're currently duplicated in rebar_prv_common_test but will be removed in a separate pr once (if) this one is accepted