### PR TITLE
contributors -> maintaiers in template app data

### DIFF
--- a/priv/templates/otp_app.app.src
+++ b/priv/templates/otp_app.app.src
@@ -10,7 +10,7 @@
   {env,[]},
   {modules, []},
 
-  {contributors, []},
+  {maintainers, []},
   {licenses, []},
   {links, []}
  ]}.

--- a/priv/templates/otp_lib.app.src
+++ b/priv/templates/otp_lib.app.src
@@ -9,7 +9,7 @@
   {env,[]},
   {modules, []},
 
-  {contributors, []},
+  {maintainers, []},
   {licenses, []},
   {links, []}
  ]}.


### PR DESCRIPTION
hex.pm is now using maintainers instead of contributors in metadata.
Templates should be updated to reflect it.