### PR TITLE
Default to no eunit formatter if verbose specified

### DIFF
--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -346,7 +346,8 @@ resolve_eunit_opts(State) ->
                     true  -> set_verbose(EUnitOpts);
                     false -> EUnitOpts
                  end,
-    case proplists:get_value(eunit_formatters, EUnitOpts1, true) of
+    IsVerbose = lists:member(verbose, EUnitOpts1),
+    case proplists:get_value(eunit_formatters, EUnitOpts1, not IsVerbose) of
         true  -> custom_eunit_formatters(EUnitOpts1);
         false -> EUnitOpts1
     end.


### PR DESCRIPTION
The previous default meant that verbose output would not be emitted, thanks to the custom formatter which doesn't seem to interact well with `verbose`.

I'm opening this now because I wanted to quickly fix this behavior, but I'm open to suggestions on how to improve the tests for this.