### PR TITLE
compiler refactor/eunit & ct fixes

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -18,6 +18,7 @@
                       {"rebar/priv/templates/*", "_build/default/lib/"}]}.
 
 {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
+            {platform_define, "^R1[4|5]", no_list_dir_all},
             no_debug_info,
             warnings_as_errors]}.
 

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -92,13 +92,13 @@
 %% @equiv compile(AppInfo, []).
 
 -spec compile(rebar_app_info:t()) -> ok.
-compile(AppInfo) when is_tuple(AppInfo), element(1, AppInfo) == app_info_t ->
+compile(AppInfo) when element(1, AppInfo) == app_info_t ->
     compile(AppInfo, []).
 
 %% @doc compile an individual application.
 
 -spec compile(rebar_app_info:t(), compile_opts()) -> ok.
-compile(AppInfo, CompileOpts) when is_tuple(AppInfo), element(1, AppInfo) == app_info_t ->
+compile(AppInfo, CompileOpts) when element(1, AppInfo) == app_info_t ->
     Dir = ec_cnv:to_list(rebar_app_info:out_dir(AppInfo)),
     RebarOpts = rebar_app_info:opts(AppInfo),
 
@@ -139,7 +139,7 @@ compile(AppInfo, CompileOpts) when is_tuple(AppInfo), element(1, AppInfo) == app
 %% directory of those src_dirs
 
 -spec compile(rebar_dict() | rebar_state:t(), file:name(), file:name()) -> ok.
-compile(State, BaseDir, OutDir) when is_tuple(State), element(1, State) == state_t ->
+compile(State, BaseDir, OutDir) when element(1, State) == state_t ->
     compile(rebar_state:opts(State), BaseDir, OutDir, [{recursive, false}]);
 compile(RebarOpts, BaseDir, OutDir) ->
     compile(RebarOpts, BaseDir, OutDir, [{recursive, false}]).
@@ -147,7 +147,7 @@ compile(RebarOpts, BaseDir, OutDir) ->
 %% @hidden
 
 -spec compile(rebar_dict() | rebar_state:t(), file:name(), file:name(), compile_opts()) -> ok.
-compile(State, BaseDir, OutDir, CompileOpts) when is_tuple(State), element(1, State) == state_t ->
+compile(State, BaseDir, OutDir, CompileOpts) when element(1, State) == state_t ->
     compile(rebar_state:opts(State), BaseDir, OutDir, CompileOpts);
 compile(RebarOpts, BaseDir, OutDir, CompileOpts) ->
     SrcDirs = lists:map(fun(SrcDir) -> filename:join(BaseDir, SrcDir) end,
@@ -166,7 +166,7 @@ compile(RebarOpts, BaseDir, OutDir, CompileOpts) ->
 %% @equiv compile_dirs(Context, BaseDir, [Dir], Dir, [{recursive, false}]).
 
 -spec compile_dir(rebar_dict() | rebar_state:t(), file:name(), file:name()) -> ok.
-compile_dir(State, BaseDir, Dir) when is_tuple(State), element(1, State) == state_t ->
+compile_dir(State, BaseDir, Dir) when element(1, State) == state_t ->
     compile_dir(rebar_state:opts(State), BaseDir, Dir, [{recursive, false}]);
 compile_dir(RebarOpts, BaseDir, Dir) ->
     compile_dir(RebarOpts, BaseDir, Dir, [{recursive, false}]).
@@ -174,7 +174,7 @@ compile_dir(RebarOpts, BaseDir, Dir) ->
 %% @equiv compile_dirs(Context, BaseDir, [Dir], Dir, Opts).
 
 -spec compile_dir(rebar_dict() | rebar_state:t(), file:name(), file:name(), compile_opts()) -> ok.
-compile_dir(State, BaseDir, Dir, Opts) when is_tuple(State), element(1, State) == state_t ->
+compile_dir(State, BaseDir, Dir, Opts) when element(1, State) == state_t ->
     compile_dirs(rebar_state:opts(State), BaseDir, [Dir], Dir, Opts);
 compile_dir(RebarOpts, BaseDir, Dir, Opts) ->
     compile_dirs(RebarOpts, BaseDir, [Dir], Dir, Opts).
@@ -186,14 +186,16 @@ compile_dir(RebarOpts, BaseDir, Dir, Opts) ->
                    [file:filename()],
                    file:filename(),
                    compile_opts()) -> ok.
-compile_dirs(State, BaseDir, Dirs, OutDir, CompileOpts) when is_tuple(State), element(1, State) == state_t ->
+compile_dirs(State, BaseDir, Dirs, OutDir, CompileOpts) when element(1, State) == state_t ->
     compile_dirs(rebar_state:opts(State), BaseDir, Dirs, OutDir, CompileOpts);
 compile_dirs(RebarOpts, BaseDir, SrcDirs, OutDir, Opts) ->
     CompileOpts = parse_opts(Opts),
   
     ErlOpts = rebar_opts:erl_opts(RebarOpts),
+    ?DEBUG("erlopts ~p", [ErlOpts]),
     Recursive = CompileOpts#compile_opts.recursive,
     AllErlFiles = gather_src(SrcDirs, Recursive),
+    ?DEBUG("files to compile ~p", [AllErlFiles]),
 
     %% Make sure that outdir is on the path
     ok = filelib:ensure_dir(filename:join(OutDir, "dummy.beam")),

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -26,8 +26,9 @@
 %% -------------------------------------------------------------------
 -module(rebar_erlc_compiler).
 
--export([compile/1,
-         compile/3,
+-export([compile/1, compile/2, compile/3,
+         compile_dir/3, compile_dir/4,
+         compile_dirs/5,
          clean/1]).
 
 -include("rebar.hrl").
@@ -38,13 +39,21 @@
 -type erlc_info_v() :: {digraph:vertex(), term()} | 'false'.
 -type erlc_info_e() :: {digraph:vertex(), digraph:vertex()}.
 -type erlc_info() :: {list(erlc_info_v()), list(erlc_info_e()), list(string())}.
--record(erlcinfo,
-        {
-          vsn = ?ERLCINFO_VSN :: pos_integer(),
-          info = {[], [], []} :: erlc_info()
-        }).
+-record(erlcinfo, {
+    vsn = ?ERLCINFO_VSN :: pos_integer(),
+    info = {[], [], []} :: erlc_info()
+}).
 
+-type compile_opts() :: [compile_opt()].
+-type compile_opt() :: {recursive, boolean()}.
+
+-record(compile_opts, {
+    recursive = true
+}).
+
+-define(DEFAULT_OUTDIR, "ebin").
 -define(RE_PREFIX, "^[^._]").
+
 
 %% ===================================================================
 %% Public API
@@ -80,106 +89,189 @@
 %%                           'old_inets'}]}.
 %%
 
--spec compile(rebar_app_info:t()) -> 'ok'.
-compile(AppInfo) ->
-    Dir = ec_cnv:to_list(rebar_app_info:out_dir(AppInfo)),
-    compile(rebar_app_info:opts(AppInfo), Dir, filename:join([Dir, "ebin"])).
+%% @equiv compile(AppInfo, []).
 
