### PR TITLE
Updates cth_readable so it supports dumb terminals

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
         {bbmustache,          "1.0.4"},
         {relx,                "3.11.0"},
         {cf,                  "0.2.1"},
-        {cth_readable,        "1.1.1"},
+        {cth_readable,        "1.2.0"},
         {eunit_formatters,    "0.3.1"}]}.
 
 {escript_name, rebar3}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.4">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"0.3.0">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.2.1">>},0},
- {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.1.1">>},0},
+ {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.2.0">>},0},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.18.0">>},0},
  {<<"eunit_formatters">>,{pkg,<<"eunit_formatters">>,<<"0.3.1">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},


### PR DESCRIPTION
cth_readable 1.2.0 uses cf 0.2.1 to output colors, which makes it
support dumb terminals without issue.