### PR TITLE
Bump cf for fixing #879

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,7 @@
         {getopt,              "0.8.2"},
         {bbmustache,          "1.0.4"},
         {relx,                "3.7.1"},
-        {cf,                  "0.1.2"}]}.
+        {cf,                  "0.1.3"}]}.
 
 {escript_name, rebar3}.
 {escript_emu_args, "%%! +sbtu +A0\n"}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,6 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.4">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"0.1.1">>},0},
- {<<"cf">>,{pkg,<<"cf">>,<<"0.1.2">>},0},
+ {<<"cf">>,{pkg,<<"cf">>,<<"0.1.3">>},0},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.16.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.5.0">>},0},


### PR DESCRIPTION
cf 0.1.3 fixes the issue mentioned in #879 and marks all xterm* terminals as colour capable.