### PR TITLE
symlink mib hrl output in apps `include' directories

### DIFF
--- a/src/rebar_erlc_compiler.erl
+++ b/src/rebar_erlc_compiler.erl
@@ -521,16 +521,12 @@ target_base(OutDir, Source) ->
 compile_mib(AppInfo) ->
     fun(Source, Target, Opts) ->
         Dir = filename:dirname(Target),
-        IncludeDir = filename:join(Dir, "include"),
-
         Mib = filename:rootname(Target),
         HrlFilename = Mib ++ ".hrl",
-        Hrl = filename:basename(HrlFilename),
 
         AppInclude = filename:join([rebar_app_info:dir(AppInfo), "include"]),
 
         ok = filelib:ensure_dir(Target),
-        ok = filelib:ensure_dir(filename:join([IncludeDir, "dummy.hrl"])),
         ok = filelib:ensure_dir(filename:join([AppInclude, "dummy.hrl"])),
 
         AllOpts = [{outdir, Dir}
@@ -547,9 +543,7 @@ compile_mib(AppInfo) ->
                             #options{specific = [{verbosity, Verbosity}]}
                     end,
                 ok = snmpc:mib_to_hrl(Mib, Mib, MibToHrlOpts),
-                rebar_file_utils:mv(HrlFilename, IncludeDir),
-                rebar_file_utils:symlink_or_copy(filename:join([IncludeDir, Hrl]),
-                                                 filename:join([AppInclude, Hrl])),
+                rebar_file_utils:mv(HrlFilename, AppInclude),
                 ok;
             {error, compilation_failed} ->
                 ?FAIL

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -1025,6 +1025,9 @@ mib_test(Config) ->
     %% check a hrl corresponding to the mib in the mibs dir exists in priv/mibs/include
     true = filelib:is_file(filename:join([PrivMibsDir, "include", "SIMPLE-MIB.hrl"])),
 
+    %% check a hrl corresponding to the mib in the mibs dir exists in include
+    true = filelib:is_file(filename:join([AppDir, "include", "SIMPLE-MIB.hrl"])),
+
     %% check the mibs dir was linked into the _build dir
     true = filelib:is_dir(filename:join([AppDir, "_build", "default", "lib", Name, "mibs"])).
 
@@ -1074,6 +1077,9 @@ umbrella_mib_first_test(Config) ->
 
     %% check a hrl corresponding to the mib in the mibs dir exists in priv/mibs/include
     true = filelib:is_file(filename:join([PrivMibsDir, "include", "SIMPLE-MIB.hrl"])),
+
+    %% check a hrl corresponding to the mib in the mibs dir exists in include
+    true = filelib:is_file(filename:join([AppDir, "include", "SIMPLE-MIB.hrl"])),
 
     %% check the mibs dir was linked into the _build dir
     true = filelib:is_dir(filename:join([AppsDir, "_build", "default", "lib", Name, "mibs"])).

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -1022,9 +1022,6 @@ mib_test(Config) ->
     PrivMibsDir = filename:join([AppDir, "_build", "default", "lib", Name, "priv", "mibs"]),
     true = filelib:is_file(filename:join([PrivMibsDir, "SIMPLE-MIB.bin"])),
 
-    %% check a hrl corresponding to the mib in the mibs dir exists in priv/mibs/include
-    true = filelib:is_file(filename:join([PrivMibsDir, "include", "SIMPLE-MIB.hrl"])),
-
     %% check a hrl corresponding to the mib in the mibs dir exists in include
     true = filelib:is_file(filename:join([AppDir, "include", "SIMPLE-MIB.hrl"])),
 
@@ -1074,9 +1071,6 @@ umbrella_mib_first_test(Config) ->
     %% check a bin corresponding to the mib in the mibs dir exists in priv/mibs
     PrivMibsDir = filename:join([AppsDir, "_build", "default", "lib", Name, "priv", "mibs"]),
     true = filelib:is_file(filename:join([PrivMibsDir, "SIMPLE-MIB.bin"])),
-
-    %% check a hrl corresponding to the mib in the mibs dir exists in priv/mibs/include
-    true = filelib:is_file(filename:join([PrivMibsDir, "include", "SIMPLE-MIB.hrl"])),
 
     %% check a hrl corresponding to the mib in the mibs dir exists in include
     true = filelib:is_file(filename:join([AppDir, "include", "SIMPLE-MIB.hrl"])),


### PR DESCRIPTION
this restores compatibility with rebar2 and erlang.mk

the fix is somewhat of a hackjob but without refactoring rebar_base_compiler pretty substantially there's no good way to pass the mib compiler the extra information it needs