### PR TITLE
Group dialyzer warnings by file and concentrate output

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
         {getopt,              "0.8.2"},
         {bbmustache,          "1.0.4"},
         {relx,                "3.7.1"},
-        {cf,                  "0.1.1"}]}.
+        {cf,                  "0.1.2"}]}.
 
 {escript_name, rebar3}.
 {escript_emu_args, "%%! +sbtu +A0\n"}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,7 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.4">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"0.1.1">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.1.2">>},0},
+ {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.16.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.5.0">>},0},
  {<<"relx">>,{pkg,<<"relx">>,<<"3.7.1">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,6 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.4">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"0.1.1">>},0},
- {<<"cf">>,{pkg,<<"cf">>,<<"0.1.1">>},0},
- {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.16.0">>},0},
+ {<<"cf">>,{pkg,<<"cf">>,<<"0.1.2">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.5.0">>},0},
  {<<"relx">>,{pkg,<<"relx">>,<<"3.7.1">>},0},

--- a/src/rebar_dialyzer_format.erl
+++ b/src/rebar_dialyzer_format.erl
@@ -278,14 +278,11 @@ call_or_apply_to_string(ArgNs, FailReason, SigArgs, SigRet,
     end.
 
 form_positions(ArgNs) ->
+    ArgS = form_position_string(ArgNs),
     case ArgNs of
-        [_] -> "an opaque term as ";
-        [_,_|_] -> "opaque terms as "
-    end ++ form_position_string(ArgNs) ++
-        case ArgNs of
-            [_] -> " argument";
-            [_,_|_] -> " arguments"
-        end.
+        [_] ->     fmt("~!^an opaque term as ~!!~s~!^ argument", [ArgS]);
+        [_,_|_] -> fmt("~!^opaque terms as ~!!~s~!^ arguments", [ArgS])
+    end.
 
 %% We know which positions N are to blame;
 %% the list of triples will never be empty.

--- a/src/rebar_dialyzer_format.erl
+++ b/src/rebar_dialyzer_format.erl
@@ -2,40 +2,46 @@
 
 -include("rebar.hrl").
 
--export([format/1]).
+-export([format_warnings/1]).
+
+format_warnings(Warnings) ->
+    {_, Res} = lists:foldl(fun format_warning_/2, {undefined, []}, Warnings),
+    lists:reverse(Res).
 
 
-format(Warning) ->
-    Str = try
-              format_warning(Warning, fullpath)
-          catch
-              Error:Reason ->
-                  ?DEBUG("Failed to pretty format warning: ~p:~p",
-                         [Error, Reason]),
-                  dialyzer:format_warning(Warning, fullpath)
-          end,
-    case strip(Str) of
-        ":0: " ++ Unknown ->
-            Unknown;
-        Warning1 ->
-            Warning1
+format_warning_(Warning = {_Tag, {File, Line}, Msg}, {File, Acc}) ->
+    try
+        String = message_to_string(Msg),
+        {File, [lists:flatten(fmt("~!c~4w~!!: ~s", [Line, String])) | Acc]}
+    catch
+        Error:Reason ->
+            ?DEBUG("Failed to pretty format warning: ~p:~p",
+                   [Error, Reason]),
+            {File, [dialyzer:format_warning(Warning, fullpath) | Acc]}
+    end;
+
+format_warning_(Warning = {_Tag, {File, Line}, Msg}, {_LastFile, Acc}) ->
+    try
+        Base = filename:basename(File),
+        Dir = filename:dirname(File),
+        Root = filename:rootname(Base),
+        Ext = filename:extension(Base),
+        Path = re:replace(Dir, "^.*/_build/", "_build/", [{return, list}]),
+        Base1 = fmt("~!_c~s~!!~!__~s", [Root, Ext]),
+        F = fmt("~!__~s", [filename:join(Path, Base1)]),
+        String = message_to_string(Msg),
+        {File, [lists:flatten(fmt("~n~s~n~!c~4w~!!: ~s", [F, Line, String])) | Acc]}
+    catch
+        Error:Reason ->
+            ?DEBUG("Failed to pretty format warning: ~p:~p~n~p",
+                   [Error, Reason, erlang:get_stacktrace()]),
+            {File, [dialyzer:format_warning(Warning, fullpath) | Acc]}
     end.
-
-strip(Warning) ->
-    string:strip(Warning, right, $\n).
 
 fmt(Fmt) ->
     cf:format(Fmt, []).
 fmt(Fmt, Args) ->
     cf:format(Fmt, Args).
-
-format_warning({Tag, {File, Line, _MFA}, Msg}, FOpt) ->
-    format_warning({Tag, {File, Line}, Msg}, FOpt);
-format_warning({_Tag, {File, Line}, Msg}, fullpath) when is_list(File),
-                                                       is_integer(Line) ->
-    F = re:replace(File, "^.*/_build/", "_build/"),
-    String = lists:flatten(message_to_string(Msg)),
-    lists:flatten(fmt("~s:~w~n~s", [F, Line, String])).
 
 %%-----------------------------------------------------------------------------
 %% Message classification and pretty-printing below. Messages appear in
@@ -51,48 +57,48 @@ message_to_string({apply, [Args, ArgNs, FailReason,
 message_to_string({app_call, [M, F, Args, Culprit, ExpectedType, FoundType]}) ->
     fmt("~!^The call~!! ~s:~s~s ~!^requires that"
         "~!! ~s ~!^is of type ~!g~s~!^ not ~!r~s"
-        "~!!\n",
+        "~!!",
         [M, F, Args, Culprit, ExpectedType, FoundType]);
 message_to_string({bin_construction, [Culprit, Size, Seg, Type]}) ->
     fmt("~!^Binary construction will fail since the ~!b~s~!^ field~!!"
-        " ~s~!^ in segment~!! ~s~!^ has type~!! ~s\n",
+        " ~s~!^ in segment~!! ~s~!^ has type~!! ~s",
         [Culprit, Size, Seg, Type]);
 message_to_string({call, [M, F, Args, ArgNs, FailReason,
                           SigArgs, SigRet, Contract]}) ->
     fmt("~!^The call~!! ~w:~w~s ", [M, F, bad_arg(ArgNs, Args)]) ++
         call_or_apply_to_string(ArgNs, FailReason, SigArgs, SigRet, Contract);
 message_to_string({call_to_missing, [M, F, A]}) ->
-    fmt("~!^Call to missing or unexported function ~!!~w:~w/~w\n",
+    fmt("~!^Call to missing or unexported function ~!!~w:~w/~w",
         [M, F, A]);
 message_to_string({exact_eq, [Type1, Op, Type2]}) ->
-    fmt("~!^The test ~!!~s ~s ~s~!^ can never evaluate to 'true'\n",
+    fmt("~!^The test ~!!~s ~s ~s~!^ can never evaluate to 'true'",
         [Type1, Op, Type2]);
 message_to_string({fun_app_args, [Args, Type]}) ->
     fmt("~!^Fun application with arguments ~!!~s~!^ will fail"
-        " since the function has type ~!!~s\n", [Args, Type]);
+        " since the function has type ~!!~s", [Args, Type]);
 message_to_string({fun_app_no_fun, [Op, Type, Arity]}) ->
     fmt("~!^Fun application will fail since ~!!~s ~!^::~!! ~s"
-        " is not a function of arity ~!!~w\n", [Op, Type, Arity]);
+        " is not a function of arity ~!!~w", [Op, Type, Arity]);
 message_to_string({guard_fail, []}) ->
-    "~!^Clause guard cannot succeed.\n~!!";
+    "~!^Clause guard cannot succeed.~!!";
 message_to_string({guard_fail, [Arg1, Infix, Arg2]}) ->
-    fmt("~!^Guard test ~!!~s ~s ~s~!^ can never succeed\n",
+    fmt("~!^Guard test ~!!~s ~s ~s~!^ can never succeed",
         [Arg1, Infix, Arg2]);
 message_to_string({neg_guard_fail, [Arg1, Infix, Arg2]}) ->
-    fmt("~!^Guard test not(~!!~s ~s ~s~!^) can never succeed\n",
+    fmt("~!^Guard test not(~!!~s ~s ~s~!^) can never succeed",
         [Arg1, Infix, Arg2]);
 message_to_string({guard_fail, [Guard, Args]}) ->
-    fmt("~!^Guard test ~!!~w~s~!^ can never succeed\n",
+    fmt("~!^Guard test ~!!~w~s~!^ can never succeed",
         [Guard, Args]);
 message_to_string({neg_guard_fail, [Guard, Args]}) ->
-    fmt("~!^Guard test not(~!!~w~s~!^) can never succeed\n",
+    fmt("~!^Guard test not(~!!~w~s~!^) can never succeed",
         [Guard, Args]);
 message_to_string({guard_fail_pat, [Pat, Type]}) ->
     fmt("~!^Clause guard cannot succeed. The ~!!~s~!^ was matched"
-        " against the type ~!!~s\n", [Pat, Type]);
+        " against the type ~!!~s", [Pat, Type]);
 message_to_string({improper_list_constr, [TlType]}) ->
     fmt("~!^Cons will produce an improper list"
-        " since its ~!b2~!!nd~!^ argument is~!! ~s\n", [TlType]);
+        " since its ~!b2~!!nd~!^ argument is~!! ~s", [TlType]);
 message_to_string({no_return, [Type|Name]}) ->
     NameString =
         case Name of
@@ -100,133 +106,133 @@ message_to_string({no_return, [Type|Name]}) ->
             [F, A] -> fmt("~!^Function ~!r~w/~w ", [F, A])
         end,
     case Type of
-        no_match -> fmt("~s~!^has no clauses that will ever match\n",[NameString]);
-        only_explicit -> fmt("~s~!^only terminates with explicit exception\n", [NameString]);
-        only_normal -> fmt("~s~!^has no local return\n", [NameString]);
-        both -> fmt("~s~!^has no local return\n", [NameString])
+        no_match -> fmt("~s~!^has no clauses that will ever match",[NameString]);
+        only_explicit -> fmt("~s~!^only terminates with explicit exception", [NameString]);
+        only_normal -> fmt("~s~!^has no local return", [NameString]);
+        both -> fmt("~s~!^has no local return", [NameString])
     end;
 message_to_string({record_constr, [RecConstr, FieldDiffs]}) ->
     fmt("~!^Record construction ~!!~s~!^ violates the"
-        " declared type of field ~!!~s\n", [RecConstr, FieldDiffs]);
+        " declared type of field ~!!~s", [RecConstr, FieldDiffs]);
 message_to_string({record_constr, [Name, Field, Type]}) ->
     fmt("~!^Record construction violates the declared type for ~!!#~w{}~!^"
-        " since ~!!~s~!^ cannot be of type ~!!~s\n",
+        " since ~!!~s~!^ cannot be of type ~!!~s",
         [Name, Field, Type]);
 message_to_string({record_matching, [String, Name]}) ->
     fmt("~!^The ~!!~s~!^ violates the"
-        " declared type for ~!!#~w{}\n", [String, Name]);
+        " declared type for ~!!#~w{}", [String, Name]);
 message_to_string({record_match, [Pat, Type]}) ->
     fmt("~!^Matching of ~!!~s~!^ tagged with a record name violates the"
-        " declared type of ~!!~s\n", [Pat, Type]);
+        " declared type of ~!!~s", [Pat, Type]);
 message_to_string({pattern_match, [Pat, Type]}) ->
-    fmt("~!^The ~s~!^ can never match the type ~!g~s\n",
+    fmt("~!^The ~s~!^ can never match the type ~!g~s",
         [bad_pat(Pat), Type]);
 message_to_string({pattern_match_cov, [Pat, Type]}) ->
     fmt("~!^The ~s~!^ can never match since previous"
-        " clauses completely covered the type ~!g~s\n",
+        " clauses completely covered the type ~!g~s",
         [bad_pat(Pat), Type]);
 message_to_string({unmatched_return, [Type]}) ->
     fmt("~!^Expression produces a value of type ~!!~s~!^,"
-        " but this value is unmatched\n", [Type]);
+        " but this value is unmatched", [Type]);
 message_to_string({unused_fun, [F, A]}) ->
-    fmt("~!^Function ~!r~w/~w~!^ will never be called\n", [F, A]);
+    fmt("~!^Function ~!r~w/~w~!^ will never be called", [F, A]);
 %%----- Warnings for specs and contracts -------------------
 message_to_string({contract_diff, [M, F, _A, Contract, Sig]}) ->
     fmt("~!^Type specification ~!!~w:~w~s~!^"
-        " is not equal to the success typing: ~!!~w:~w~s\n",
+        " is not equal to the success typing: ~!!~w:~w~s",
         [M, F, Contract, M, F, Sig]);
 message_to_string({contract_subtype, [M, F, _A, Contract, Sig]}) ->
     fmt("~!^Type specification ~!!~w:~w~s~!^"
-        " is a subtype of the success typing: ~!!~w:~w~s\n",
+        " is a subtype of the success typing: ~!!~w:~w~s",
         [M, F, Contract, M, F, Sig]);
 message_to_string({contract_supertype, [M, F, _A, Contract, Sig]}) ->
     fmt("~!^Type specification ~!!~w:~w~s~!^"
-        " is a supertype of the success typing: ~!!~w:~w~s\n",
+        " is a supertype of the success typing: ~!!~w:~w~s",
         [M, F, Contract, M, F, Sig]);
 message_to_string({contract_range, [Contract, M, F, ArgStrings, Line, CRet]}) ->
     fmt("~!^The contract ~!!~w:~w~s~!^ cannot be right because the"
-        " inferred return for ~!!~w~s~!^ on line ~!!~w~!^ is ~!!~s\n",
+        " inferred return for ~!!~w~s~!^ on line ~!!~w~!^ is ~!!~s",
         [M, F, Contract, F, ArgStrings, Line, CRet]);
 message_to_string({invalid_contract, [M, F, A, Sig]}) ->
     fmt("~!^Invalid type specification for function~!! ~w:~w/~w."
-        "~!^ The success typing is~!! ~s\n", [M, F, A, Sig]);
+        "~!^ The success typing is~!! ~s", [M, F, A, Sig]);
 message_to_string({extra_range, [M, F, A, ExtraRanges, SigRange]}) ->
     fmt("~!^The specification for ~!!~w:~w/~w~!^ states that the function"
-        " might also return ~!!~s~!^ but the inferred return is ~!!~s\n",
+        " might also return ~!!~s~!^ but the inferred return is ~!!~s",
         [M, F, A, ExtraRanges, SigRange]);
 message_to_string({overlapping_contract, [M, F, A]}) ->
     fmt("~!^Overloaded contract for ~!!~w:~w/~w~!^ has overlapping"
         " domains; such contracts are currently unsupported and are simply "
-        "ignored\n", [M, F, A]);
+        "ignored", [M, F, A]);
 message_to_string({spec_missing_fun, [M, F, A]}) ->
-    fmt("~!^Contract for function that does not exist: ~!!~w:~w/~w\n",
+    fmt("~!^Contract for function that does not exist: ~!!~w:~w/~w",
         [M, F, A]);
 %%----- Warnings for opaque type violations -------------------
 message_to_string({call_with_opaque, [M, F, Args, ArgNs, ExpArgs]}) ->
-    fmt("~!^The call ~!!~w:~w~s~!^ contains ~!!~s~!^ when ~!!~s\n",
+    fmt("~!^The call ~!!~w:~w~s~!^ contains ~!!~s~!^ when ~!!~s",
         [M, F, Args, form_positions(ArgNs), form_expected(ExpArgs)]);
 message_to_string({call_without_opaque, [M, F, Args, [{N,_,_}|_] = ExpectedTriples]}) ->
-    fmt("~!^The call ~!!~w:~w~s ~!^does not have~!! ~s\n",
+    fmt("~!^The call ~!!~w:~w~s ~!^does not have~!! ~s",
         [M, F, bad_arg(N, Args), form_expected_without_opaque(ExpectedTriples)]);
 message_to_string({opaque_eq, [Type, _Op, OpaqueType]}) ->
     fmt("~!^Attempt to test for equality between a term of type ~!!~s~!^"
-        " and a term of opaque type ~!!~s\n", [Type, OpaqueType]);
+        " and a term of opaque type ~!!~s", [Type, OpaqueType]);
 message_to_string({opaque_guard, [Arg1, Infix, Arg2, ArgNs]}) ->
-    fmt("~!^Guard test ~!!~s ~s ~s~!^ contains ~!!~s\n",
+    fmt("~!^Guard test ~!!~s ~s ~s~!^ contains ~!!~s",
         [Arg1, Infix, Arg2, form_positions(ArgNs)]);
 message_to_string({opaque_guard, [Guard, Args]}) ->
     fmt("~!^Guard test ~!!~w~s~!^ breaks the opaqueness of its"
-        " argument\n", [Guard, Args]);
+        " argument", [Guard, Args]);
 message_to_string({opaque_match, [Pat, OpaqueType, OpaqueTerm]}) ->
     Term = if OpaqueType =:= OpaqueTerm -> "the term";
               true -> OpaqueTerm
            end,
     fmt("~!^The attempt to match a term of type ~!!~s~!^ against the"
-        "~!! ~s~!^ breaks the opaqueness of ~!!~s\n",
+        "~!! ~s~!^ breaks the opaqueness of ~!!~s",
         [OpaqueType, Pat, Term]);
 message_to_string({opaque_neq, [Type, _Op, OpaqueType]}) ->
     fmt("~!^Attempt to test for inequality between a term of type ~!!~s"
-        "~!^ and a term of opaque type ~!!~s\n", [Type, OpaqueType]);
+        "~!^ and a term of opaque type ~!!~s", [Type, OpaqueType]);
 message_to_string({opaque_type_test, [Fun, Args, Arg, ArgType]}) ->
     fmt("~!^The type test ~!!~s~s~!^ breaks the opaqueness of the term "
-        "~!!~s~s\n", [Fun, Args, Arg, ArgType]);
+        "~!!~s~s", [Fun, Args, Arg, ArgType]);
 message_to_string({opaque_size, [SizeType, Size]}) ->
-    fmt("~!^The size ~!!~s~!^ breaks the opaqueness of ~!!~s\n",
+    fmt("~!^The size ~!!~s~!^ breaks the opaqueness of ~!!~s",
         [SizeType, Size]);
 message_to_string({opaque_call, [M, F, Args, Culprit, OpaqueType]}) ->
     fmt("~!^The call ~!!~s:~s~s~!^ breaks the opaqueness of the term~!!"
-        " ~s :: ~s\n", [M, F, Args, Culprit, OpaqueType]);
+        " ~s :: ~s", [M, F, Args, Culprit, OpaqueType]);
 %%----- Warnings for concurrency errors --------------------
 message_to_string({race_condition, [M, F, Args, Reason]}) ->
-    fmt("~!^The call ~!!~w:~w~s ~s\n", [M, F, Args, Reason]);
+    fmt("~!^The call ~!!~w:~w~s ~s", [M, F, Args, Reason]);
 %%----- Warnings for behaviour errors --------------------
 message_to_string({callback_type_mismatch, [B, F, A, ST, CT]}) ->
     fmt("~!^The inferred return type of~!! ~w/~w (~s) ~!^"
         "has nothing in common with~!! ~s, ~!^which is the expected"
-        " return type for the callback of~!! ~w ~!^behaviour\n",
+        " return type for the callback of~!! ~w ~!^behaviour",
         [F, A, ST, CT, B]);
 message_to_string({callback_arg_type_mismatch, [B, F, A, N, ST, CT]}) ->
     fmt("~!^The inferred type for the~!! ~s ~!^argument of~!!"
         " ~w/~w (~s) ~!^is not a supertype of~!! ~s~!^, which is"
         "expected type for this argument in the callback of the~!! ~w "
-        "~!^behaviour\n",
+        "~!^behaviour",
         [ordinal(N), F, A, ST, CT, B]);
 message_to_string({callback_spec_type_mismatch, [B, F, A, ST, CT]}) ->
     fmt("~!^The return type ~!!~s~!^ in the specification of ~!!"
         "~w/~w~!^ is not a subtype of ~!!~s~!^, which is the expected"
-        " return type for the callback of ~!!~w~!^ behaviour\n",
+        " return type for the callback of ~!!~w~!^ behaviour",
         [ST, F, A, CT, B]);
 message_to_string({callback_spec_arg_type_mismatch, [B, F, A, N, ST, CT]}) ->
     fmt("~!^The specified type for the ~!!~s~!^ argument of ~!!"
         "~w/~w (~s)~!^ is not a supertype of ~!!~s~!^, which is"
         " expected type for this argument in the callback of the ~!!~w"
-        "~!^ behaviour\n", [ordinal(N), F, A, ST, CT, B]);
+        "~!^ behaviour", [ordinal(N), F, A, ST, CT, B]);
 message_to_string({callback_missing, [B, F, A]}) ->
     fmt("~!^Undefined callback function ~!!~w/~w~!^ (behaviour ~!!"
-        "'~w'~!^)\n",[F, A, B]);
+        "'~w'~!^)",[F, A, B]);
 message_to_string({callback_info_missing, [B]}) ->
     fmt("~!^Callback info about the ~!r~w~!^"
-        " behaviour is not available\n", [B]);
+        " behaviour is not available", [B]);
 %%----- Warnings for unknown functions, types, and behaviours -------------
 message_to_string({unknown_type, {M, F, A}}) ->
     fmt("~!^Unknown type ~!r~w:~w/~w", [M, F, A]);
@@ -248,26 +254,26 @@ call_or_apply_to_string(ArgNs, FailReason, SigArgs, SigRet,
                 true ->
                     %% We do not know which argument(s) caused the failure
                     fmt("~!^will never return since the success typing arguments"
-                        " are ~!!~s\n", [SigArgs]);
+                        " are ~!!~s", [SigArgs]);
                 false ->
                     fmt("~!^will never return since it differs in the~!!"
                         " ~s ~!^argument from the success typing"
-                        " arguments:~!! ~s\n",
+                        " arguments:~!! ~s",
                         [PositionString, good_arg(ArgNs, SigArgs)])
             end;
         only_contract ->
             case (ArgNs =:= []) orelse IsOverloaded of
                 true ->
                     %% We do not know which arguments caused the failure
-                    fmt("~!^breaks the contract~!! ~s\n", [good_arg(ArgNs, Contract)]);
+                    fmt("~!^breaks the contract~!! ~s", [good_arg(ArgNs, Contract)]);
                 false ->
                     fmt("~!^breaks the contract~!! ~s ~!^in the~!!"
-                        " ~s ~!^argument\n",
+                        " ~s ~!^argument",
                         [good_arg(ArgNs, Contract), PositionString])
             end;
         both ->
             fmt("~!^will never return since the success typing is "
-                "~!!~s ~!^->~!! ~s ~!^and the contract is ~!!~s\n",
+                "~!!~s ~!^->~!! ~s ~!^and the contract is ~!!~s",
                 [good_arg(ArgNs, SigArgs), SigRet,
                  good_arg(ArgNs, Contract)])
     end.

--- a/src/rebar_dialyzer_format.erl
+++ b/src/rebar_dialyzer_format.erl
@@ -56,8 +56,7 @@ message_to_string({apply, [Args, ArgNs, FailReason,
         call_or_apply_to_string(ArgNs, FailReason, SigArgs, SigRet, Contract);
 message_to_string({app_call, [M, F, Args, Culprit, ExpectedType, FoundType]}) ->
     fmt("~!^The call~!! ~s:~s~s ~!^requires that"
-        "~!! ~s ~!^is of type ~!g~s~!^ not ~!r~s"
-        "~!!",
+        "~!! ~s ~!^is of type ~!g~s~!^ not ~!r~s",
         [M, F, Args, Culprit, ExpectedType, FoundType]);
 message_to_string({bin_construction, [Culprit, Size, Seg, Type]}) ->
     fmt("~!^Binary construction will fail since the ~!b~s~!^ field~!!"
@@ -135,7 +134,7 @@ message_to_string({unmatched_return, [Type]}) ->
     fmt("~!^Expression produces a value of type ~!!~s~!^,"
         " but this value is unmatched", [Type]);
 message_to_string({unused_fun, [F, A]}) ->
-    fmt("~!^Function ~!r~w/~w~!^ will never be called", [F, A]);
+    fmt("~!^Function ~!r~w/~w~!!~!^ will never be called", [F, A]);
 %%----- Warnings for specs and contracts -------------------
 message_to_string({contract_diff, [M, F, _A, Contract, Sig]}) ->
     fmt("~!^Type specification ~!!~w:~w~s~!^"
@@ -231,7 +230,7 @@ message_to_string({callback_missing, [B, F, A]}) ->
     fmt("~!^Undefined callback function ~!!~w/~w~!^ (behaviour ~!!"
         "'~w'~!^)",[F, A, B]);
 message_to_string({callback_info_missing, [B]}) ->
-    fmt("~!^Callback info about the ~!r~w~!^"
+    fmt("~!^Callback info about the ~!r~w~!!~!^"
         " behaviour is not available", [B]);
 %%----- Warnings for unknown functions, types, and behaviours -------------
 message_to_string({unknown_type, {M, F, A}}) ->

--- a/src/rebar_dialyzer_format.erl
+++ b/src/rebar_dialyzer_format.erl
@@ -169,7 +169,7 @@ message_to_string({spec_missing_fun, [M, F, A]}) ->
 %%----- Warnings for opaque type violations -------------------
 message_to_string({call_with_opaque, [M, F, Args, ArgNs, ExpArgs]}) ->
     fmt("~!^The call ~!!~w:~w~s~!^ contains ~!!~s~!^ when ~!!~s",
-        [M, F, Args, form_positions(ArgNs), form_expected(ExpArgs)]);
+        [M, F, bad_arg(ArgNs, Args), form_positions(ArgNs), form_expected(ExpArgs)]);
 message_to_string({call_without_opaque, [M, F, Args, [{N,_,_}|_] = ExpectedTriples]}) ->
     fmt("~!^The call ~!!~w:~w~s ~!^does not have~!! ~s",
         [M, F, bad_arg(N, Args), form_expected_without_opaque(ExpectedTriples)]);

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -402,14 +402,10 @@ run_dialyzer(State, Opts, Output) ->
     end.
 
 format_warnings(Output, Warnings) ->
-    Warnings1 = format_warnings(Warnings),
+    Warnings1 = rebar_dialyzer_format:format_warnings(Warnings),
     console_warnings(Warnings1),
     file_warnings(Output, Warnings),
     length(Warnings1).
-
-format_warnings(Warnings) ->
-    [rebar_dialyzer_format:format(Warning) || Warning <- Warnings].
-
 
 console_warnings(Warnings) ->
     _ = [?CONSOLE("~s", [Warning]) || Warning <- Warnings],

--- a/src/rebar_prv_dialyzer.erl
+++ b/src/rebar_prv_dialyzer.erl
@@ -405,7 +405,7 @@ format_warnings(Output, Warnings) ->
     Warnings1 = rebar_dialyzer_format:format_warnings(Warnings),
     console_warnings(Warnings1),
     file_warnings(Output, Warnings),
-    length(Warnings1).
+    length(Warnings).
 
 console_warnings(Warnings) ->
     _ = [?CONSOLE("~s", [Warning]) || Warning <- Warnings],


### PR DESCRIPTION
Some more improvements on output, it's now easier to spot the file / line number the warning is in those are coded cyan. Also warnings are grouped by file now and the filename is only printed once. 

This combination allows for a more concise output while staying nicely readable.
![1 bash 2015-09-22 19-18-31](https://cloud.githubusercontent.com/assets/119093/10025865/bb9fad28-615e-11e5-8b4c-af626b577fbe.png)
