### PR TITLE
Improved git versioning

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -194,7 +194,7 @@ parse_tags(Dir) ->
         {error, _} ->
             {undefined, "0.0.0"};
         {ok, Line} ->
-            case re:run(Line, "(\\(|\\s)tag:\\s(v?([^,\\)]+))", [{capture, [2, 3], list}]) of
+            case re:run(Line, "(\\(|\\s)(HEAD,\\s)tag:\\s(v?([^,\\)]+))", [{capture, [3, 4], list}]) of
                 {match,[Tag, Vsn]} ->
                     {Tag, Vsn};
                 nomatch ->

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -194,7 +194,7 @@ parse_tags(Dir) ->
         {error, _} ->
             {undefined, "0.0.0"};
         {ok, Line} ->
-            case re:run(Line, "(\\(|\\s)tag:\\s(v([^,\\)]+))", [{capture, [2, 3], list}]) of
+            case re:run(Line, "(\\(|\\s)tag:\\s(v?([^,\\)]+))", [{capture, [2, 3], list}]) of
                 {match,[Tag, Vsn]} ->
                     {Tag, Vsn};
                 nomatch ->

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -198,6 +198,12 @@ parse_tags(Dir) ->
                 {match,[Tag, Vsn]} ->
                     {Tag, Vsn};
                 nomatch ->
-                    {undefined, "0.0.0"}
+                    case rebar_utils:sh("git describe --tags",
+                            [{use_stdout, false}, return_on_error, {cd, Dir}]) of
+                        {error, _} ->
+                            {undefined, "0.0.0"};
+                        {ok, LatestVsn} ->
+                            {undefined, string:strip(LatestVsn, both, $\n)}
+                    end
             end
     end.


### PR DESCRIPTION
Fixing two bugs in semantic versions with git and hopefully improved it.

I noticed the issue(s) while working with rebar3 on a project that uses jiffy. jiffy relies on semantic versioning, and tags various versions, but does not include a 'v' prefix in the tag. As such, rebar3 was unable to detect the version. This was the first bug. This is fixed by making the v prefix optional.

The second bug was more subtle and has no readily available example (though one is easy to prepare). Specifically, suppose you had checked out an older tag of a repository that used semantic versioning: when compiling the .app file, the regex used would find the *latest* tag, not the current tag, and use that for the version. This is the second bug. This is fixed by looking for the "HEAD" string in the git log appearing prior to the tag (as this means that the HEAD is set to the listed tag).

Finally, the improvement: in cases where a ref instead of a tag is used, rebar3 will now try to find the most recent/relevant tag version and use this as the base of the ref-counted version. For instance:

    $ git clone https://github.com/davisp/jiffy.git
    $ cd jiffy
    $ git checkout 0.11.2
    $ git checkout HEAD~1
    $ rebar3 compile
    $ cat _build/default/lib/jiffy/ebin/jiffy.app | grep vsn
                  {vsn,"0.11.1-2-gb3ef636+build.96.refb3ef636"},

As you can see, we are somewhere between tags 0.11.1 and 0.11.2; the versioning system now detects this and marks it as a derivative of 0.11.1.