### PR TITLE
Fix for issue #859 - unicode rendering of deps tree

### DIFF
--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -66,13 +66,13 @@ print_children(_, [], _, _) ->
 print_children(Prefix, [{Name, Vsn, Source} | Rest], Dict, Verbose) ->
     Prefix1 = case Rest of
                   [] ->
-                      io:format("~ts└─ ", [Prefix]),
-                      [Prefix, "   "];
+                      io:format("~ts~ts", [Prefix, <<"└─ ">>]),
+                      [Prefix, <<"   ">>];
                   _ ->
-                      io:format("~ts├─ ", [Prefix]),
-                      [Prefix, "│  "]
+                      io:format("~ts~ts", [Prefix, <<"├─ ">>]),
+                      [Prefix, <<"│  ">>]
               end,
-    io:format("~ts─~ts (~ts)~n", [Name, Vsn, type(Source, Verbose)]),
+    io:format("~ts~ts~ts (~ts)~n", [Name, <<"─">>, Vsn, type(Source, Verbose)]),
     case dict:find(Name, Dict) of
         {ok, Children} ->
             print_children(Prefix1, lists:keysort(1, Children), Dict, Verbose),


### PR DESCRIPTION
Fix issue #859 by moving utf-8 encoded strings into binaries
(see http://www.erlang.org/doc/apps/stdlib/unicode_usage.html)
