### PR TITLE
Prettify all of common test output.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -8,7 +8,8 @@
         {getopt,              "0.8.2"},
         {bbmustache,          "1.0.4"},
         {relx,                "3.8.0"},
-        {cf,                  "0.1.3"}]}.
+        {cf,                  "0.1.3"},
+        {cth_readable,        "1.0.0"}]}.
 
 {escript_name, rebar3}.
 {escript_emu_args, "%%! +sbtu +A0\n"}.

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
         {bbmustache,          "1.0.4"},
         {relx,                "3.8.0"},
         {cf,                  "0.1.3"},
-        {cth_readable,        "1.0.0"}]}.
+        {cth_readable,        "1.0.1"}]}.
 
 {escript_name, rebar3}.
 {escript_emu_args, "%%! +sbtu +A0\n"}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.4">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"0.1.1">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.1.3">>},0},
- {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.0.0">>},0},
+ {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.0.1">>},0},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.16.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.5.0">>},0},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,7 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.4">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"0.1.1">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.1.3">>},0},
+ {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.0.0">>},0},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.16.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.5.0">>},0},

--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -25,6 +25,7 @@
                   bbmustache,
                   ssl_verify_hostname,
                   certifi,
+                  cth_readable,
                   relx,
                   inets]},
   {env, [


### PR DESCRIPTION
This uses cth_readable to:
- silence error_logger output to the shell unless a test fails
- silence ct:pal output to the shell unless a test fails

I have currently not baked in any way to disable this behaviour, but I
figured if it is required, there is time to do it before the final
3.0.0 release.

## What it looks like

![example](http://i.imgur.com/dDFNxZr.png)
![example](http://i.imgur.com/RXZBG7H.png)