### PR TITLE
local install and local upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Stable versions can be obtained from the [releases page](https://github.com/reba
 The rebar3 escript can also extract itself with a run script under the user's home directory:
 
 ```bash
-$ ./rebar3 unstable install
+$ ./rebar3 local install
 ===> Extracting rebar3 libs to ~/.cache/rebar3/lib...
 ===> Writing rebar3 run script ~/.cache/rebar3/bin/rebar3...
 ===> Add to $PATH for use: export PATH=$PATH:~/.cache/rebar3/bin
 ```
 
-To keep it up to date after you've installed rebar3 this way you can use `rebar3 unstable upgrade` which
+To keep it up to date after you've installed rebar3 this way you can use `rebar3 local upgrade` which
 fetches the latest nightly and extracts to the same place as above.
 
 Rebar3 may also be available on various OS-specific package managers such as

--- a/src/rebar_prv_local_install.erl
+++ b/src/rebar_prv_local_install.erl
@@ -15,7 +15,7 @@
 -include_lib("kernel/include/file.hrl").
 
 -define(PROVIDER, install).
--define(NAMESPACE, unstable).
+-define(NAMESPACE, local).
 -define(DEPS, []).
 
 %% ===================================================================

--- a/src/rebar_prv_local_install.erl
+++ b/src/rebar_prv_local_install.erl
@@ -60,7 +60,7 @@ format_error(Reason) ->
 bin_contents(OutputDir) ->
     <<"#!/usr/bin/env sh
 
-erl -pz ", (ec_cnv:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A0  -noshell -boot start_clean -s rebar3 main -extra \"$@\"
+erl -pz ", (ec_cnv:to_binary(OutputDir))/binary,"/*/ebin +sbtu +A0 -noshell -boot start_clean -s rebar3 main $REBAR3_ERL_ARGS -extra \"$@\"
 ">>.
 
 extract_escript(State, ScriptPath) ->

--- a/src/rebar_prv_local_upgrade.erl
+++ b/src/rebar_prv_local_upgrade.erl
@@ -14,7 +14,7 @@
 -include_lib("kernel/include/file.hrl").
 
 -define(PROVIDER, upgrade).
--define(NAMESPACE, unstable).
+-define(NAMESPACE, local).
 -define(DEPS, []).
 
 %% ===================================================================


### PR DESCRIPTION
This PR moves `unstable install` and `unstable upgrade` to the `local` namespace and adds an optional env var `REBAR3_ERL_ARGS` to allow setting custom VM args when running `rebar3`.