### PR TITLE
Allow bootstrap to pick up existing Hex cache and deps

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -2,8 +2,7 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ft=erlang ts=4 sw=4 et
 
-
-main(_Args) ->
+main(_) ->
     application:start(crypto),
     application:start(asn1),
     application:start(public_key),
@@ -34,7 +33,14 @@ main(_Args) ->
 
     setup_env(),
     os:putenv("REBAR_PROFILE", "bootstrap"),
-    rebar3:run(["update"]),
+    RegistryFile = default_registry_file(),
+    case filelib:is_file(RegistryFile) of
+        true ->
+            ok;
+        false ->
+            rebar3:run(["update"])
+    end,
+
     {ok, State} = rebar3:run(["compile"]),
     reset_env(),
     os:putenv("REBAR_PROFILE", ""),
@@ -62,6 +68,11 @@ main(_Args) ->
             ok
     end.
 
+default_registry_file() ->
+    {ok, [[Home]]} = init:get_argument(home),
+    CacheDir = filename:join([Home, ".cache", "rebar3"]),
+    filename:join([CacheDir, "hex", "default", "registry"]).
+
 fetch_and_compile({Name, ErlFirstFiles}, Deps) ->
     case lists:keyfind(Name, 1, Deps) of
         {Name, Vsn} ->
@@ -79,15 +90,20 @@ fetch_and_compile({Name, ErlFirstFiles}, Deps) ->
 
 fetch({pkg, Name, Vsn}, App) ->
     Dir = filename:join([filename:absname("_build/default/lib/"), App]),
-    CDN = "https://s3.amazonaws.com/s3.hex.pm/tarballs",
-    Package = binary_to_list(<<Name/binary, "-", Vsn/binary, ".tar">>),
-    Url = string:join([CDN, Package], "/"),
-    case request(Url) of
-        {ok, Binary} ->
-            {ok, Contents} = extract(Binary),
-            ok = erl_tar:extract({binary, Contents}, [{cwd, Dir}, compressed]);
-        _ ->
-            io:format("Error: Unable to fetch package ~p ~p~n", [Name, Vsn])
+    case filelib:is_dir(Dir) of
+        false ->
+            CDN = "https://s3.amazonaws.com/s3.hex.pm/tarballs",
+            Package = binary_to_list(<<Name/binary, "-", Vsn/binary, ".tar">>),
+            Url = string:join([CDN, Package], "/"),
+            case request(Url) of
+                {ok, Binary} ->
+                    {ok, Contents} = extract(Binary),
+                    ok = erl_tar:extract({binary, Contents}, [{cwd, Dir}, compressed]);
+                _ ->
+                    io:format("Error: Unable to fetch package ~p ~p~n", [Name, Vsn])
+            end;
+        true ->
+            io:format("Dependency ~s already exists~n", [Name])
     end.
 
 extract(Binary) ->


### PR DESCRIPTION
This allows rebar to pick up existing assets, if present:
- hex registry from .cache/rebar3/hex/default/registry
- built deps from _build/default/lib/*

@tsloughter, does this approach look good?

Rationale: this allows to build rebar3 in a build system, which requires it to be hermetic. This is the case for Debian (they are working on making their builds reproducible) and for Nix. I am working on Nix packaging for Erlang using rebar3 and hex.pm here:
https://github.com/NixOS/nixpkgs/pull/11651

Currently I have to apply the following patch to make it hermetic:
https://github.com/gleber/nixpkgs/blob/add-erlang-modules/pkgs/development/tools/build-managers/rebar3/hermetic-bootstrap.patch

And in the build rules I am manually providing plugins to build process:
https://github.com/NixOS/nixpkgs/pull/11651/files#diff-177ea02978ffc72f964033695c5e023eR93

and provide a snapshot of registry:
https://github.com/NixOS/nixpkgs/pull/11651/files#diff-177ea02978ffc72f964033695c5e023eR9