### PR TITLE
Git versioning 2

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -194,7 +194,7 @@ parse_tags(Dir) ->
         {error, _} ->
             {undefined, "0.0.0"};
         {ok, Line} ->
-            case re:run(Line, "(\\(|\\s)tag:\\s(v?([^,\\)]+))", [{capture, [2, 3], list}]) of
+            case re:run(Line, "(\\(|\\s)(HEAD,\\s)tag:\\s(v?([^,\\)]+))", [{capture, [3, 4], list}]) of
                 {match,[Tag, Vsn]} ->
                     {Tag, Vsn};
                 nomatch ->

--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -198,6 +198,12 @@ parse_tags(Dir) ->
                 {match,[Tag, Vsn]} ->
                     {Tag, Vsn};
                 nomatch ->
-                    {undefined, "0.0.0"}
+                    case rebar_utils:sh("git describe --tags --abbrev=0",
+                            [{use_stdout, false}, return_on_error, {cd, Dir}]) of
+                        {error, _} ->
+                            {undefined, "0.0.0"};
+                        {ok, LatestVsn} ->
+                            {undefined, string:strip(LatestVsn, both, $\n)}
+                    end
             end
     end.


### PR DESCRIPTION
Fixed the broken of two reverted patches such that it only returns the latest tag and no additional abbreviation, thus leaving the abbreviation to rebar.