### PR TITLE
handle case that upgraded app no longer has .app.src file

### DIFF
--- a/src/rebar_app_discover.erl
+++ b/src/rebar_app_discover.erl
@@ -229,7 +229,8 @@ try_handle_app_file(AppInfo0, [File], AppDir, AppSrcFile, _, Validate) ->
                            [F] ->
                                rebar_app_info:app_file_src(AppInfo1, F);
                            [] ->
-                               AppInfo1;
+                               %% Set to undefined in case AppInfo previous had a .app.src
+                               rebar_app_info:app_file_src(AppInfo1, undefined);
                            Other when is_list(Other) ->
                                throw({error, {multiple_app_files, Other}})
                       end,

--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -232,6 +232,8 @@ app_file_src(#app_info_t{app_file_src=AppFileSrc}) ->
     ec_cnv:to_list(AppFileSrc).
 
 -spec app_file_src(t(), file:filename_all()) -> t().
+app_file_src(AppInfo=#app_info_t{}, undefined) ->
+    AppInfo#app_info_t{app_file_src=undefined};
 app_file_src(AppInfo=#app_info_t{}, AppFileSrc) ->
     AppInfo#app_info_t{app_file_src=ec_cnv:to_list(AppFileSrc)}.
 
@@ -248,6 +250,8 @@ app_file_src_script(#app_info_t{app_file_src_script=AppFileSrcScript}) ->
     ec_cnv:to_list(AppFileSrcScript).
 
 -spec app_file_src_script(t(), file:filename_all()) -> t().
+app_file_src_script(AppInfo=#app_info_t{}, undefined) ->
+    AppInfo#app_info_t{app_file_src_script=undefined};
 app_file_src_script(AppInfo=#app_info_t{}, AppFileSrcScript) ->
     AppInfo#app_info_t{app_file_src_script=ec_cnv:to_list(AppFileSrcScript)}.
 


### PR DESCRIPTION
If an app is upgraded and no longer has a `.app.src` file (but it did before) the app record still contained a path for that file that no longer exists as though it was still expected to use it. The fix here sets `app_src` to undefined if it isn't there when the new version is unpacked and inspected so that later rebar3 doesn't attempt to read it in expecting it to be there.