### PR TITLE
Fix for issue #859 - unicode rendering of deps tree based on PR #865

### DIFF
--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -66,13 +66,13 @@ print_children(_, [], _, _) ->
 print_children(Prefix, [{Name, Vsn, Source} | Rest], Dict, Verbose) ->
     Prefix1 = case Rest of
                   [] ->
-                      io:format("~ts└─ ", [Prefix]),
+                      io:format("~ts~ts", [Prefix, <<"└─ "/utf8>>]),
                       [Prefix, "   "];
                   _ ->
-                      io:format("~ts├─ ", [Prefix]),
+                      io:format("~ts~ts", [Prefix, <<"├─ "/utf8>>]),
                       [Prefix, "│  "]
               end,
-    io:format("~ts─~ts (~ts)~n", [Name, Vsn, type(Source, Verbose)]),
+    io:format("~ts~ts~ts (~ts)~n", [Name, <<"─"/utf8>>, Vsn, type(Source, Verbose)]),
     case dict:find(Name, Dict) of
         {ok, Children} ->
             print_children(Prefix1, lists:keysort(1, Children), Dict, Verbose),

--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -66,13 +66,13 @@ print_children(_, [], _, _) ->
 print_children(Prefix, [{Name, Vsn, Source} | Rest], Dict, Verbose) ->
     Prefix1 = case Rest of
                   [] ->
-                      io:format("~ts~ts", [Prefix, <<226,148,148,226,148,128,32>>]),
+                      io:format("~ts~ts", [Prefix, <<226,148,148,226,148,128,32>>]), %Binary for └─ utf8%
                       [Prefix, "   "];
                   _ ->
-                      io:format("~ts~ts", [Prefix, <<226,148,156,226,148,128,32>>]),
+                      io:format("~ts~ts", [Prefix, <<226,148,156,226,148,128,32>>]), %Binary for ├─ utf8%
                       [Prefix, "│  "]
               end,
-    io:format("~ts~ts~ts (~ts)~n", [Name, <<226,148,128>>, Vsn, type(Source, Verbose)]),
+    io:format("~ts~ts~ts (~ts)~n", [Name, <<226,148,128>>, Vsn, type(Source, Verbose)]), %Binary for ─ utf8%
     case dict:find(Name, Dict) of
         {ok, Children} ->
             print_children(Prefix1, lists:keysort(1, Children), Dict, Verbose),

--- a/src/rebar_prv_deps_tree.erl
+++ b/src/rebar_prv_deps_tree.erl
@@ -66,13 +66,13 @@ print_children(_, [], _, _) ->
 print_children(Prefix, [{Name, Vsn, Source} | Rest], Dict, Verbose) ->
     Prefix1 = case Rest of
                   [] ->
-                      io:format("~ts~ts", [Prefix, <<"└─ "/utf8>>]),
+                      io:format("~ts~ts", [Prefix, <<226,148,148,226,148,128,32>>]),
                       [Prefix, "   "];
                   _ ->
-                      io:format("~ts~ts", [Prefix, <<"├─ "/utf8>>]),
+                      io:format("~ts~ts", [Prefix, <<226,148,156,226,148,128,32>>]),
                       [Prefix, "│  "]
               end,
-    io:format("~ts~ts~ts (~ts)~n", [Name, <<"─"/utf8>>, Vsn, type(Source, Verbose)]),
+    io:format("~ts~ts~ts (~ts)~n", [Name, <<226,148,128>>, Vsn, type(Source, Verbose)]),
     case dict:find(Name, Dict) of
         {ok, Children} ->
             print_children(Prefix1, lists:keysort(1, Children), Dict, Verbose),


### PR DESCRIPTION
Fix for issue #859 - unicode rendering of deps tree based on PR #865
modified PR #865 to the /utf8 flag indicates this is supposed to be a UTF8 string.