--spec compile(rebar_dict(), file:name(), file:name()) -> 'ok'.
-compile(Opts, Dir, OutDir) ->
-    rebar_base_compiler:run(Opts,
+-spec compile(rebar_app_info:t()) -> ok.
+compile(AppInfo) when is_tuple(AppInfo), element(1, AppInfo) == app_info_t ->
+    compile(AppInfo, []).
+
+%% @doc compile an individual application.
+
+-spec compile(rebar_app_info:t(), compile_opts()) -> ok.
+compile(AppInfo, CompileOpts) when is_tuple(AppInfo), element(1, AppInfo) == app_info_t ->
+    Dir = ec_cnv:to_list(rebar_app_info:out_dir(AppInfo)),
+    RebarOpts = rebar_app_info:opts(AppInfo),
+
+    rebar_base_compiler:run(RebarOpts,
                             check_files([filename:join(Dir, File)
-                                         || File <- rebar_opts:get(Opts, xrl_first_files, [])]),
+                                         || File <- rebar_opts:get(RebarOpts, xrl_first_files, [])]),
                             filename:join(Dir, "src"), ".xrl", filename:join(Dir, "src"), ".erl",
                             fun compile_xrl/3),
-    rebar_base_compiler:run(Opts,
+    rebar_base_compiler:run(RebarOpts,
                             check_files([filename:join(Dir, File)
-                                         || File <- rebar_opts:get(Opts, yrl_first_files, [])]),
+                                         || File <- rebar_opts:get(RebarOpts, yrl_first_files, [])]),
                             filename:join(Dir, "src"), ".yrl", filename:join(Dir, "src"), ".erl",
                             fun compile_yrl/3),
-    rebar_base_compiler:run(Opts,
+    rebar_base_compiler:run(RebarOpts,
                             check_files([filename:join(Dir, File)
-                                         || File <- rebar_opts:get(Opts, mib_first_files, [])]),
+                                         || File <- rebar_opts:get(RebarOpts, mib_first_files, [])]),
                             filename:join(Dir, "mibs"), ".mib", filename:join([Dir, "priv", "mibs"]), ".bin",
                             fun compile_mib/3),
-    doterl_compile(Opts, Dir, OutDir).
 
--spec clean(file:filename()) -> 'ok'.
-clean(AppDir) ->
-    MibFiles = rebar_utils:find_files(filename:join(AppDir, "mibs"), ?RE_PREFIX".*\\.mib\$"),
-    MIBs = [filename:rootname(filename:basename(MIB)) || MIB <- MibFiles],
-    rebar_file_utils:delete_each(
-      [filename:join([AppDir, "include",MIB++".hrl"]) || MIB <- MIBs]),
-    lists:foreach(fun(F) -> ok = rebar_file_utils:rm_rf(F) end,
-                  [filename:join(AppDir, "ebin/*.beam"), filename:join(AppDir, "priv/mibs/*.bin")]),
+    SrcDirs = lists:map(fun(SrcDir) -> filename:join(Dir, SrcDir) end,
+                        rebar_dir:src_dirs(RebarOpts, ["src"])),
+    OutDir = filename:join(Dir, outdir(RebarOpts)),
+    compile_dirs(RebarOpts, Dir, SrcDirs, OutDir, CompileOpts),
 
-    YrlFiles = rebar_utils:find_files(filename:join(AppDir, "src"), ?RE_PREFIX".*\\.[x|y]rl\$"),
-    rebar_file_utils:delete_each(
-      [ binary_to_list(iolist_to_binary(re:replace(F, "\\.[x|y]rl$", ".erl")))
-        || F <- YrlFiles ]),
+    ExtraDirs = rebar_dir:extra_src_dirs(RebarOpts),
+    F = fun(D) ->
+        case ec_file:is_dir(filename:join([Dir, D])) of
+            true  -> compile_dirs(RebarOpts, Dir, [D], D, CompileOpts);
+            false -> ok
+        end
+    end,
+    lists:foreach(F, lists:map(fun(SrcDir) -> filename:join(Dir, SrcDir) end, ExtraDirs)).
 
-    %% Delete the build graph, if any
-    rebar_file_utils:rm_rf(erlcinfo_file(AppDir)),
+%% @hidden
+%% these are kept for backwards compatibility but they're bad functions with
+%% bad interfaces you probably shouldn't use
+%% State/RebarOpts have to have src_dirs set and BaseDir must be the parent
+%% directory of those src_dirs
 
-    %% Erlang compilation is recursive, so it's possible that we have a nested
-    %% directory structure in ebin with .beam files within. As such, we want
-    %% to scan whatever is left in the ebin/ directory for sub-dirs which
-    %% satisfy our criteria.
-    BeamFiles = rebar_utils:find_files(filename:join(AppDir, "ebin"), ?RE_PREFIX".*\\.beam\$"),
-    rebar_file_utils:delete_each(BeamFiles),
-    lists:foreach(fun(Dir) -> delete_dir(Dir, dirs(Dir)) end, dirs(filename:join(AppDir, "ebin"))),
-    ok.
+-spec compile(rebar_dict() | rebar_state:t(), file:name(), file:name()) -> ok.
+compile(State, BaseDir, OutDir) when is_tuple(State), element(1, State) == state_t ->
+    compile(rebar_state:opts(State), BaseDir, OutDir, [{recursive, false}]);
+compile(RebarOpts, BaseDir, OutDir) ->
+    compile(RebarOpts, BaseDir, OutDir, [{recursive, false}]).
 
-%% ===================================================================
-%% Internal functions
-%% ===================================================================
+%% @hidden
 
--spec doterl_compile(rebar_dict(), file:filename(), file:filename()) -> ok.
-doterl_compile(Opts, Dir, ODir) ->
-    ErlOpts = rebar_opts:erl_opts(Opts),
-    doterl_compile(Opts, Dir, ODir, [], ErlOpts).
+-spec compile(rebar_dict() | rebar_state:t(), file:name(), file:name(), compile_opts()) -> ok.
+compile(State, BaseDir, OutDir, CompileOpts) when is_tuple(State), element(1, State) == state_t ->
+    compile(rebar_state:opts(State), BaseDir, OutDir, CompileOpts);
+compile(RebarOpts, BaseDir, OutDir, CompileOpts) ->
+    SrcDirs = lists:map(fun(SrcDir) -> filename:join(BaseDir, SrcDir) end,
+                        rebar_dir:src_dirs(RebarOpts, ["src"])),
+    compile_dirs(RebarOpts, BaseDir, SrcDirs, OutDir, CompileOpts),
 
-doterl_compile(Opts, Dir, OutDir, MoreSources, ErlOpts) ->
-    ?DEBUG("erl_opts ~p", [ErlOpts]),
-    %% Support the src_dirs option allowing multiple directories to
-    %% contain erlang source. This might be used, for example, should
-    %% eunit tests be separated from the core application source.
-    SrcDirs = [filename:join(Dir, X) || X <- rebar_dir:all_src_dirs(Opts, ["src"], [])],
-    AllErlFiles = gather_src(SrcDirs, []) ++ MoreSources,
+    ExtraDirs = rebar_dir:extra_src_dirs(RebarOpts),
+    F = fun(D) ->
+        case ec_file:is_dir(filename:join([BaseDir, D])) of
+            true  -> compile_dirs(RebarOpts, BaseDir, [D], D, CompileOpts);
+            false -> ok
+        end
+    end,
+    lists:foreach(F, lists:map(fun(SrcDir) -> filename:join(BaseDir, SrcDir) end, ExtraDirs)).
 
