### PR TITLE
handle newly added deps to config even when lock is empty

### DIFF
--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -86,9 +86,6 @@ verify_config_format([Term | _]) ->
 %% no lockfile
 merge_locks(Config, []) ->
     Config;
-%% empty lockfile
-merge_locks(Config, [[]]) ->
-    Config;
 %% lockfile with entries
 merge_locks(Config, [Locks]) ->
     ConfigDeps = proplists:get_value(deps, Config, []),


### PR DESCRIPTION
Stupidly wasn't parsing an empty lock like a normal lock file. Getting rid of that special case in `rebar_config` makes sure newly added deps are treated the same whether the lock is empty or contains locks -- but exists. Also adds a test for that case, we were already testing the case that the lock had contents and a new dep was added to rebar.config.