### PR TITLE
Add secondary hook for rebar_prv_compile

### DIFF
--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -13,6 +13,7 @@
 -include("rebar.hrl").
 
 -define(PROVIDER, compile).
+-define(ERLC_HOOK, erlc_compile).
 -define(DEPS, [lock]).
 
 %% ===================================================================
@@ -116,12 +117,15 @@ compile(State, Providers, AppInfo) ->
     AppDir = rebar_app_info:dir(AppInfo),
     AppInfo1 = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER,  Providers, AppInfo, State),
 
-    rebar_erlc_compiler:compile(AppInfo1),
-    case rebar_otp_app:compile(State, AppInfo1) of
-        {ok, AppInfo2} ->
-            AppInfo3 = rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo2, State),
-            has_all_artifacts(AppInfo3),
-            AppInfo3;
+    AppInfo2 = rebar_hooks:run_all_hooks(AppDir, pre, ?ERLC_HOOK, Providers, AppInfo1, State),
+    rebar_erlc_compiler:compile(AppInfo2),
+    AppInfo3 = rebar_hooks:run_all_hooks(AppDir, post, ?ERLC_HOOK, Providers, AppInfo2, State),
+
+    case rebar_otp_app:compile(State, AppInfo3) of
+        {ok, AppInfo4} ->
+            AppInfo5 = rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo4, State),
+            has_all_artifacts(AppInfo5),
+            AppInfo5;
         Error ->
             throw(Error)
     end.
@@ -143,7 +147,7 @@ paths_for_apps([App|Rest], Acc) ->
     Paths = [filename:join([rebar_app_info:out_dir(App), Dir]) || Dir <- ["ebin"|ExtraDirs]],
     FilteredPaths = lists:filter(fun ec_file:is_dir/1, Paths),
     paths_for_apps(Rest, Acc ++ FilteredPaths).
-    
+
 paths_for_extras(State, Apps) ->
     F = fun(App) -> rebar_app_info:dir(App) == rebar_state:dir(State) end,
     %% check that this app hasn't already been dealt with

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -14,6 +14,7 @@
 
 -define(PROVIDER, compile).
 -define(ERLC_HOOK, erlc_compile).
+-define(APP_HOOK, app_compile).
 -define(DEPS, [lock]).
 
 %% ===================================================================
@@ -121,11 +122,13 @@ compile(State, Providers, AppInfo) ->
     rebar_erlc_compiler:compile(AppInfo2),
     AppInfo3 = rebar_hooks:run_all_hooks(AppDir, post, ?ERLC_HOOK, Providers, AppInfo2, State),
 
-    case rebar_otp_app:compile(State, AppInfo3) of
-        {ok, AppInfo4} ->
-            AppInfo5 = rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo4, State),
+    AppInfo4 = rebar_hooks:run_all_hooks(AppDir, pre, ?APP_HOOK, Providers, AppInfo3, State),
+    case rebar_otp_app:compile(State, AppInfo4) of
+        {ok, AppInfo5} ->
+            AppInfo6 = rebar_hooks:run_all_hooks(AppDir, post, ?APP_HOOK, Providers, AppInfo5, State),
+            AppInfo7 = rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo6, State),
             has_all_artifacts(AppInfo5),
-            AppInfo5;
+            AppInfo7;
         Error ->
             throw(Error)
     end.


### PR DESCRIPTION
erlc_compile, for before/after compiling .erls to .beams, but before .app.src to .app

After discussing #1044 some on IRC with @tsloughter and @talentdeficit, we concluded something in this form would be viable.

My understanding is that it was originally intended for providers to have only two hooks: pre and post. However, the ability to define arbitrary hook points allows for greater flexibility with respect to scoping out the responsibilities of a given provider. We arguably shouldn't need to separate two closely related operations into different modules just so we can put hooks in between them.

The more I think about this, though, the less certain I am that there is an "optimal" solution. It feels dirty to be adding a "provider hook" for something that's not really a provider. Maybe there's some space in the lexicon for something like pseudo-providers, but it seems kludgy without a formal way for rebar3 to know of their existence.

I can and will write tests for this if it's accepted.