-    %% Make sure that ebin/ exists and is on the path
+%% @equiv compile_dirs(Context, BaseDir, [Dir], Dir, [{recursive, false}]).
+
+-spec compile_dir(rebar_dict() | rebar_state:t(), file:name(), file:name()) -> ok.
+compile_dir(State, BaseDir, Dir) when is_tuple(State), element(1, State) == state_t ->
+    compile_dir(rebar_state:opts(State), BaseDir, Dir, [{recursive, false}]);
+compile_dir(RebarOpts, BaseDir, Dir) ->
+    compile_dir(RebarOpts, BaseDir, Dir, [{recursive, false}]).
+
+%% @equiv compile_dirs(Context, BaseDir, [Dir], Dir, Opts).
+
+-spec compile_dir(rebar_dict() | rebar_state:t(), file:name(), file:name(), compile_opts()) -> ok.
+compile_dir(State, BaseDir, Dir, Opts) when is_tuple(State), element(1, State) == state_t ->
+    compile_dirs(rebar_state:opts(State), BaseDir, [Dir], Dir, Opts);
+compile_dir(RebarOpts, BaseDir, Dir, Opts) ->
+    compile_dirs(RebarOpts, BaseDir, [Dir], Dir, Opts).
+
+%% @doc compile a list of directories with the given opts.
+
+-spec compile_dirs(rebar_dict() | rebar_state:t(),
+                   file:filename(),
+                   [file:filename()],
+                   file:filename(),
+                   compile_opts()) -> ok.
+compile_dirs(State, BaseDir, Dirs, OutDir, CompileOpts) when is_tuple(State), element(1, State) == state_t ->
+    compile_dirs(rebar_state:opts(State), BaseDir, Dirs, OutDir, CompileOpts);
+compile_dirs(RebarOpts, BaseDir, SrcDirs, OutDir, Opts) ->
+    CompileOpts = parse_opts(Opts),
+  
+    ErlOpts = rebar_opts:erl_opts(RebarOpts),
+    Recursive = CompileOpts#compile_opts.recursive,
+    AllErlFiles = gather_src(SrcDirs, Recursive),
+
+    %% Make sure that outdir is on the path
     ok = filelib:ensure_dir(filename:join(OutDir, "dummy.beam")),
     true = code:add_patha(filename:absname(OutDir)),
 
-    OutDir1 = proplists:get_value(outdir, ErlOpts, OutDir),
+    G = init_erlcinfo(proplists:get_all_values(i, ErlOpts), AllErlFiles, BaseDir, OutDir),
 
-    G = init_erlcinfo(proplists:get_all_values(i, ErlOpts), AllErlFiles, Dir, OutDir),
-
-    NeededErlFiles = needed_files(G, ErlOpts, Dir, OutDir1, AllErlFiles),
-    {ErlFirstFiles, ErlOptsFirst} = erl_first_files(Opts, ErlOpts, Dir, NeededErlFiles),
+    NeededErlFiles = needed_files(G, ErlOpts, BaseDir, OutDir, AllErlFiles),
+    {ErlFirstFiles, ErlOptsFirst} = erl_first_files(RebarOpts, ErlOpts, BaseDir, NeededErlFiles),
     {DepErls, OtherErls} = lists:partition(
                              fun(Source) -> digraph:in_degree(G, Source) > 0 end,
                              [File || File <- NeededErlFiles, not lists:member(File, ErlFirstFiles)]),
     SubGraph = digraph_utils:subgraph(G, DepErls),
     DepErlsOrdered = digraph_utils:topsort(SubGraph),
     FirstErls = ErlFirstFiles ++ lists:reverse(DepErlsOrdered),
-    ?DEBUG("Files to compile first: ~p", [FirstErls]),
     try
         rebar_base_compiler:run(
-          Opts, FirstErls, OtherErls,
-          fun(S, C) ->
-                  ErlOpts1 = case lists:member(S, ErlFirstFiles) of
-                                 true -> ErlOptsFirst;
-                                 false -> ErlOpts
-                             end,
-                  internal_erl_compile(C, Dir, S, OutDir1, ErlOpts1)
-          end)
+            RebarOpts, FirstErls, OtherErls,
+            fun(S, C) ->
+                    ErlOpts1 = case lists:member(S, ErlFirstFiles) of
+                                   true -> ErlOptsFirst;
+                                   false -> ErlOpts
+                               end,
+                    internal_erl_compile(C, BaseDir, S, OutDir, ErlOpts1)
+            end)
     after
         true = digraph:delete(SubGraph),
         true = digraph:delete(G)
     end,
     ok.
 
+%% @doc remove compiled artifacts from an AppDir.
+
+-spec clean(rebar_app_info:t()) -> 'ok'.
+clean(AppInfo) ->
+    AppDir = rebar_app_info:out_dir(AppInfo),
+
+    MibFiles = rebar_utils:find_files(filename:join([AppDir, "mibs"]), ?RE_PREFIX".*\\.mib\$"),
+    MIBs = [filename:rootname(filename:basename(MIB)) || MIB <- MibFiles],
+    rebar_file_utils:delete_each(
+      [filename:join([AppDir, "include",MIB++".hrl"]) || MIB <- MIBs]),
+    ok = rebar_file_utils:rm_rf(filename:join([AppDir, "priv/mibs/*.bin"])),
+
+    YrlFiles = rebar_utils:find_files(filename:join([AppDir, "src"]), ?RE_PREFIX".*\\.[x|y]rl\$"),
+    rebar_file_utils:delete_each(
+      [ binary_to_list(iolist_to_binary(re:replace(F, "\\.[x|y]rl$", ".erl")))
+        || F <- YrlFiles ]),
+
+    BinDirs = ["ebin"|rebar_dir:extra_src_dirs(rebar_app_info:opts(AppInfo))],
+    ok = clean_dirs(AppDir, BinDirs),
+
+    %% Delete the build graph, if any
+    rebar_file_utils:rm_rf(erlcinfo_file(AppDir)).
+
+clean_dirs(_AppDir, []) -> ok;
+clean_dirs(AppDir, [Dir|Rest]) ->
+    ok = rebar_file_utils:rm_rf(filename:join([AppDir, Dir, "*.beam"])),
+    %% Erlang compilation is recursive, so it's possible that we have a nested
+    %% directory structure in ebin with .beam files within. As such, we want
+    %% to scan whatever is left in the app's out_dir directory for sub-dirs which
+    %% satisfy our criteria.
+    BeamFiles = rebar_utils:find_files(filename:join([AppDir, Dir]), ?RE_PREFIX".*\\.beam\$"),
+    rebar_file_utils:delete_each(BeamFiles),
+    lists:foreach(fun(D) -> delete_dir(D, dirs(D)) end, dirs(filename:join([AppDir, Dir]))),
+    clean_dirs(AppDir, Rest).
+
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+gather_src(Dirs, Recursive) ->
+    gather_src(Dirs, [], Recursive).
+
+gather_src([], Srcs, _Recursive) -> Srcs;
+gather_src([Dir|Rest], Srcs, Recursive) ->
+    gather_src(Rest, Srcs ++ rebar_utils:find_files(Dir, ?RE_PREFIX".*\\.erl\$", Recursive), Recursive).
+    
 %% Get files which need to be compiled first, i.e. those specified in erl_first_files
 %% and parse_transform options.  Also produce specific erl_opts for these first
 %% files, so that yet to be compiled parse transformations are excluded from it.
@@ -487,11 +579,7 @@ compile_xrl_yrl(_Opts, Source, Target, AllOpts, Mod) ->
 needs_compile(Source, Target) ->
     filelib:last_modified(Source) > filelib:last_modified(Target).
 
-gather_src([], Srcs) ->
-    Srcs;
-gather_src([Dir|Rest], Srcs) ->
-    gather_src(
-      Rest, Srcs ++ rebar_utils:find_files(Dir, ?RE_PREFIX".*\\.erl\$")).
+
 
 -spec dirs(file:filename()) -> [file:filename()].
 dirs(Dir) ->
@@ -620,3 +708,13 @@ check_file(File) ->
         false -> ?ABORT("File ~p is missing, aborting\n", [File]);
         true -> File
     end.
