### PR TITLE
Fix parsing of version #'s of dependencies

### DIFF
--- a/src/rebar_pkg_resource.erl
+++ b/src/rebar_pkg_resource.erl
@@ -176,7 +176,7 @@ check_ssl_version() ->
     end.
 
 parse_vsn(Vsn) ->
-    version_pad(string:tokens(Vsn, ".")).
+    version_pad(string:tokens(Vsn, ".-")).
 
 version_pad([Major]) ->
     {list_to_integer(Major), 0, 0};


### PR DESCRIPTION
Version #'s with patch info like "1.1.1-x" would cause an error. Now
tokenize the version string with "." AND "-".

Some versions of OTP return an unexpected version #:
```
8> application:get_key(ssl, vsn).
{ok,"6.0.1-basho1"}
```

This was causing a bootstrap error:
```
./bootstrap
===> Updating package registry...
===> Writing registry to /home/jbalint/.cache/rebar3/hex/default/registry
===> Generating package index...
===> Writing index to /home/jbalint/.cache/rebar3/hex/default/packages.idx
===> Verifying dependencies...
===> Fetching bbmustache ({pkg,<<"bbmustache">>,<<"1.0.4">>})
escript: exception error: no match of right hand side value
                 {error,
                     {rebar_fetch,
                         {fetch_fail,{pkg,<<"bbmustache">>,<<"1.0.4">>}}}}
```