### PR TITLE
include Sean Cribbs eunit formatter by default

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,8 @@
         {bbmustache,          "1.0.4"},
         {relx,                "3.8.0"},
         {cf,                  "0.1.3"},
-        {cth_readable,        "1.0.1"}]}.
+        {cth_readable,        "1.0.1"},
+        {eunit_formatters,    "0.2.0"}]}.
 
 {escript_name, rebar3}.
 {escript_emu_args, "%%! +sbtu +A0\n"}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,6 +3,7 @@
  {<<"cf">>,{pkg,<<"cf">>,<<"0.1.3">>},0},
  {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.0.1">>},0},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.16.0">>},0},
+ {<<"eunit_formatters">>,{pkg,<<"eunit_formatters">>,<<"0.2.0">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.5.0">>},0},
  {<<"relx">>,{pkg,<<"relx">>,<<"3.8.0">>},0},

--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -27,7 +27,8 @@
                   certifi,
                   cth_readable,
                   relx,
-                  inets]},
+                  inets,
+                  eunit_formatters]},
   {env, [
         %% Default log level
         {log_level, warn},

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -304,9 +304,20 @@ validate_module(_State, Module) ->
 resolve_eunit_opts(State) ->
     {Opts, _} = rebar_state:command_parsed_args(State),
     EUnitOpts = rebar_state:get(State, eunit_opts, []),
-    case proplists:get_value(verbose, Opts, false) of
-        true  -> set_verbose(EUnitOpts);
-        false -> EUnitOpts
+    EUnitOpts1 = case proplists:get_value(verbose, Opts, false) of
+                    true  -> set_verbose(EUnitOpts);
+                    false -> EUnitOpts
+                end,
+    case proplists:get_value(eunit_formatters, Opts, true) of
+        true  -> custom_eunit_formatters(EUnitOpts1);
+        false -> EUnitOpts1
+    end.
+
+custom_eunit_formatters(Opts) ->
+    %% If `report` is already set then treat that like `eunit_formatters` is false
+    case lists:keymember(report, 1, Opts) of
+        true -> Opts;
+        false -> [no_tty, {report, {eunit_progress, [colored, profile]}} | Opts]
     end.
 
 set_verbose(Opts) ->

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -307,7 +307,7 @@ resolve_eunit_opts(State) ->
     EUnitOpts1 = case proplists:get_value(verbose, Opts, false) of
                     true  -> set_verbose(EUnitOpts);
                     false -> EUnitOpts
-                end,
+                 end,
     case proplists:get_value(eunit_formatters, Opts, true) of
         true  -> custom_eunit_formatters(EUnitOpts1);
         false -> EUnitOpts1


### PR DESCRIPTION
Pinging @seancribbs in case he has any warnings about making this a default.

It can be turned off by either the user already having a `report` key in their eunit opts or setting `eunit_formatters` to `false` in `eunit_opts`.