+
+outdir(RebarOpts) ->
+    ErlOpts = rebar_opts:erl_opts(RebarOpts),
+    proplists:get_value(outdir, ErlOpts, ?DEFAULT_OUTDIR).
+
+parse_opts(Opts) -> parse_opts(Opts, #compile_opts{}).
+
+parse_opts([], CompileOpts) -> CompileOpts;
+parse_opts([{recursive, Recursive}|Rest], CompileOpts) when Recursive == true; Recursive == false ->
+    parse_opts(Rest, CompileOpts#compile_opts{recursive = Recursive}).

--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -28,7 +28,6 @@
 
 -export([compile/1,
          compile/3,
-         compile/4,
          clean/1]).
 
 -include("rebar.hrl").
@@ -104,11 +103,6 @@ compile(Opts, Dir, OutDir) ->
                             filename:join(Dir, "mibs"), ".mib", filename:join([Dir, "priv", "mibs"]), ".bin",
                             fun compile_mib/3),
     doterl_compile(Opts, Dir, OutDir).
-
--spec compile(rebar_dict(), file:filename(), file:filename(), [file:filename()]) -> 'ok'.
-compile(Opts, Dir, OutDir, More) ->
-    ErlOpts = rebar_opts:erl_opts(Opts),
-    doterl_compile(Opts, Dir, OutDir, More, ErlOpts).
 
 -spec clean(file:filename()) -> 'ok'.
 clean(AppDir) ->
@@ -494,7 +488,6 @@ needs_compile(Source, Target) ->
     filelib:last_modified(Source) > filelib:last_modified(Target).
 
 gather_src([], Srcs) ->
-    ?DEBUG("src_files ~p", [Srcs]),
     Srcs;
 gather_src([Dir|Rest], Srcs) ->
     gather_src(

--- a/src/rebar_prv_clean.erl
+++ b/src/rebar_prv_clean.erl
@@ -49,6 +49,7 @@ do(State) ->
     Cwd = rebar_dir:get_cwd(),
     rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
     clean_apps(State, Providers, ProjectApps),
+    clean_extras(State),
     rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State),
 
     {ok, State}.
@@ -66,9 +67,13 @@ clean_apps(State, Providers, Apps) ->
          ?INFO("Cleaning out ~s...", [rebar_app_info:name(AppInfo)]),
          AppDir = rebar_app_info:dir(AppInfo),
          AppInfo1 = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER, Providers, AppInfo, State),
-         rebar_erlc_compiler:clean(rebar_app_info:out_dir(AppInfo1)),
+         rebar_erlc_compiler:clean(AppInfo1),
          rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo1, State)
      end || AppInfo <- Apps].
+
+clean_extras(State) ->
+    BaseDir = rebar_dir:base_dir(State),
+    rebar_file_utils:rm_rf(filename:join([BaseDir, "extras"])).
 
 handle_args(State) ->
     {Args, _} = rebar_state:command_parsed_args(State),

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -77,8 +77,8 @@ do(State, Tests) ->
 run_tests(State, Tests) ->
     T = translate_paths(State, Tests),
     EUnitOpts = resolve_eunit_opts(State),
-    ?INFO("eunit_tests ~p", [T]),
-    ?INFO("eunit_opts  ~p", [EUnitOpts]),
+    ?DEBUG("eunit_tests ~p", [T]),
+    ?DEBUG("eunit_opts  ~p", [EUnitOpts]),
     Result = eunit:test(T, EUnitOpts),
     ok = maybe_write_coverdata(State),
     case handle_results(Result) of

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -133,7 +133,7 @@ compile(State, {ok, Tests}) ->
 compile(_State, Error) -> Error.
 
 inject_eunit_state(State, Tests) ->
-    Apps = project_apps(State),
+    Apps = rebar_state:project_apps(State),
     ModdedApps = lists:map(fun(App) ->
         NewOpts = inject(rebar_app_info:opts(App), State),
         rebar_app_info:opts(App, NewOpts)
@@ -200,7 +200,7 @@ prepare_tests(State) ->
     %% parse and translate command line tests
     CmdTests = resolve_tests(State),
     CfgTests = rebar_state:get(State, eunit_tests, []),
-    ProjectApps = project_apps(State),
+    ProjectApps = rebar_state:project_apps(State),
     %% prioritize tests to run first trying any command line specified
     %% tests falling back to tests specified in the config file finally
     %% running a default set if no other tests are present
@@ -230,18 +230,6 @@ resolve(Flag, EUnitKey, RawOpts) ->
 
 normalize(Key, Value) when Key == dir; Key == file -> {Key, Value};
 normalize(Key, Value) -> {Key, list_to_atom(Value)}.
-
-project_apps(State) ->
-    filter_checkouts(rebar_state:project_apps(State)).
-
-filter_checkouts(Apps) -> filter_checkouts(Apps, []).
-
-filter_checkouts([], Acc) -> lists:reverse(Acc);
-filter_checkouts([App|Rest], Acc) ->
-    case rebar_app_info:is_checkout(App) of
-        true  -> filter_checkouts(Rest, Acc);
-        false -> filter_checkouts(Rest, [App|Acc])
-    end.
 
 select_tests(State, ProjectApps, [], []) -> default_tests(State, ProjectApps);
 select_tests(_State, _ProjectApps, [], Tests)  -> Tests;
@@ -350,11 +338,11 @@ translate_paths(State, Tests) -> translate_paths(State, Tests, []).
 
 translate_paths(_State, [], Acc) -> lists:reverse(Acc);
 translate_paths(State, [{dir, Dir}|Rest], Acc) ->
-    Apps = project_apps(State),
+    Apps = rebar_state:project_apps(State),
     translate_paths(State, Rest, [translate(State, Apps, Dir)|Acc]);
 translate_paths(State, [{file, File}|Rest], Acc) ->
     Dir = filename:dirname(File),
-    Apps = project_apps(State),
+    Apps = rebar_state:project_apps(State),
     translate_paths(State, Rest, [translate(State, Apps, Dir)|Acc]);
 translate_paths(State, [Test|Rest], Acc) ->
     translate_paths(State, Rest, [Test|Acc]).

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -9,7 +9,7 @@
          do/1,
          format_error/1]).
 %% exported solely for tests
--export([compile/1, prepare_tests/1, eunit_opts/1]).
+-export([compile/2, prepare_tests/1, eunit_opts/1]).
 
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").
@@ -39,14 +39,15 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
-    case compile(State) of
+    Tests = prepare_tests(State),
+    case compile(State, Tests) of
         %% successfully compiled apps
-        {ok, S} -> do_tests(S);
+        {ok, S} -> do(S, Tests);
         %% this should look like a compiler error, not an eunit error
         Error   -> Error
     end.
 
-do_tests(State) ->
+do(State, Tests) ->
     ?INFO("Performing EUnit tests...", []),
 
     rebar_utils:update_code(rebar_state:code_paths(State, all_deps)),
@@ -56,9 +57,9 @@ do_tests(State) ->
     Cwd = rebar_dir:get_cwd(),
     rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
 
-    case prepare_tests(State) of
-        {ok, Tests} ->
-            case do_tests(State, Tests) of
+    case Tests of
+        {ok, T} ->
+            case run_tests(State, T) of
                 {ok, State1} ->
                     %% Run eunit provider posthooks
                     rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State1),
@@ -73,11 +74,12 @@ do_tests(State) ->
             Error
     end.
 
-do_tests(State, Tests) ->
+run_tests(State, Tests) ->
+    T = translate_paths(State, Tests),
     EUnitOpts = resolve_eunit_opts(State),
