### PR TITLE
special handling of relx configs in profiles

### DIFF
--- a/src/rebar_opts.erl
+++ b/src/rebar_opts.erl
@@ -115,6 +115,8 @@ merge_opts(NewOpts, OldOpts) ->
                        Value;
                   (mib_first_files, NewValue, OldValue) ->
                        OldValue ++ NewValue;
+                  (relx, NewValue, OldValue) ->
+                       rebar_utils:tup_umerge(OldValue, NewValue);
                   (_Key, NewValue, OldValue) when is_list(NewValue) ->
                        case io_lib:printable_list(NewValue) of
                            true when NewValue =:= [] ->

--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -30,9 +30,8 @@ do(Module, Command, Provider, State) ->
                 relx:main([{lib_dirs, LibDirs}
                           ,{caller, api} | output_dir(OutputDir, Options)], AllOptions);
             Config ->
-                Config1 = update_config(Config),
                 relx:main([{lib_dirs, LibDirs}
-                          ,{config, Config1}
+                          ,{config, Config}
                           ,{caller, api} | output_dir(OutputDir, Options)], AllOptions)
         end,
         rebar_hooks:run_all_hooks(Cwd, post, Provider, Providers, State),
@@ -45,26 +44,6 @@ do(Module, Command, Provider, State) ->
 -spec format_error(any()) -> iolist().
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
-
-%% To handle profiles rebar3 expects the provider to use the first entry
-%% in a configuration key-value list as the value of a key if dups exist.
-%% This does not work with relx. Some config options must not lose their
-%% order (release which has an extends option is one). So here we pull out
-%% options that are special so we can reverse the rest so what we expect
-%% from a rebar3 profile is what we get on the relx side.
--define(SPECIAL_KEYS, [release, vm_args, sys_config, overlay_vars, lib_dirs]).
-
-update_config(Config) ->
-    {Special, Other} =
-        lists:foldl(fun(Tuple, {SpecialAcc, OtherAcc}) when is_tuple(Tuple) ->
-                            case lists:member(element(1, Tuple), ?SPECIAL_KEYS) of
-                                true ->
-                                    {[Tuple | SpecialAcc], OtherAcc};
-                                false ->
-                                    {SpecialAcc, [Tuple | OtherAcc]}
-                            end
-                    end, {[], []}, Config),
-    lists:reverse(Special) ++ Other.
 
 %% Don't override output_dir if the user passed one on the command line
 output_dir(OutputDir, Options) ->


### PR DESCRIPTION
Relx config need new values at the end of the list and
profile additions prepended. So now in apply_profile in
the case it is a relx config we prepend the config list.
This does, however, mean that a profile release can not
'extend' a release defined in the default profile since
the one being extended would have its definition after
the profile release and thus relx would not be able to
use its values for extending.

Fixes https://github.com/rebar/rebar3/issues/936