### PR TITLE
install project app plugins after discovering them not before

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -123,7 +123,7 @@ run_aux(State, RawArgs) ->
     {ok, Providers} = application:get_env(rebar, providers),
     %% Providers can modify profiles stored in opts, so set default after initializing providers
     State5 = rebar_state:create_logic_providers(Providers, State4),
-    State6 = rebar_plugins:project_apps_install(State5),
+    State6 = rebar_plugins:top_level_install(State5),
     State7 = rebar_state:default(State6, rebar_state:opts(State6)),
 
     {Task, Args} = parse_args(RawArgs),

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -3,7 +3,8 @@
 
 -module(rebar_plugins).
 
--export([project_apps_install/1
+-export([top_level_install/1
+        ,project_apps_install/1
         ,install/2
         ,handle_plugins/3
         ,handle_plugins/4]).
@@ -14,11 +15,18 @@
 %% Public API
 %% ===================================================================
 
+-spec top_level_install(rebar_state:t()) -> rebar_state:t().
+top_level_install(State) ->
+    Profiles = rebar_state:current_profiles(State),
+    lists:foldl(fun(Profile, StateAcc) ->
+                        Plugins = rebar_state:get(State, {plugins, Profile}, []),
+                        handle_plugins(Profile, Plugins, StateAcc)
+                end, State, Profiles).
+
 -spec project_apps_install(rebar_state:t()) -> rebar_state:t().
 project_apps_install(State) ->
     Profiles = rebar_state:current_profiles(State),
     ProjectApps = rebar_state:project_apps(State),
-
     lists:foldl(fun(Profile, StateAcc) ->
                         Plugins = rebar_state:get(State, {plugins, Profile}, []),
                         StateAcc1 = handle_plugins(Profile, Plugins, StateAcc),

--- a/src/rebar_prv_app_discovery.erl
+++ b/src/rebar_prv_app_discovery.erl
@@ -36,7 +36,8 @@ do(State) ->
     LibDirs = rebar_dir:lib_dirs(State),
     try
         State1 = rebar_app_discover:do(State, LibDirs),
-        {ok, State1}
+        State2 = rebar_plugins:project_apps_install(State1),
+        {ok, State2}
     catch
         throw:{error, {rebar_packages, Error}} ->
             {error, {rebar_packages, Error}};


### PR DESCRIPTION
Fix for https://github.com/rebar/rebar3/issues/947

We were trying to install project app plugins before we discovered them. I changed that to just a top level config plugins install and moved the project app plugin install to after they are discovered.