### PR TITLE
dedup `src_dirs` and `extra_src_dirs` on read

### DIFF
--- a/src/rebar_dir.erl
+++ b/src/rebar_dir.erl
@@ -139,7 +139,7 @@ src_dirs(Opts, Default) ->
     Vs = proplists:get_all_values(src_dirs, ErlOpts),
     case lists:append([rebar_opts:get(Opts, src_dirs, []) | Vs]) of
         []   -> Default;
-        Dirs -> Dirs
+        Dirs -> lists:usort(Dirs)
     end.
 
 -spec extra_src_dirs(rebar_dict()) -> list(file:filename_all()).
@@ -151,7 +151,7 @@ extra_src_dirs(Opts, Default) ->
     Vs = proplists:get_all_values(extra_src_dirs, ErlOpts),
     case lists:append([rebar_opts:get(Opts, extra_src_dirs, []) | Vs]) of
         []   -> Default;
-        Dirs -> Dirs
+        Dirs -> lists:usort(Dirs)
     end.
 
 -spec all_src_dirs(rebar_dict()) -> list(file:filename_all()).
@@ -160,7 +160,7 @@ all_src_dirs(Opts) -> all_src_dirs(Opts, [], []).
 -spec all_src_dirs(rebar_dict(), list(file:filename_all()), list(file:filename_all())) ->
     list(file:filename_all()).
 all_src_dirs(Opts, SrcDefault, ExtraDefault) ->
-    src_dirs(Opts, SrcDefault) ++ extra_src_dirs(Opts, ExtraDefault).
+    lists:usort(src_dirs(Opts, SrcDefault) ++ extra_src_dirs(Opts, ExtraDefault)).
 
 %% given a path if that path is an ancestor of an app dir return the path relative to that
 %% apps outdir. if the path is not an ancestor to any app dirs but is an ancestor of the

--- a/test/rebar_dir_SUITE.erl
+++ b/test/rebar_dir_SUITE.erl
@@ -55,19 +55,19 @@ src_dirs(Config) ->
     RebarConfig = [{erl_opts, [{src_dirs, ["foo", "bar", "baz"]}]}],
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
-    ["foo", "bar", "baz"] = rebar_dir:src_dirs(rebar_state:opts(State)).
+    ["bar", "baz", "foo"] = rebar_dir:src_dirs(rebar_state:opts(State)).
 
 extra_src_dirs(Config) ->
     RebarConfig = [{erl_opts, [{extra_src_dirs, ["foo", "bar", "baz"]}]}],
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
-    ["foo", "bar", "baz"] = rebar_dir:extra_src_dirs(rebar_state:opts(State)).
+    ["bar", "baz", "foo"] = rebar_dir:extra_src_dirs(rebar_state:opts(State)).
 
 all_src_dirs(Config) ->
     RebarConfig = [{erl_opts, [{src_dirs, ["foo", "bar"]}, {extra_src_dirs, ["baz", "qux"]}]}],
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
-    ["foo", "bar", "baz", "qux"] = rebar_dir:all_src_dirs(rebar_state:opts(State)).
+    ["bar", "baz", "foo", "qux"] = rebar_dir:all_src_dirs(rebar_state:opts(State)).
 
 profile_src_dirs(Config) ->
     RebarConfig = [
@@ -79,7 +79,7 @@ profile_src_dirs(Config) ->
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "more", "compile"], return),
 
     R = lists:sort(["foo", "bar", "baz", "qux"]),
-    R = lists:sort(rebar_dir:src_dirs(rebar_state:opts(State))).
+    R = rebar_dir:src_dirs(rebar_state:opts(State)).
 
 profile_extra_src_dirs(Config) ->
     RebarConfig = [
@@ -91,7 +91,7 @@ profile_extra_src_dirs(Config) ->
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "more", "compile"], return),
 
     R = lists:sort(["foo", "bar", "baz", "qux"]),
-    R = lists:sort(rebar_dir:extra_src_dirs(rebar_state:opts(State))).
+    R = rebar_dir:extra_src_dirs(rebar_state:opts(State)).
 
 profile_all_src_dirs(Config) ->
     RebarConfig = [
@@ -103,7 +103,7 @@ profile_all_src_dirs(Config) ->
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["as", "more", "compile"], return),
 
     R = lists:sort(["foo", "bar", "baz", "qux"]),
-    R = lists:sort(rebar_dir:all_src_dirs(rebar_state:opts(State))).
+    R = rebar_dir:all_src_dirs(rebar_state:opts(State)).
 
 retarget_path(Config) ->
     {ok, State} = rebar_test_utils:run_and_check(Config, [], ["compile"], return),

--- a/test/rebar_src_dirs_SUITE.erl
+++ b/test/rebar_src_dirs_SUITE.erl
@@ -49,7 +49,7 @@ src_dirs_at_root(Config) ->
 
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
-    ["foo", "bar", "baz"] = rebar_dir:src_dirs(rebar_state:opts(State), []).
+    ["bar", "baz", "foo"] = rebar_dir:src_dirs(rebar_state:opts(State), []).
 
 extra_src_dirs_at_root(Config) ->
     AppDir = ?config(apps, Config),
@@ -62,7 +62,7 @@ extra_src_dirs_at_root(Config) ->
 
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
-    ["foo", "bar", "baz"] = rebar_dir:extra_src_dirs(rebar_state:opts(State), []).
+    ["bar", "baz", "foo"] = rebar_dir:extra_src_dirs(rebar_state:opts(State), []).
 
 src_dirs_in_erl_opts(Config) ->
     AppDir = ?config(apps, Config),
@@ -75,7 +75,7 @@ src_dirs_in_erl_opts(Config) ->
 
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
-    ["foo", "bar", "baz"] = rebar_dir:src_dirs(rebar_state:opts(State), []).
+    ["bar", "baz", "foo"] = rebar_dir:src_dirs(rebar_state:opts(State), []).
 
 extra_src_dirs_in_erl_opts(Config) ->
     AppDir = ?config(apps, Config),
@@ -88,7 +88,7 @@ extra_src_dirs_in_erl_opts(Config) ->
 
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
-    ["foo", "bar", "baz"] = rebar_dir:extra_src_dirs(rebar_state:opts(State), []).
+    ["bar", "baz", "foo"] = rebar_dir:extra_src_dirs(rebar_state:opts(State), []).
 
 src_dirs_at_root_and_in_erl_opts(Config) ->
     AppDir = ?config(apps, Config),
@@ -101,7 +101,7 @@ src_dirs_at_root_and_in_erl_opts(Config) ->
 
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
-    ["baz", "qux", "foo", "bar"] = rebar_dir:src_dirs(rebar_state:opts(State), []).
+    ["bar", "baz", "foo", "qux"] = rebar_dir:src_dirs(rebar_state:opts(State), []).
 
 extra_src_dirs_at_root_and_in_erl_opts(Config) ->
     AppDir = ?config(apps, Config),
@@ -114,7 +114,7 @@ extra_src_dirs_at_root_and_in_erl_opts(Config) ->
 
     {ok, State} = rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], return),
 
-    ["baz", "qux", "foo", "bar"] = rebar_dir:extra_src_dirs(rebar_state:opts(State), []).
+    ["bar", "baz", "foo", "qux"] = rebar_dir:extra_src_dirs(rebar_state:opts(State), []).
 
 build_basic_app(Config) ->
     AppDir = ?config(apps, Config),


### PR DESCRIPTION
deduplicating `src_dirs` on read removes the need to do it at call site repeatedly or do an upsert style add to `src_dirs`