### PR TITLE
add eunit and ct profiles

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -32,7 +32,7 @@ init(State) ->
                                  {short_desc, "Run Common Tests."},
                                  {desc, "Run Common Tests."},
                                  {opts, ct_opts(State)},
-                                 {profiles, [test]}]),
+                                 {profiles, [test, ct]}]),
     {ok, rebar_state:add_provider(State, Provider)}.
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
@@ -340,7 +340,7 @@ test_dirs(State, Apps, Opts) ->
         {Suites, Dir} when is_integer(hd(Dir)) ->
             set_compile_dirs(State, Apps, join(Suites, Dir));
         {Suites, [Dir]} when is_integer(hd(Dir)) ->
-            set_compile_dirs(State, Apps, join(Suites, Dir));          
+            set_compile_dirs(State, Apps, join(Suites, Dir));
         {_Suites, _Dirs}    -> {error, "Only a single directory may be specified when specifying suites"}
     end.
 
@@ -620,4 +620,3 @@ help(verbose) ->
     "Verbose output";
 help(_) ->
     "".
-

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -32,7 +32,7 @@ init(State) ->
                                  {short_desc, "Run EUnit Tests."},
                                  {desc, "Run EUnit Tests."},
                                  {opts, eunit_opts(State)},
-                                 {profiles, [test]}]),
+                                 {profiles, [test, eunit]}]),
     State1 = rebar_state:add_provider(State, Provider),
     {ok, State1}.
 


### PR DESCRIPTION
If the user has tests under a specific directory and wants to run an individual test from that directory with `rebar3 eunit --module=<module>` they would currently have to add: `{profiles, [{test, [{extra_src_dirs, [Dir]}]}]}` to their rebar.config. This would mean those src files would also be built for common test runs. Instead here I add a var `eunit_dir` which injects that `extra_src_dirs` config when run.

The reason `{eunit_tests, [{dir, Dir}]}` doesn't work for this either is that is for specifying which tests to actually run, it translates to: `eunit:test([{dir, Dir}])` which will run all tests in `Dir`.