### PR TITLE
Display error message when bad config is loaded

### DIFF
--- a/src/rebar_prv_shell.erl
+++ b/src/rebar_prv_shell.erl
@@ -325,9 +325,14 @@ reread_config(State) ->
         no_config ->
             ok;
         ConfigList ->
-            _ = [application:set_env(Application, Key, Val)
+            try
+                [application:set_env(Application, Key, Val)
                   || {Application, Items} <- ConfigList,
-                     {Key, Val} <- Items],
+                     {Key, Val} <- Items]
+            catch _:_ ->
+                ?ERROR("The configuration file submitted could not be read "
+                       "and will be ignored.", [])
+            end,
             ok
     end.
 


### PR DESCRIPTION
If a bad configuration file is submitted to rebar3 shell, display the
following error:

    ===> The configuration file submitted could not be read and will be
    ignored.

And keep going otherwise rather than silently failing.

While crash-fast is usually a good mechanism, the shell so far is very
tolerant of failures from apps to boot and whatnot, so this feels
appropriate.

Fixes #1019