### PR TITLE
Fix a small bug in the MIB compiler when building dependencies

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -526,7 +526,7 @@ compile_mib(Source, Target, Opts) ->
     HrlFilename = Mib ++ ".hrl",
 
     ok = filelib:ensure_dir(Target),
-    ok = filelib:ensure_dir(filename:join([IncludeDir, HrlFilename])),
+    ok = filelib:ensure_dir(filename:join([IncludeDir, "dummy.hrl"])),
 
     AllOpts = [{outdir, Dir}
               ,{i, [Dir]}] ++

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -1018,11 +1018,14 @@ mib_test(Config) ->
 
     rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], {ok, [{app, Name}]}),
 
-    %% check a beam corresponding to the src in the extra src_dir exists in ebin
+    %% check a bin corresponding to the mib in the mibs dir exists in priv/mibs
     PrivMibsDir = filename:join([AppDir, "_build", "default", "lib", Name, "priv", "mibs"]),
     true = filelib:is_file(filename:join([PrivMibsDir, "SIMPLE-MIB.bin"])),
 
-    %% check the extra src_dir was linked into the _build dir
+    %% check a hrl corresponding to the mib in the mibs dir exists in priv/mibs/include
+    true = filelib:is_file(filename:join([PrivMibsDir, "include", "SIMPLE-MIB.hrl"])),
+
+    %% check the mibs dir was linked into the _build dir
     true = filelib:is_dir(filename:join([AppDir, "_build", "default", "lib", Name, "mibs"])).
 
 umbrella_mib_first_test(Config) ->
@@ -1065,11 +1068,14 @@ umbrella_mib_first_test(Config) ->
 
     rebar_test_utils:run_and_check(Config, RebarConfig, ["compile"], {ok, [{app, Name}]}),
 
-    %% check a beam corresponding to the src in the extra src_dir exists in ebin
+    %% check a bin corresponding to the mib in the mibs dir exists in priv/mibs
     PrivMibsDir = filename:join([AppsDir, "_build", "default", "lib", Name, "priv", "mibs"]),
     true = filelib:is_file(filename:join([PrivMibsDir, "SIMPLE-MIB.bin"])),
 
-    %% check the extra src_dir was linked into the _build dir
+    %% check a hrl corresponding to the mib in the mibs dir exists in priv/mibs/include
+    true = filelib:is_file(filename:join([PrivMibsDir, "include", "SIMPLE-MIB.hrl"])),
+
+    %% check the mibs dir was linked into the _build dir
     true = filelib:is_dir(filename:join([AppsDir, "_build", "default", "lib", Name, "mibs"])).
 
 only_default_transitive_deps(Config) ->


### PR DESCRIPTION
When compiling a dependency with a MIB file the generated hrl file is left in the root project directory in a file called "include". This has the perverse effect of messing up the search path for include files causing any dependencies with files in their "include" directory to fail to build after that.