### PR TITLE
make short name the default in vmargs

### DIFF
--- a/priv/templates/vm.args
+++ b/priv/templates/vm.args
@@ -1,4 +1,4 @@
--name {{name}}
+-sname {{name}}
 
 -setcookie {{name}}_cookie
 


### PR DESCRIPTION
Better default. More likely that the long name doesn't work for someone than the short name.