### PR TITLE
allow ct suites to be specified at root of project (or root of app)

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -381,7 +381,8 @@ maybe_inject_test_dir(State, AppAcc, [App|Rest], Dir) ->
             %% the current compiler tries to compile all subdirs including priv
             %% instead copy only files ending in `.erl' and directories
             %% ending in `_SUITE_data' into the `_build/PROFILE/extras' dir
-            ExtrasDir = filename:join([rebar_dir:base_dir(State), "extras"]),
+            {ok, RelAppDir} = rebar_file_utils:path_from_ancestor(rebar_app_info:dir(App), rebar_state:dir(State)),
+            ExtrasDir = filename:join([rebar_dir:base_dir(State), "extras", RelAppDir]),
             ok = copy_bare_suites(Dir, ExtrasDir),
             Opts = inject_test_dir(rebar_state:opts(State), ExtrasDir),
             {rebar_state:opts(State, Opts), AppAcc};

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -340,7 +340,7 @@ test_dirs(State, Apps, Opts) ->
         {Suites, Dir} when is_integer(hd(Dir)) ->
             set_compile_dirs(State, Apps, join(Suites, Dir));
         {Suites, [Dir]} when is_integer(hd(Dir)) ->
-            set_compile_dirs(State, Apps, join(Suites, Dir));          
+            set_compile_dirs(State, Apps, join(Suites, Dir));
         {_Suites, _Dirs}    -> {error, "Only a single directory may be specified when specifying suites"}
     end.
 

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -217,6 +217,10 @@ copy(OldAppDir, AppDir, Dir) ->
 
 %% TODO: use ec_file:copy/2 to do this, it preserves timestamps and
 %% may prevent recompilation of files in extra dirs
+copy(Source, Source) ->
+    %% allow users to specify a directory in _build as a directory
+    %% containing additional source/tests
+    ok;
 copy(Source, Target) ->
     %% important to do this so no files are copied onto themselves
     %% which truncates them to zero length on some platforms

--- a/test/rebar_ct_SUITE.erl
+++ b/test/rebar_ct_SUITE.erl
@@ -654,7 +654,10 @@ suite_at_root(Config) ->
     true = filelib:is_file(TestBeam),
 
     DataDir = filename:join([AppDir, "_build", "test", "extras", "root_SUITE_data"]),
-    true = filelib:is_dir(DataDir).
+    true = filelib:is_dir(DataDir),
+
+    DataFile = filename:join([AppDir, "_build", "test", "extras", "root_SUITE_data", "some_data.txt"]),
+    true = filelib:is_file(DataFile).
 
 suite_at_app_root(Config) ->
     AppDir = ?config(apps, Config),
@@ -688,7 +691,10 @@ suite_at_app_root(Config) ->
     true = filelib:is_file(TestBeam),
 
     DataDir = filename:join([AppDir, "_build", "test", "extras", "apps", Name2, "app_root_SUITE_data"]),
-    true = filelib:is_dir(DataDir).
+    true = filelib:is_dir(DataDir),
+
+    DataFile = filename:join([AppDir, "_build", "test", "extras", "root_SUITE_data", "some_data.txt"]),
+    true = filelib:is_file(DataFile).
 
 %% this test probably only fails when this suite is run via rebar3 with the --cover flag
 data_dir_correct(Config) ->


### PR DESCRIPTION
previously rebar3 dropped suites declared at the root of the project (via
`--suite=whatever_SUITE' probably) and warned. this was because the compiler
would recursively copy and compile everything in the directory indicated by
the test suite. this changes the copy mechanism to only copy erl source files
and directories that end with `_SUITE_data' into the `extras' dir in `_build'