-    ?DEBUG("eunit_tests ~p", [Tests]),
-    ?DEBUG("eunit_opts  ~p", [EUnitOpts]),
-    Result = eunit:test(Tests, EUnitOpts),
+    ?INFO("eunit_tests ~p", [T]),
+    ?INFO("eunit_opts  ~p", [EUnitOpts]),
+    Result = eunit:test(T, EUnitOpts),
     ok = maybe_write_coverdata(State),
     case handle_results(Result) of
         {error, Reason} ->
@@ -114,38 +116,80 @@ safe_define_test_macro(Opts) ->
        false -> [{d, 'TEST'}] ++ Opts
     end.
 
-compile(State) ->
-    %% inject `eunit_first_files` and `eunit_compile_opts` into the applications to be compiled
-    NewState = inject_eunit_state(State),
+compile(State, {ok, Tests}) ->
+    %% inject `eunit_first_files`, `eunit_compile_opts` and any
+    %% directories required by tests into the applications
+    NewState = inject_eunit_state(State, Tests),
 
     case rebar_prv_compile:do(NewState) of
         %% successfully compiled apps
         {ok, S} ->
             ok = maybe_cover_compile(S),
-            ok = maybe_compile_bare_testdir(S),
             {ok, S};
         %% this should look like a compiler error, not an eunit error
         Error   -> Error
-    end.
+    end;
+%% maybe compile even in the face of errors?
+compile(_State, Error) -> Error.
 
-inject_eunit_state(State) ->
+inject_eunit_state(State, Tests) ->
     Apps = project_apps(State),
-    ModdedApps = lists:map(fun(App) -> inject(State, App) end, Apps),
-    rebar_state:project_apps(State, ModdedApps).
+    ModdedApps = lists:map(fun(App) ->
+        NewOpts = inject(rebar_app_info:opts(App), State),
+        rebar_app_info:opts(App, NewOpts)
+    end, Apps),
+    NewOpts = inject(rebar_state:opts(State), State),
+    NewState = rebar_state:opts(State, NewOpts),
+    test_dirs(NewState, ModdedApps, Tests).
 
-inject(State, App) ->
+inject(Opts, State) ->
     %% append `eunit_compile_opts` to app defined `erl_opts`
-    ErlOpts = rebar_app_info:get(App, erl_opts, []),
+    ErlOpts = rebar_opts:get(Opts, erl_opts, []),
     EUnitOpts = rebar_state:get(State, eunit_compile_opts, []),
-    NewOpts = EUnitOpts ++ ErlOpts,
+    NewErlOpts = EUnitOpts ++ ErlOpts,
     %% append `eunit_first_files` to app defined `erl_first_files`
-    FirstFiles = rebar_app_info:get(App, erl_first_files, []),
+    FirstFiles = rebar_opts:get(Opts, erl_first_files, []),
     EUnitFirstFiles = rebar_state:get(State, eunit_first_files, []),
     NewFirstFiles = EUnitFirstFiles ++ FirstFiles,
-    %% insert the new keys into the app
-    lists:foldl(fun({K, V}, NewApp) -> rebar_app_info:set(NewApp, K, V) end,
-                App,
-                [{erl_opts, NewOpts}, {erl_first_files, NewFirstFiles}]).
+    %% insert the new keys into the opts
+    lists:foldl(fun({K, V}, NewOpts) -> rebar_opts:set(NewOpts, K, V) end,
+                Opts,
+                [{erl_opts, NewErlOpts}, {erl_first_files, NewFirstFiles}]).
+
+test_dirs(State, Apps, []) -> rebar_state:project_apps(State, Apps);
+test_dirs(State, Apps, [{dir, Dir}|Rest]) ->
+    %% insert `Dir` into an app if relative, or the base state if not
+    %% app relative but relative to the root or not at all if outside
+    %% project scope
+    {NewState, NewApps} = maybe_inject_test_dir(State, [], Apps, Dir),
+    test_dirs(NewState, NewApps, Rest);
+test_dirs(State, Apps, [{file, File}|Rest]) ->
+    Dir = filename:dirname(File),
+    {NewState, NewApps} = maybe_inject_test_dir(State, [], Apps, Dir),
+    test_dirs(NewState, NewApps, Rest);
+test_dirs(State, Apps, [_|Rest]) -> test_dirs(State, Apps, Rest).
+
+maybe_inject_test_dir(State, AppAcc, [App|Rest], Dir) ->
+    case rebar_file_utils:path_from_ancestor(Dir, rebar_app_info:dir(App)) of
+        {ok, Path} ->
+            Opts = inject_test_dir(rebar_app_info:opts(App), Path),
+            {State, AppAcc ++ [rebar_app_info:opts(App, Opts)] ++ Rest};
+        {error, badparent} ->
+            maybe_inject_test_dir(State, AppAcc ++ [App], Rest, Dir)
+    end;
+maybe_inject_test_dir(State, AppAcc, [], Dir) ->
+    case rebar_file_utils:path_from_ancestor(Dir, rebar_state:dir(State)) of
+        {ok, Path} ->
+            Opts = inject_test_dir(rebar_state:opts(State), Path),
+            {rebar_state:opts(State, Opts), AppAcc};
+        {error, badparent} ->
+            {State, AppAcc}
+    end.
+
+inject_test_dir(Opts, Dir) ->
+    %% append specified test targets to app defined `extra_src_dirs`
+    ExtraSrcDirs = rebar_opts:get(Opts, extra_src_dirs, []),
+    rebar_opts:set(Opts, extra_src_dirs, ExtraSrcDirs ++ [Dir]).
 
 test_defined([{d, 'TEST'}|_]) -> true;
 test_defined([{d, 'TEST', true}|_]) -> true;
@@ -212,7 +256,7 @@ default_tests(State, Apps) ->
         %%  included or `test` does not exist
         false -> lists:reverse(Tests);
         %% need to add `test` dir at root to dirs to be included
-        true  -> lists:reverse([{dir, filename:join([rebar_dir:base_dir(State), "test"])}|Tests])
+        true  -> lists:reverse([{dir, BareTest}|Tests])
     end.
 
 set_apps([], Acc) -> Acc;
@@ -268,14 +312,14 @@ validate_app(State, [App|Rest], AppName) ->
         false -> validate_app(State, Rest, AppName)
     end.
 
-validate_dir(_State, Dir) ->
-    case ec_file:is_dir(Dir) of
+validate_dir(State, Dir) ->
+    case ec_file:is_dir(filename:join([rebar_state:dir(State), Dir])) of
         true  -> ok;
         false -> {error, lists:concat(["Directory `", Dir, "' not found."])}
     end.
 
-validate_file(_State, File) ->
-    case ec_file:exists(File) of
+validate_file(State, File) ->
+    case ec_file:exists(filename:join([rebar_state:dir(State), File])) of
         true  -> ok;
         false -> {error, lists:concat(["File `", File, "' not found."])}
     end.
@@ -302,6 +346,31 @@ set_verbose(Opts) ->
         false -> [verbose] ++ Opts
     end.
 
