### PR TITLE
Rebar compile umbrella tests

### DIFF
--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -571,6 +571,10 @@ mib_test(Config) ->
     PrivMibsDir = filename:join([ProjectDir, "_build", "default", "lib", Name, "priv", "mibs"]),
     true = filelib:is_file(filename:join([PrivMibsDir, "SIMPLE-MIB.bin"])),
 
+    %% check mib header
+    IncludeDir = filename:join([ProjectDir, "_build", "default", "lib", Name, "include"]),
+    true = filelib:is_file(filename:join([IncludeDir, "SIMPLE-MIB.hrl"])),
+
     %% check the extra src_dir was linked into the _build dir
     true = filelib:is_dir(filename:join([ProjectDir, "_build", "default", "lib", Name, "mibs"])).
 

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -21,6 +21,7 @@ init_rebar_state(Config, Name) ->
     application:load(rebar),
     DataDir = ?config(priv_dir, Config),
     AppsDir = filename:join([DataDir, create_random_name(Name)]),
+    SubjectDir = filename:join([AppsDir, proplists:get_value(subject_relative_dir, Config, ".")]),
     CheckoutsDir = filename:join([AppsDir, "_checkouts"]),
     ok = ec_file:mkdir_p(AppsDir),
     ok = ec_file:mkdir_p(CheckoutsDir),
@@ -30,7 +31,7 @@ init_rebar_state(Config, Name) ->
     State = rebar_state:new([{base_dir, filename:join([AppsDir, "_build"])}
                             ,{global_rebar_dir, GlobalDir}
                             ,{root_dir, AppsDir}]),
-    [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, State} | Config].
+    [{apps, AppsDir}, {checkouts, CheckoutsDir}, {state, State}, {subject_dir, SubjectDir} | Config].
 
 %% @doc Takes common test config, a rebar config ([] if empty), a command to
 %% run ("install_deps", "compile", etc.), and a list of expected applications


### PR DESCRIPTION
*The obvious*: This branch generalizes some infrastructure in `rebar_compile_SUITE` so that tests can be written once and then run in both umbrella and plain application mode.  Existing cases are backwards compatible, but some have been updated to be "dual use".

*The less obvious*:  This branch adds a test that reveals multiple problems in MIB compilation.
