### PR TITLE
fetch eunit_formatters config not from the command args but from the config

### DIFF
--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -346,7 +346,7 @@ resolve_eunit_opts(State) ->
                     true  -> set_verbose(EUnitOpts);
                     false -> EUnitOpts
                  end,
-    case proplists:get_value(eunit_formatters, Opts, true) of
+    case proplists:get_value(eunit_formatters, EUnitOpts1, true) of
         true  -> custom_eunit_formatters(EUnitOpts1);
         false -> EUnitOpts1
     end.


### PR DESCRIPTION
Fixes my last changes so it properly recognizes: `{eunit_opts, [{eunit_formatters, false}]}.` for turning off the special eunit formatters.