### PR TITLE
check at runtime instead of compile time for `file:list_dir_all/1`

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,6 @@
                       {"rebar/priv/templates/*", "_build/default/lib/"}]}.
 
 {erl_opts, [{platform_define, "^[0-9]+", namespaced_types},
-            {platform_define, "^R1[4|5]", no_list_dir_all},
             no_debug_info,
             warnings_as_errors]}.
 

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -828,8 +828,11 @@ info_useless(Old, New) ->
         not lists:member(Name, New)],
     ok.
 
--ifdef(no_list_dir_all).
-list_dir(Dir) -> file:list_dir(Dir).
--else.
-list_dir(Dir) -> file:list_dir_all(Dir).
--endif.
+list_dir(Dir) ->
+    %% `list_dir_all` returns raw files which are unsupported
+    %% prior to R16 so just fall back to `list_dir` if running
+    %% on an earlier vm
+    case erlang:function_exported(file, list_dir_all, 1) of
+        true  -> file:list_dir_all(Dir);
+        false -> file:list_dir(Dir)
+    end.


### PR DESCRIPTION
this is slower than the compile time check but i guess packaging rebars with
repos is still a thing and i think only the `eunit` and `ct` providers call it
anyways

fixes #1004