### PR TITLE
Fix error reports on missing include paths

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -688,7 +688,7 @@ warn_and_find_path(File, Dir) ->
         true ->
             [SrcHeader];
         false ->
-            IncludeDir = filename:join(filename:join(rebar_utils:droplast(filename:split(Dir))), "include"),
+            IncludeDir = filename:join(rebar_utils:droplast(filename:split(Dir))++["include"]),
             IncludeHeader = filename:join(IncludeDir, File),
             case filelib:is_regular(IncludeHeader) of
                 true ->


### PR DESCRIPTION
In some cases (nested includes?) paths end up in such a way that joining
them breaks up and hard-crashes rebar3. This patch specifically handles
this scenario to fix things by avoiding passing empty lists to
filename:join.

fixes #914.

I'm not sure how exactly to reproduce for tests. I showed it is fixed it by using https://github.com/rabbitmq/rabbitmq-erlang-client : 

```
→ rebar3 compile
===> Verifying dependencies...
===> Compiling amqp_client
===> Compiling /home/ferd/code/experiment/rabbitmq-erlang-client/_build/default/lib/amqp_client/src/amqp_gen_consumer.erl failed
/home/ferd/code/experiment/rabbitmq-erlang-client/_build/default/lib/amqp_client/include/amqp_client.hrl:20: can't find include lib "rabbit_common/include/rabbit.hrl"
/home/ferd/code/experiment/rabbitmq-erlang-client/_build/default/lib/amqp_client/include/amqp_client.hrl:21: can't find include lib "rabbit_common/include/rabbit_framing.hrl"
...
```