### PR TITLE
add an option to soft purge rather than purge old code

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -38,7 +38,7 @@ init(State) ->
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
     ?INFO("Running Common Test suites...", []),
-    rebar_utils:update_code(rebar_state:code_paths(State, all_deps)),
+    rebar_utils:update_code(rebar_state:code_paths(State, all_deps), [soft_purge]),
 
     %% Run ct provider prehooks
     Providers = rebar_state:providers(State),

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -49,7 +49,7 @@ do(State) ->
 do(State, Tests) ->
     ?INFO("Performing EUnit tests...", []),
 
-    rebar_utils:update_code(rebar_state:code_paths(State, all_deps)),
+    rebar_utils:update_code(rebar_state:code_paths(State, all_deps), [soft_purge]),
 
     %% Run eunit provider prehooks
     Providers = rebar_state:providers(State),


### PR DESCRIPTION
at the cost of some SASL warnings this prevents rebar3 from terminating
processes when reloading their code before running tests