+translate_paths(State, Tests) -> translate_paths(State, Tests, []).
+
+translate_paths(_State, [], Acc) -> lists:reverse(Acc);
+translate_paths(State, [{dir, Dir}|Rest], Acc) ->
+    Apps = project_apps(State),
+    translate_paths(State, Rest, [translate(State, Apps, Dir)|Acc]);
+translate_paths(State, [{file, File}|Rest], Acc) ->
+    Dir = filename:dirname(File),
+    Apps = project_apps(State),
+    translate_paths(State, Rest, [translate(State, Apps, Dir)|Acc]);
+translate_paths(State, [Test|Rest], Acc) ->
+    translate_paths(State, Rest, [Test|Acc]).
+
+translate(State, [App|Rest], Dir) ->
+    case rebar_file_utils:path_from_ancestor(Dir, rebar_app_info:dir(App)) of
+        {ok, Path}         -> {dir, filename:join([rebar_app_info:out_dir(App), Path])};
+        {error, badparent} -> translate(State, Rest, Dir)
+    end;
+translate(State, [], Dir) ->
+    case rebar_file_utils:path_from_ancestor(Dir, rebar_state:dir(State)) of
+        {ok, Path}         -> {dir, filename:join([rebar_dir:base_dir(State), "extras", Path])};
+        %% not relative, leave as is
+        {error, badparent} -> {dir, Dir}
+    end.
+
 maybe_cover_compile(State) ->
     {RawOpts, _} = rebar_state:command_parsed_args(State),
     State1 = case proplists:get_value(cover, RawOpts, false) of
@@ -310,14 +379,6 @@ maybe_cover_compile(State) ->
     end,
     rebar_prv_cover:maybe_cover_compile(State1).
 
-maybe_cover_compile(State, Dir) ->
-    {RawOpts, _} = rebar_state:command_parsed_args(State),
-    State1 = case proplists:get_value(cover, RawOpts, false) of
-        true  -> rebar_state:set(State, cover_enabled, true);
-        false -> State
-    end,
-    rebar_prv_cover:maybe_cover_compile(State1, [Dir]).
-
 maybe_write_coverdata(State) ->
     {RawOpts, _} = rebar_state:command_parsed_args(State),
     State1 = case proplists:get_value(cover, RawOpts, false) of
@@ -325,30 +386,6 @@ maybe_write_coverdata(State) ->
         false -> State
     end,
     rebar_prv_cover:maybe_write_coverdata(State1, ?PROVIDER).
-
-maybe_compile_bare_testdir(State) ->
-    Apps = project_apps(State),
-    BareTest = filename:join([rebar_state:dir(State), "test"]),
-    F = fun(App) -> rebar_app_info:dir(App) == rebar_state:dir(State) end,
-    case ec_file:is_dir(BareTest) andalso not lists:any(F, Apps) of
-        true ->
-            ErlOpts = rebar_state:get(State, erl_opts, []),
-            EUnitOpts = rebar_state:get(State, eunit_compile_opts, []),
-            NewErlOpts = safe_define_test_macro(EUnitOpts ++ ErlOpts),
-            %% append `eunit_first_files` to app defined `erl_first_files`
-            FirstFiles = rebar_state:get(State, erl_first_files, []),
-            EUnitFirstFiles = rebar_state:get(State, eunit_first_files, []),
-            NewFirstFiles = EUnitFirstFiles ++ FirstFiles,
-            Opts = rebar_state:opts(State),
-            NewOpts = lists:foldl(fun({K, V}, Dict) -> rebar_opts:set(Dict, K, V) end,
-                                  Opts,
-                                  [{erl_opts, NewErlOpts}, {erl_first_files, NewFirstFiles}, {src_dirs, ["test"]}]),
-            OutDir = filename:join([rebar_dir:base_dir(State), "test"]),
-            filelib:ensure_dir(filename:join([OutDir, "dummy.beam"])),
-            rebar_erlc_compiler:compile(NewOpts, rebar_state:dir(State), OutDir),
-            maybe_cover_compile(State, [OutDir]);
-        false -> ok
-    end.
 
 handle_results(ok) -> ok;
 handle_results(error) ->

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -65,7 +65,8 @@
          escape_double_quotes_weak/1,
          check_min_otp_version/1,
          check_blacklisted_otp_versions/1,
-         info_useless/2]).
+         info_useless/2,
+         list_dir/1]).
 
 %% for internal use only
 -export([otp_release/0]).
@@ -774,3 +775,9 @@ info_useless(Old, New) ->
      || Name <- Old,
         not lists:member(Name, New)],
     ok.
+
+-ifdef(no_list_dir_all).
+list_dir(Dir) -> file:list_dir(Dir).
+-else.
+list_dir(Dir) -> file:list_dir_all(Dir).
+-endif.

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -26,8 +26,7 @@
          only_default_transitive_deps/1,
          clean_all/1,
          override_deps/1,
-         profile_override_deps/1,
-         build_more_sources/1]).
+         profile_override_deps/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -681,31 +680,3 @@ profile_override_deps(Config) ->
         Config, RebarConfig, ["as", "a", "compile"],
         {ok, [{dep, "some_dep"},{dep_not_exist, "other_dep"}]}
     ).
-
-build_more_sources(Config) ->
-    AppDir = ?config(apps, Config),
-
-    ASrc = <<"-module(a_src).\n-export([ok/0]).\nok() -> ok.\n">>,
-    BSrc = <<"-module(b_src).\n-export([ok/0]).\nok() -> ok.\n">>,
-    CSrc = <<"-module(c_src).\n-export([ok/0]).\nok() -> ok.\n">>,
-
-    ok = filelib:ensure_dir(filename:join([AppDir, "more", "dummy"])),
-    ok = filelib:ensure_dir(filename:join([AppDir, "ebin", "dummy"])),
-    ok = file:write_file(filename:join([AppDir, "more", "a_src.erl"]), ASrc),
-    ok = file:write_file(filename:join([AppDir, "more", "b_src.erl"]), BSrc),
-    ok = file:write_file(filename:join([AppDir, "more", "c_src.erl"]), CSrc),
-
-    Opts = dict:new(),
-
-    rebar_erlc_compiler:compile(Opts,
-                                filename:join([AppDir, "more"]),
-                                filename:join([AppDir, "ebin"]),
-                                [filename:join([AppDir, "more", "a_src.erl"]),
-                                 filename:join([AppDir, "more", "b_src.erl"]),
-                                 filename:join([AppDir, "more", "c_src.erl"])]),
-
-    EbinDir = filename:join([AppDir, "ebin"]),
-    true = filelib:is_file(filename:join([EbinDir, "a_src.beam"])),
-    true = filelib:is_file(filename:join([EbinDir, "b_src.beam"])),
-    true = filelib:is_file(filename:join([EbinDir, "c_src.beam"])).
-

--- a/test/rebar_cover_SUITE.erl
+++ b/test/rebar_cover_SUITE.erl
@@ -7,6 +7,9 @@
          all/0,
          flag_coverdata_written/1,
          config_coverdata_written/1,
+         basic_extra_src_dirs/1,
+         release_extra_src_dirs/1,
+         root_extra_src_dirs/1,
          index_written/1,
          flag_verbose/1,
          config_verbose/1]).
@@ -29,6 +32,8 @@ init_per_testcase(_, Config) ->
 
 all() ->
     [flag_coverdata_written, config_coverdata_written,
+     basic_extra_src_dirs, release_extra_src_dirs,
+     root_extra_src_dirs,
      index_written,
      flag_verbose, config_verbose].
 
@@ -61,6 +66,88 @@ config_coverdata_written(Config) ->
                                    {ok, [{app, Name}]}),
 
     true = filelib:is_file(filename:join([AppDir, "_build", "test", "cover", "eunit.coverdata"])).
