### PR TITLE
change detection of valid modules for `eunit`

### DIFF
--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -333,10 +333,9 @@ validate_file(State, File) ->
     end.
 
 validate_module(_State, Module) ->
-    Path = code:which(Module),
-    case beam_lib:chunks(Path, [exports]) of
-        {ok, _}              -> ok;
-        {error, beam_lib, _} -> {error, lists:concat(["Module `", Module, "' not found in project."])}
+    case code:which(Module) of
+        non_existing -> {error, lists:concat(["Module `", Module, "' not found in project."])};
+        _            -> ok
     end.
 
 resolve_eunit_opts(State) ->


### PR DESCRIPTION
`beam_lib:chunks(..)` needs a path to object code which, frustratingly,
`code:which/1` won't return for cover compiled modules. instead just
assume that if `code:which/1` doesn't return `non_existing` a module
is something we can run tests on

fixes #1014