### PR TITLE
Update erlware commons and relx

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
         {providers,           "1.5.0"},
         {getopt,              "0.8.2"},
         {bbmustache,          "1.0.4"},
-        {relx,                "3.5.0"}]}.
+        {relx,                "3.6.0"}]}.
 
 {escript_name, rebar3}.
 {escript_emu_args, "%%! +sbtu +A0\n"}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 
-{deps, [{erlware_commons,     "0.15.0"},
+{deps, [{erlware_commons,     "0.16.0"},
         {ssl_verify_hostname, "1.0.5"},
         {certifi,             "0.1.1"},
         {providers,           "1.5.0"},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.4">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"0.1.1">>},0},
- {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.15.0">>},0},
+ {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.16.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.5.0">>},0},
  {<<"relx">>,{pkg,<<"relx">>,<<"3.5.0">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,5 +3,5 @@
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.16.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.5.0">>},0},
- {<<"relx">>,{pkg,<<"relx">>,<<"3.5.0">>},0},
+ {<<"relx">>,{pkg,<<"relx">>,<<"3.6.0">>},0},
  {<<"ssl_verify_hostname">>,{pkg,<<"ssl_verify_hostname">>,<<"1.0.5">>},0}].

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -592,6 +592,8 @@ vcs_vsn(Vcs, Dir, Resources) ->
     end.
 
 %% Temp work around for repos like relx that use "semver"
+vcs_vsn_cmd(Vsn, _, _) when is_binary(Vsn) ->
+    {plain, Vsn};
 vcs_vsn_cmd(VCS, Dir, Resources) when VCS =:= semver ; VCS =:= "semver" ->
     vcs_vsn_cmd(git, Dir, Resources);
 vcs_vsn_cmd({cmd, _Cmd}=Custom, _, _) ->


### PR DESCRIPTION
Includes changes related to the `v` prefix in versions being optional now.