### PR TITLE
only apply default and prod profile to dependencies

### DIFF
--- a/src/rebar_app_utils.erl
+++ b/src/rebar_app_utils.erl
@@ -166,7 +166,9 @@ dep_to_app(Parent, DepsDir, Name, Vsn, Source, IsLock, State) ->
     Overrides = rebar_state:get(State, overrides, []),
     AppInfo2 = rebar_app_info:set(AppInfo1, overrides, rebar_app_info:get(AppInfo, overrides, [])++Overrides),
     AppInfo3 = rebar_app_info:apply_overrides(rebar_app_info:get(AppInfo2, overrides, []), AppInfo2),
-    rebar_app_info:is_lock(AppInfo3, IsLock).
+    AppInfo4 = rebar_app_info:apply_profiles(AppInfo3, [default, prod]),
+    AppInfo5 = rebar_app_info:profiles(AppInfo4, [default]),
+    rebar_app_info:is_lock(AppInfo5, IsLock).
 
 update_source(AppInfo, {pkg, PkgName, PkgVsn}, State) ->
     {PkgName1, PkgVsn1} = case PkgVsn of

--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -251,13 +251,12 @@ update_unseen_dep(AppInfo, Profile, Level, Deps, Apps, State, Upgrade, Seen, Loc
 
 -spec handle_dep(rebar_state:t(), atom(), file:filename_all(), rebar_app_info:t(), list(), integer()) -> {rebar_app_info:t(), [rebar_app_info:t()], rebar_state:t()}.
 handle_dep(State, Profile, DepsDir, AppInfo, Locks, Level) ->
-    Profiles = rebar_state:current_profiles(State),
     Name = rebar_app_info:name(AppInfo),
     C = rebar_config:consult(rebar_app_info:dir(AppInfo)),
 
     AppInfo0 = rebar_app_info:update_opts(AppInfo, rebar_app_info:opts(AppInfo), C),
     AppInfo1 = rebar_app_info:apply_overrides(rebar_app_info:get(AppInfo, overrides, []), AppInfo0),
-    AppInfo2 = rebar_app_info:apply_profiles(AppInfo1, Profiles),
+    AppInfo2 = rebar_app_info:apply_profiles(AppInfo1, [default, prod]),
 
     Plugins = rebar_app_info:get(AppInfo2, plugins, []),
     AppInfo3 = rebar_app_info:set(AppInfo2, {plugins, Profile}, Plugins),
@@ -269,7 +268,7 @@ handle_dep(State, Profile, DepsDir, AppInfo, Locks, Level) ->
     State1 = rebar_plugins:install(State, AppInfo3),
 
     %% Upgrade lock level to be the level the dep will have in this dep tree
-    Deps = rebar_app_info:get(AppInfo3, {deps, default}, []),
+    Deps = rebar_app_info:get(AppInfo3, {deps, default}, []) ++ rebar_app_info:get(AppInfo3, {deps, prod}, []),
     AppInfo4 = rebar_app_info:deps(AppInfo3, rebar_state:deps_names(Deps)),
 
     %% Keep all overrides from the global config and this dep when parsing its deps

--- a/test/rebar_compile_SUITE.erl
+++ b/test/rebar_compile_SUITE.erl
@@ -37,7 +37,8 @@
          only_default_transitive_deps/1,
          clean_all/1,
          override_deps/1,
-         profile_override_deps/1]).
+         profile_override_deps/1,
+         deps_build_in_prod/1]).
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -58,7 +59,7 @@ all() ->
      deps_in_path, checkout_priority, highest_version_of_pkg_dep,
      parse_transform_test, erl_first_files_test, mib_test,
      umbrella_mib_first_test, only_default_transitive_deps,
-     clean_all, override_deps, profile_override_deps].
+     clean_all, override_deps, profile_override_deps, deps_build_in_prod].
 
 groups() ->
     [{basic_app, [], [build_basic_app, paths_basic_app, clean_basic_app]},
@@ -89,7 +90,7 @@ init_per_group(basic_app, Config) ->
     Name = rebar_test_utils:create_random_name("app1"),
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
-    
+
     [{app_names, [Name]}, {vsns, [Vsn]}|NewConfig];
 
 init_per_group(release_apps, Config) ->
@@ -103,7 +104,7 @@ init_per_group(release_apps, Config) ->
     Name2 = rebar_test_utils:create_random_name("relapp2_"),
     Vsn2 = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(filename:join([AppDir,"apps",Name2]), Name2, Vsn2, [kernel, stdlib]),
-    
+
     [{app_names, [Name1, Name2]}, {vsns, [Vsn1, Vsn2]}|NewConfig];
 
 init_per_group(checkout_apps, Config) ->
@@ -415,7 +416,7 @@ paths_basic_app(Config) ->
     [Vsn] = ?config(vsns, Config),
 
     {ok, State} = rebar_test_utils:run_and_check(Config, [], ["compile"], return),
-    
+
     code:add_paths(rebar_state:code_paths(State, all_deps)),
     ok = application:load(list_to_atom(Name)),
     Loaded = application:loaded_applications(),
@@ -1173,3 +1174,32 @@ profile_override_deps(Config) ->
         {ok, [{dep, "some_dep"},{dep_not_exist, "other_dep"}]}
     ).
 
+%% verify a deps prod profile is used
+%% tested by checking prod hooks run and outputs to default profile dir for dep
+%% and prod deps are installed for dep
+deps_build_in_prod(Config) ->
+    AppDir = ?config(apps, Config),
+
+    Name = rebar_test_utils:create_random_name("app1_"),
+    Vsn = rebar_test_utils:create_random_vsn(),
+    rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
+
+    GitDeps = rebar_test_utils:expand_deps(git, [{"asdf", "1.0.0", []}]),
+    PkgName = rebar_test_utils:create_random_name("pkg1_"),
+    {SrcDeps, _} = rebar_test_utils:flat_deps(GitDeps),
+    mock_git_resource:mock([{deps, SrcDeps},
+                            {config, [{profiles, [{prod, [{pre_hooks, [{compile, "echo whatsup > randomfile"}]},
+                                                          {deps, [list_to_atom(PkgName)]}]}]}]}]),
+
+    mock_pkg_resource:mock([{pkgdeps, [{{iolist_to_binary(PkgName), <<"0.1.0">>}, []}]}]),
+
+    Deps = rebar_test_utils:top_level_deps(GitDeps),
+    RConfFile = rebar_test_utils:create_config(AppDir, [{deps, Deps}]),
+    {ok, RConf} = file:consult(RConfFile),
+
+    %% Build with deps.
+    rebar_test_utils:run_and_check(
+        Config, RConf, ["compile"],
+        {ok, [{app, Name}, {dep, "asdf", <<"1.0.0">>}, {dep, PkgName},
+              {file, filename:join([AppDir, "_build", "default", "lib", "asdf", "randomfile"])}]}
+    ).


### PR DESCRIPTION
Fix for https://github.com/rebar/rebar3/issues/998

When implementing this I discovered we actually were applying profiles to dependencies! This removes that mistake and only applies the `prod` profile to dependencies.

The reason we didn't notice is this only happened in `handle_dep` which would not be called for a dep when say `rebar3 eunit` is run because the dep was already fetched to `default`, so the `test` profile wouldn't be wrongly applied to it, it would only happen for test deps, which is still wrong and now won't happen.