### PR TITLE
App script fix

### DIFF
--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -69,7 +69,7 @@ consult_file_(File) ->
             Script = File ++ ".script",
             case filelib:is_regular(Script) of
                 true ->
-                    {ok, [Term]} = consult_and_eval(File, Script),
+                    {ok, Term} = consult_and_eval(File, Script),
                     [Term];
                 false ->
                     rebar_file_utils:try_consult(File)

--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -63,14 +63,14 @@ consult_file_(File) when is_binary(File) ->
 consult_file_(File) ->
     case filename:extension(File) of
         ".script" ->
-            {ok, Terms} = consult_and_eval(remove_script_ext(File), File),
-            Terms;
+            {ok, Term} = consult_and_eval(remove_script_ext(File), File),
+            [Term];
         _ ->
             Script = File ++ ".script",
             case filelib:is_regular(Script) of
                 true ->
-                    {ok, Terms} = consult_and_eval(File, Script),
-                    Terms;
+                    {ok, [Term]} = consult_and_eval(File, Script),
+                    [Term];
                 false ->
                     rebar_file_utils:try_consult(File)
             end

--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -63,14 +63,14 @@ consult_file_(File) when is_binary(File) ->
 consult_file_(File) ->
     case filename:extension(File) of
         ".script" ->
-            {ok, Term} = consult_and_eval(remove_script_ext(File), File),
-            [Term];
+            {ok, Terms} = consult_and_eval(remove_script_ext(File), File),
+            Terms;
         _ ->
             Script = File ++ ".script",
             case filelib:is_regular(Script) of
                 true ->
-                    {ok, Term} = consult_and_eval(File, Script),
-                    [Term];
+                    {ok, Terms} = consult_and_eval(File, Script),
+                    Terms;
                 false ->
                     rebar_file_utils:try_consult(File)
             end

--- a/src/rebar_otp_app.erl
+++ b/src/rebar_otp_app.erl
@@ -210,7 +210,12 @@ consult_app_file(Filename) ->
                 false ->
                     file:consult(Filename);
                 true ->
-                    {ok, rebar_config:consult_app_file(Filename)}
+                    case rebar_config:consult_app_file(Filename) of
+                        Terms when is_list(Terms) ->
+                            {ok, Terms};
+                        Term when is_tuple(Term) ->
+                            {ok, [Term]}
+                    end
             end
     end.
 


### PR DESCRIPTION
This fixes a bug that `app.src.scipt` files crashed rebar3 since `consult_file_` would return `[{aplicaiton, ...}]` for `app.src` files but `{applicaiton, ...}` for `app.src.script` files