+
+basic_extra_src_dirs(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("cover_extra_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_eunit_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    ExtraSrc = io_lib:format("-module(~ts_extra).\n-export([ok/0]).\nok() -> ok.\n", [Name]),
+
+    ok = filelib:ensure_dir(filename:join([AppDir, "extra", "dummy"])),
+    ok = file:write_file(filename:join([AppDir, "extra", io_lib:format("~ts_extra.erl", [Name])]),
+                         ExtraSrc),
+
+    RebarConfig = [{erl_opts, [{d, some_define}]}, {extra_src_dirs, ["extra"]}],
+    rebar_test_utils:run_and_check(Config,
+                                   RebarConfig,
+                                   ["eunit", "--cover"],
+                                   {ok, [{app, Name}]}),
+
+    Mod = list_to_atom(lists:flatten(io_lib:format("~ts_extra", [Name]))),
+    {file, _} = cover:is_compiled(Mod).
+
+release_extra_src_dirs(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name1 = rebar_test_utils:create_random_name("relapp1_"),
+    Vsn1 = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(filename:join([AppDir, "apps", Name1]), Name1, Vsn1, [kernel, stdlib]),
+
+    Name2 = rebar_test_utils:create_random_name("relapp2_"),
+    Vsn2 = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(filename:join([AppDir, "apps", Name2]), Name2, Vsn2, [kernel, stdlib]),
+
+    ExtraOne = io_lib:format("-module(~ts_extra).\n-export([ok/0]).\nok() -> ok.\n", [Name1]),
+
+    ok = filelib:ensure_dir(filename:join([AppDir, "apps", Name1, "extra", "dummy"])),
+    ok = file:write_file(filename:join([AppDir, "apps", Name1, "extra",
+                                        io_lib:format("~ts_extra.erl", [Name1])]),
+                         ExtraOne),
+
+    ExtraTwo = io_lib:format("-module(~ts_extra).\n-export([ok/0]).\nok() -> ok.\n", [Name2]),
+
+    ok = filelib:ensure_dir(filename:join([AppDir, "apps", Name2, "extra", "dummy"])),
+    ok = file:write_file(filename:join([AppDir, "apps", Name2, "extra",
+                                        io_lib:format("~ts_extra.erl", [Name2])]),
+                         ExtraTwo),
+
+    RebarConfig = [{erl_opts, [{d, some_define}]}, {extra_src_dirs, ["extra"]}],
+    rebar_test_utils:run_and_check(Config,
+                                   RebarConfig,
+                                   ["eunit", "--cover"],
+                                   {ok, [{app, Name1}, {app, Name2}]}),
+
+    Mod1 = list_to_atom(lists:flatten(io_lib:format("~ts_extra", [Name1]))),
+    {file, _} = cover:is_compiled(Mod1),
+    Mod2 = list_to_atom(lists:flatten(io_lib:format("~ts_extra", [Name2]))),
+    {file, _} = cover:is_compiled(Mod2).
+
+root_extra_src_dirs(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name1 = rebar_test_utils:create_random_name("relapp1_"),
+    Vsn1 = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(filename:join([AppDir, "apps", Name1]), Name1, Vsn1, [kernel, stdlib]),
+
+    Name2 = rebar_test_utils:create_random_name("relapp2_"),
+    Vsn2 = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(filename:join([AppDir, "apps", Name2]), Name2, Vsn2, [kernel, stdlib]),
+
+    Extra = <<"-module(extra).\n-export([ok/0]).\nok() -> ok.\n">>,
+
+    ok = filelib:ensure_dir(filename:join([AppDir, "extra", "dummy"])),
+    ok = file:write_file(filename:join([AppDir, "extra", "extra.erl"]), Extra),
+
+    RebarConfig = [{erl_opts, [{d, some_define}]}, {extra_src_dirs, ["extra"]}],
+    rebar_test_utils:run_and_check(Config,
+                                   RebarConfig,
+                                   ["eunit", "--cover"],
+                                   {ok, [{app, Name1}, {app, Name2}]}),
+
+    {file, _} = cover:is_compiled(extra).
 
 index_written(Config) ->
     AppDir = ?config(apps, Config),

--- a/test/rebar_ct_SUITE.erl
+++ b/test/rebar_ct_SUITE.erl
@@ -204,6 +204,7 @@ multi_app_default_beams(Config) ->
     File3 = filename:join([AppDir,
                            "_build",
                            "test",
+                           "extras",
                            "test",
                            "extras_SUITE.beam"]),
 

--- a/test/rebar_eunit_SUITE.erl
+++ b/test/rebar_eunit_SUITE.erl
@@ -125,7 +125,9 @@ basic_app_files(Config) ->
     AppDir = ?config(apps, Config),
 
     lists:foreach(fun(F) -> true = ec_file:exists(filename:join([AppDir, "_build", "test", "lib", "basic_app", "ebin", F])) end,
-                  ["basic_app.app", "basic_app.beam", "basic_app_tests.beam", "basic_app_tests_helper.beam"]).
+                  ["basic_app.app", "basic_app.beam"]),
+    lists:foreach(fun(F) -> true = ec_file:exists(filename:join([AppDir, "_build", "test", "lib", "basic_app", "test", F])) end,
+                  ["basic_app_tests.beam", "basic_app_tests_helper.beam"]).
 
 %% check that the correct tests are exported from modules for project
 %% note that this implies `TEST` is set correctly
@@ -171,10 +173,14 @@ multi_app_files(Config) ->
     AppDir = ?config(apps, Config),
 
     lists:foreach(fun(F) -> true = ec_file:exists(filename:join([AppDir, "_build", "test", "lib", "multi_app_bar", "ebin", F])) end,
-                  ["multi_app_bar.app", "multi_app_bar.beam", "multi_app_bar_tests.beam", "multi_app_bar_tests_helper.beam"]),
+                  ["multi_app_bar.app", "multi_app_bar.beam"]),
     lists:foreach(fun(F) -> true = ec_file:exists(filename:join([AppDir, "_build", "test", "lib", "multi_app_baz", "ebin", F])) end,
-                  ["multi_app_baz.app", "multi_app_baz.beam", "multi_app_baz_tests.beam", "multi_app_baz_tests_helper.beam"]),
-    lists:foreach(fun(F) -> true = ec_file:exists(filename:join([AppDir, "_build", "test", "test", F])) end,
+                  ["multi_app_baz.app", "multi_app_baz.beam"]),
+    lists:foreach(fun(F) -> true = ec_file:exists(filename:join([AppDir, "_build", "test", "lib", "multi_app_bar", "test", F])) end,
+                  ["multi_app_bar_tests.beam", "multi_app_bar_tests_helper.beam"]),
+    lists:foreach(fun(F) -> true = ec_file:exists(filename:join([AppDir, "_build", "test", "lib", "multi_app_baz", "test", F])) end,
+                  ["multi_app_baz_tests.beam", "multi_app_baz_tests_helper.beam"]),
+    lists:foreach(fun(F) -> true = ec_file:exists(filename:join([AppDir, "_build", "test", "extras", "test", F])) end,
                   ["multi_app_tests.beam", "multi_app_tests_helper.beam"]).
 
 %% check that the correct tests are exported from modules for project
@@ -202,7 +208,9 @@ multi_app_testset(Config) ->
     AppDir = ?config(apps, Config),
     Result = ?config(result, Config),
 
-    Set = {ok, [{application, multi_app_bar}, {application, multi_app_baz}, {dir, filename:join([AppDir, "_build", "test", "test"])}]},
+    Set = {ok, [{application, multi_app_bar},
+                {application, multi_app_baz},
+                {dir, filename:join([AppDir, "test"])}]},
     Set = rebar_prv_eunit:prepare_tests(Result).
 
 

--- a/test/rebar_file_utils_SUITE.erl
+++ b/test/rebar_file_utils_SUITE.erl
@@ -64,7 +64,7 @@ reset_nonexistent_dir(Config) ->
     ?assertNot(filelib:is_dir(TmpDir)),
     ok = rebar_file_utils:reset_dir(TmpDir),
     ?assert(filelib:is_dir(TmpDir)),
-    {ok, []} = file:list_dir(TmpDir).
+    {ok, []} = rebar_utils:list_dir(TmpDir).
 
 reset_empty_dir(Config) ->
     TmpDir = ?config(tmpdir, Config),
@@ -73,7 +73,7 @@ reset_empty_dir(Config) ->
     ?assert(filelib:is_dir(TmpDir)),
     ok = rebar_file_utils:reset_dir(TmpDir),
     ?assert(filelib:is_dir(TmpDir)),
-    {ok, []} = file:list_dir(TmpDir).
+    {ok, []} = rebar_utils:list_dir(TmpDir).
 
 reset_dir(Config) ->
     TmpDir = ?config(tmpdir, Config),
@@ -86,7 +86,7 @@ reset_dir(Config) ->
                   ["a", "b", "c"]),
     ok = rebar_file_utils:reset_dir(TmpDir),
     ?assert(filelib:is_dir(TmpDir)),
-    {ok, []} = file:list_dir(TmpDir).
+    {ok, []} = rebar_utils:list_dir(TmpDir).
 
 path_from_ancestor(_Config) ->
     ?assertEqual({ok, "foo/bar/baz"}, rebar_file_utils:path_from_ancestor("/foo/bar/baz", "/")),

--- a/test/rebar_src_dirs_SUITE.erl
+++ b/test/rebar_src_dirs_SUITE.erl
@@ -132,9 +132,9 @@ build_basic_app(Config) ->
 
     rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], {ok, [{app, Name}]}),
 
