### PR TITLE
don't strip the project apps when running `ct` with just a root suite specified

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -381,11 +381,9 @@ maybe_inject_test_dir(State, AppAcc, [App|Rest], Dir) ->
             %% suite exists in but if the suite is in the app root directory
             %% the current compiler tries to compile all subdirs including priv
             %% instead copy only files ending in `.erl' and directories
-            %% ending in `_SUITE_data' into the `_build/PROFILE/extras' dir
-            {ok, RelAppDir} = rebar_file_utils:path_from_ancestor(rebar_app_info:dir(App), rebar_state:dir(State)),
-            ExtrasDir = filename:join([rebar_dir:base_dir(State), "extras", RelAppDir]),
-            ok = copy_bare_suites(Dir, ExtrasDir),
-            Opts = inject_test_dir(rebar_state:opts(State), ExtrasDir),
+            %% ending in `_SUITE_data' into the `_build/PROFILE/lib/APP' dir
+            ok = copy_bare_suites(Dir, rebar_app_info:out_dir(App)),
+            Opts = inject_test_dir(rebar_state:opts(State), rebar_app_info:out_dir(App)),
             {rebar_state:opts(State, Opts), AppAcc ++ [App]};
         {ok, Path} ->
             Opts = inject_test_dir(rebar_app_info:opts(App), Path),
@@ -450,14 +448,22 @@ translate_suites(_State, [], Acc) -> lists:reverse(Acc);
 translate_suites(State, [{suite, Suite}|Rest], Acc) when is_integer(hd(Suite)) ->
     %% single suite
     Apps = rebar_state:project_apps(State),
-    translate_suites(State, Rest, [{suite, translate(State, Apps, Suite)}|Acc]);
+    translate_suites(State, Rest, [{suite, translate_suite(State, Apps, Suite)}|Acc]);
 translate_suites(State, [{suite, Suites}|Rest], Acc) ->
     %% multiple suites
     Apps = rebar_state:project_apps(State),
-    NewSuites = {suite, lists:map(fun(Suite) -> translate(State, Apps, Suite) end, Suites)},
+    NewSuites = {suite, lists:map(fun(Suite) -> translate_suite(State, Apps, Suite) end, Suites)},
     translate_suites(State, Rest, [NewSuites|Acc]);
 translate_suites(State, [Test|Rest], Acc) ->
     translate_suites(State, Rest, [Test|Acc]).
+
+translate_suite(State, Apps, Suite) ->
+    Dirname = filename:dirname(Suite),
+    Basename = filename:basename(Suite),
+    case Dirname of
+        "." -> Suite;
+        _   -> filename:join([translate(State, Apps, Dirname), Basename])
+    end.
 
 translate(State, [App|Rest], Path) ->
     case rebar_file_utils:path_from_ancestor(Path, rebar_app_info:dir(App)) of

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -281,7 +281,8 @@ inject_ct_state(State, [App|Rest], Acc) ->
 inject_ct_state(State, [], Acc) ->
     case inject(rebar_state:opts(State), State) of
         {error, _} = Error -> Error;
-        NewOpts            -> {ok, {rebar_state:opts(State, NewOpts), lists:reverse(Acc)}}
+        NewOpts            ->
+          {ok, {rebar_state:opts(State, NewOpts), lists:reverse(Acc)}}
     end.
 
 opts(Opts, Key, Default) ->
@@ -385,7 +386,7 @@ maybe_inject_test_dir(State, AppAcc, [App|Rest], Dir) ->
             ExtrasDir = filename:join([rebar_dir:base_dir(State), "extras", RelAppDir]),
             ok = copy_bare_suites(Dir, ExtrasDir),
             Opts = inject_test_dir(rebar_state:opts(State), ExtrasDir),
-            {rebar_state:opts(State, Opts), AppAcc};
+            {rebar_state:opts(State, Opts), AppAcc ++ [App]};
         {ok, Path} ->
             Opts = inject_test_dir(rebar_app_info:opts(App), Path),
             {State, AppAcc ++ [rebar_app_info:opts(App, Opts)] ++ Rest};

--- a/test/rebar_ct_SUITE.erl
+++ b/test/rebar_ct_SUITE.erl
@@ -681,25 +681,26 @@ suite_at_app_root(Config) ->
     Opts = rebar_prv_common_test:translate_paths(NewState, T),
 
     Suite = proplists:get_value(suite, Opts),
-    Expected = filename:join([AppDir, "_build", "test", "extras", "apps", Name2, "app_root_SUITE"]),
+    Expected = filename:join([AppDir, "_build", "test", "lib", Name2, "app_root_SUITE"]),
     [Expected] = Suite,
 
-    TestHrl = filename:join([AppDir, "_build", "test", "extras", "apps", Name2, "app_root_SUITE.hrl"]),
+    TestHrl = filename:join([AppDir, "_build", "test", "lib", Name2, "app_root_SUITE.hrl"]),
     true = filelib:is_file(TestHrl),
 
-    TestBeam = filename:join([AppDir, "_build", "test", "extras", "apps", Name2, "app_root_SUITE.beam"]),
+    TestBeam = filename:join([AppDir, "_build", "test", "lib", Name2, "app_root_SUITE.beam"]),
     true = filelib:is_file(TestBeam),
 
-    DataDir = filename:join([AppDir, "_build", "test", "extras", "apps", Name2, "app_root_SUITE_data"]),
+    DataDir = filename:join([AppDir, "_build", "test", "lib", Name2, "app_root_SUITE_data"]),
     true = filelib:is_dir(DataDir),
 
-    DataFile = filename:join([AppDir, "_build", "test", "extras", "root_SUITE_data", "some_data.txt"]),
+    DataFile = filename:join([AppDir, "_build", "test", "lib", Name2, "app_root_SUITE_data", "some_data.txt"]),
     true = filelib:is_file(DataFile).
 
 %% this test probably only fails when this suite is run via rebar3 with the --cover flag
 data_dir_correct(Config) ->
     DataDir = ?config(data_dir, Config),
     Parts = filename:split(DataDir),
+    ct:pal(Parts),
     ["rebar_ct_SUITE_data","test","rebar","lib","test","_build"|_] = lists:reverse(Parts).
 
 cmd_label(Config) ->


### PR DESCRIPTION
this ensures the project apps are compiled to `lib/` instead of `extras/`