### PR TITLE
warn if the directories `eunit' or `ct' show up in `src_dirs'

### DIFF
--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -247,6 +247,21 @@ resolve_src_dirs(Opts) ->
 %% in src_dirs also exist in extra_src_dirs
 normalize_src_dirs(SrcDirs, ExtraDirs) ->
     S = lists:usort(SrcDirs),
-    E = lists:usort(ExtraDirs),
-    {S, lists:subtract(E, S)}.
+    E = lists:subtract(lists:usort(ExtraDirs), S),
+    ok = warn_on_problematic_directories(S ++ E),
+    {S, E}.
+
+%% warn when directories called `eunit' and `ct' are added to compile dirs
+warn_on_problematic_directories(AllDirs) ->
+    F = fun(Dir) ->
+        case is_a_problem(Dir) of
+            true  -> ?WARN("Possible name clash with directory ~p.", [Dir]);
+            false -> ok
+        end
+    end,
+    lists:foreach(F, AllDirs).
+
+is_a_problem("eunit") -> true;
+is_a_problem("common_test") -> true;
+is_a_problem(_) -> false.
 


### PR DESCRIPTION
if these directories actually exist they'll be added to the path ahead
of the release/standard distribution directories and they'll break eunit
and/or ct execution