-    %% check that `extra.erl` was compiled to the `ebin` dir
-    Ebin = filename:join([AppDir, "_build", "default", "lib", Name, "ebin"]),
-    true = filelib:is_file(filename:join([Ebin, "extra.beam"])),
+    %% check that `extra.erl` was compiled to the `extra` dir
+    ExtraOut = filename:join([AppDir, "_build", "default", "lib", Name, "extra"]),
+    true = filelib:is_file(filename:join([ExtraOut, "extra.beam"])),
 
     %% check that `extra.erl` is not in the `modules` key of the app
     {ok, App} = file:consult(filename:join([AppDir,
@@ -176,11 +176,11 @@ build_multi_apps(Config) ->
     ),
 
     %% check that `extraX.erl` was compiled to the `ebin` dir
-    Ebin1 = filename:join([AppDir, "_build", "default", "lib", Name1, "ebin"]),
-    true = filelib:is_file(filename:join([Ebin1, "extra1.beam"])),
+    ExtraOut1 = filename:join([AppDir, "_build", "default", "lib", Name1, "extra"]),
+    true = filelib:is_file(filename:join([ExtraOut1, "extra1.beam"])),
 
-    Ebin2 = filename:join([AppDir, "_build", "default", "lib", Name2, "ebin"]),
-    true = filelib:is_file(filename:join([Ebin2, "extra2.beam"])),
+    ExtraOut2 = filename:join([AppDir, "_build", "default", "lib", Name2, "extra"]),
+    true = filelib:is_file(filename:join([ExtraOut2, "extra2.beam"])),
 
     %% check that `extraX.erl` is not in the `modules` key of the app
     {ok, App1} = file:consult(filename:join([AppDir,
@@ -221,10 +221,9 @@ src_dir_takes_precedence_over_extra(Config) ->
 
     rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], {ok, [{app, Name}]}),
 
-    %% check that `extra.erl` was compiled to the `ebin` dir
-    %% check that `extraX.erl` was compiled to the `ebin` dir
-    Ebin = filename:join([AppDir, "_build", "default", "lib", Name, "ebin"]),
-    true = filelib:is_file(filename:join([Ebin, "extra.beam"])),
+    %% check that `extra.erl` was compiled to the `extra` dir
+    ExtraOut = filename:join([AppDir, "_build", "default", "lib", Name, "extra"]),
+    true = filelib:is_file(filename:join([ExtraOut, "extra.beam"])),
 
     %% check that `extra.erl` is in the `modules` key of the app
     {ok, App} = file:consult(filename:join([AppDir,

--- a/test/rebar_test_utils.erl
+++ b/test/rebar_test_utils.erl
@@ -334,7 +334,7 @@ check_results(AppDir, Expected, ProfileRun) ->
                     {ok, RelxState3} = rlx_prv_rel_discover:do(RelxState2),
 
                     LibDir = filename:join([ReleaseDir, Name, "lib"]),
-                    {ok, RelLibs} = file:list_dir(LibDir),
+                    {ok, RelLibs} = rebar_utils:list_dir(LibDir),
                     IsSymLinkFun =
                         fun(X) ->
                                 ec_file:is_symlink(filename:join(LibDir, X))
@@ -357,6 +357,9 @@ check_results(AppDir, Expected, ProfileRun) ->
         ;  ({file, Filename}) ->
                 ct:pal("Filename: ~s", [Filename]),
                 ?assert(filelib:is_file(Filename))
+        ;  ({dir, Dirname}) ->
+                ct:pal("Directory: ~s", [Dirname]),
+                ?assert(filelib:is_dir(Dirname))
         end, Expected).
 
 write_src_file(Dir, Name) ->
@@ -422,7 +425,7 @@ get_app_metadata(Name, Vsn, Deps) ->
 
 package_app(AppDir, DestDir, PkgName) ->
     Name = PkgName++".tar",
-    {ok, Fs} = file:list_dir(AppDir),
+    {ok, Fs} = rebar_utils:list_dir(AppDir),
     ok = erl_tar:create(filename:join(DestDir, "contents.tar.gz"),
                         lists:zip(Fs, [filename:join(AppDir,F) || F <- Fs]),
                         [compressed]),


### PR DESCRIPTION
changes:

* `extra_src_dirs` are copied from the project to `_build` either relative to the app they are relative to in the project or relative to `_build/profile/extras`. they're compiled in place. copied instead of symlinked so profiles can't leak into one another (and also to keep beams out of the project directories) and compiled in place because `ct` can't handle them being in `ebin`. `rebar_file_utils` calls out to shell to copy files but this loses metadata so anything in an extra dir is going to be recompiled every single time compile is invoked but there's a metadata preserving copy in ec_file that could be used instead. that can be a separate change though

* any directory in `_build` that is used as a compiler output target is added to the code_path/all_deps. i believe this is the right key, but open to correction here. the compiler currently only returns `ok` (or an exception) and changing it to return output dirs (or the application/state object compiled with a field for artifact directories, maybe?) would simplify things (and prevent having to repeatedly recalculate output dirs based on `src_dirs`/`extra_src_dirs`) but that's a refactoring that can wait

* the compiler has a `recursive` option. it's not used anywhere, but it could be controllable with a `{compiler, [{recursive, false}]}` entry in `rebar.config`. omitted for now for pending discussion but i think necessary for having code in ct data dirs, for example

* eunit scopes changes to `eunit_compile_opts`, `eunit_first_files` and files and directories in the test set properly. i'm unsure how the `rebar.config` in an app directory (as opposed to the project root) is supposed to apply to the app so there's probably some missing testing around this but that too can be fixed in a separate change. the `eunit` provider also translates paths used in test sets so doing `rebar3 eunit --dir=test` will now ensure `test` is compiled and call `eunit:test([{dir, "_build/test/extras/test"}])`. `rebar3 eunit --dir=apps/foo/test` will call `eunit:test([{dir, "_build/test/lib/foo/test"}])`
