### PR TITLE
auto-update the registry if a pkg isn't found, fail if it still isn't found

### DIFF
--- a/src/rebar_packages.erl
+++ b/src/rebar_packages.erl
@@ -28,7 +28,17 @@ packages(State) ->
             ok;
         false ->
             ?DEBUG("Error loading package index.", []),
-            ?ERROR("Bad packages index, try to fix with `rebar3 update`", []),
+            handle_bad_index(State)
+    end.
+
+handle_bad_index(State) ->
+    ?ERROR("Bad packages index. Trying to fix by updating the registry.", []),
+    {ok, State1} = rebar_prv_update:do(State),
+    case load_and_verify_version(State1) of
+        true ->
+            ok;
+        false ->
+            %% Still unable to load after an update, create an empty registry
             ets:new(?PACKAGE_TABLE, [named_table, public])
     end.
 
@@ -52,10 +62,24 @@ load_and_verify_version(State) ->
 
 deps(Name, Vsn, State) ->
     try
-        ?MODULE:verify_table(State),
-        ets:lookup_element(?PACKAGE_TABLE, {ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)}, 2)
+        deps_(Name, Vsn, State)
     catch
         _:_ ->
+            handle_missing_package(Name, Vsn, State)
+    end.
+
+deps_(Name, Vsn, State) ->
+    ?MODULE:verify_table(State),
+    ets:lookup_element(?PACKAGE_TABLE, {ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)}, 2).
+
+handle_missing_package(Name, Vsn, State) ->
+    ?INFO("Package ~s-~s not found. Fetching registry updates and trying again...", [Name, Vsn]),
+    {ok, State1} = rebar_prv_update:do(State),
+    try
+        deps_(Name, Vsn, State1)
+    catch
+        _:_ ->
+            %% Even after an update the package is still missing, time to error out
             throw(?PRV_ERROR({missing_package, ec_cnv:to_binary(Name), ec_cnv:to_binary(Vsn)}))
     end.
 
@@ -143,7 +167,7 @@ handle_single_vsn(Dep, Vsn, Constraint) ->
     end.
 
 format_error({missing_package, Package, Version}) ->
-    io_lib:format("Package not found in registry: ~s-~s. Try to fix with `rebar3 update`", [Package, Version]).
+    io_lib:format("Package not found in registry: ~s-~s.", [Package, Version]).
 
 verify_table(State) ->
     ets:info(?PACKAGE_TABLE, named_table) =:= true orelse load_and_verify_version(State).


### PR DESCRIPTION
Fix for https://github.com/rebar/rebar3/issues/939 and https://github.com/rebar/rebar3/issues/793