### PR TITLE
add an export to allow specifing arbitrary extra erl files to be compiled

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -28,6 +28,7 @@
 
 -export([compile/1,
          compile/3,
+         compile/4,
          clean/1]).
 
 -include("rebar.hrl").
@@ -103,6 +104,11 @@ compile(Opts, Dir, OutDir) ->
                             filename:join(Dir, "mibs"), ".mib", filename:join([Dir, "priv", "mibs"]), ".bin",
                             fun compile_mib/3),
     doterl_compile(Opts, Dir, OutDir).
+
+-spec compile(rebar_dict(), file:filename(), file:filename(), [file:filename()]) -> 'ok'.
+compile(Opts, Dir, OutDir, More) ->
+    ErlOpts = rebar_opts:erl_opts(Opts),
+    doterl_compile(Opts, Dir, OutDir, More, ErlOpts).
 
 -spec clean(file:filename()) -> 'ok'.
 clean(AppDir) ->
@@ -488,6 +494,7 @@ needs_compile(Source, Target) ->
     filelib:last_modified(Source) > filelib:last_modified(Target).
 
 gather_src([], Srcs) ->
+    ?DEBUG("src_files ~p", [Srcs]),
     Srcs;
 gather_src([Dir|Rest], Srcs) ->
     gather_src(

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -25,7 +25,8 @@
          only_default_transitive_deps/1,
          clean_all/1,
          override_deps/1,
-         profile_override_deps/1]).
+         profile_override_deps/1,
+         build_more_sources/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -54,7 +55,7 @@ all() ->
      dont_recompile_yrl_or_xrl, delete_beam_if_source_deleted,
      deps_in_path, checkout_priority, highest_version_of_pkg_dep,
      parse_transform_test, erl_first_files_test, mib_test, only_default_transitive_deps,
-     clean_all, override_deps, profile_override_deps].
+     clean_all, override_deps, profile_override_deps, build_more_sources].
 
 build_basic_app(Config) ->
     AppDir = ?config(apps, Config),
@@ -631,3 +632,31 @@ profile_override_deps(Config) ->
         Config, RebarConfig, ["as", "a", "compile"],
         {ok, [{dep, "some_dep"},{dep_not_exist, "other_dep"}]}
     ).
+
+build_more_sources(Config) ->
+    AppDir = ?config(apps, Config),
+
+    ASrc = <<"-module(a_src).\n-export([ok/0]).\nok() -> ok.\n">>,
+    BSrc = <<"-module(b_src).\n-export([ok/0]).\nok() -> ok.\n">>,
+    CSrc = <<"-module(c_src).\n-export([ok/0]).\nok() -> ok.\n">>,
+
+    ok = filelib:ensure_dir(filename:join([AppDir, "more", "dummy"])),
+    ok = filelib:ensure_dir(filename:join([AppDir, "ebin", "dummy"])),
+    ok = file:write_file(filename:join([AppDir, "more", "a_src.erl"]), ASrc),
+    ok = file:write_file(filename:join([AppDir, "more", "b_src.erl"]), BSrc),
+    ok = file:write_file(filename:join([AppDir, "more", "c_src.erl"]), CSrc),
+
+    Opts = dict:new(),
+
+    rebar_erlc_compiler:compile(Opts,
+                                filename:join([AppDir, "more"]),
+                                filename:join([AppDir, "ebin"]),
+                                [filename:join([AppDir, "more", "a_src.erl"]),
+                                 filename:join([AppDir, "more", "b_src.erl"]),
+                                 filename:join([AppDir, "more", "c_src.erl"])]),
+
+    EbinDir = filename:join([AppDir, "ebin"]),
+    true = filelib:is_file(filename:join([EbinDir, "a_src.beam"])),
+    true = filelib:is_file(filename:join([EbinDir, "b_src.beam"])),
+    true = filelib:is_file(filename:join([EbinDir, "c_src.beam"])).
+


### PR DESCRIPTION
`rebar_erlc_compiler` has a faculty to compile arbitrary files but it's not exposed. it'd be useful for `ct`, `eunit` and possibly other providers to expose this