### PR TITLE
replace noinput with noshell so providers that ask for input work

### DIFF
--- a/src/rebar_prv_local_install.erl
+++ b/src/rebar_prv_local_install.erl
@@ -61,7 +61,7 @@ bin_contents(OutputDir) ->
     <<"
 #!/usr/bin/env sh
 
-erl -pa ", (ec_cnv:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A0 -noinput -boot start_clean -s rebar3 main -extra \"$@\"
+erl -pa ", (ec_cnv:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A0  -noshell -boot start_clean -s rebar3 main -extra \"$@\"
 ">>.
 
 extract_escript(State, ScriptPath) ->


### PR DESCRIPTION
Fixes use of providers like `rebar3 hex` which reads user input.