### PR TITLE
App builder as compile

### DIFF
--- a/src/rebar.app.src
+++ b/src/rebar.app.src
@@ -39,6 +39,7 @@
                      {hg, rebar_hg_resource}]},
 
         {providers, [rebar_prv_app_discovery,
+                     rebar_prv_app_builder,
                      rebar_prv_as,
                      rebar_prv_bare_compile,
                      rebar_prv_clean,

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -113,7 +113,8 @@ build_plugin(AppInfo, Apps, State) ->
     %rebar_app_info:state_or_new(State, AppInfo)
     S = rebar_state:all_deps(State, Apps),
     S1 = rebar_state:set(S, deps_dir, ?DEFAULT_PLUGINS_DIR),
-    rebar_prv_compile:compile(S1, Providers, AppInfo).
+    AppInfo1 = rebar_prv_compile:compile(S1, Providers, AppInfo),
+    rebar_prv_app_builder:build_app_file(S1, Providers, AppInfo1).
 
 plugin_providers({Plugin, _, _, _}) when is_atom(Plugin) ->
     validate_plugin(Plugin);

--- a/src/rebar_prv_app_builder.erl
+++ b/src/rebar_prv_app_builder.erl
@@ -1,0 +1,93 @@
+-module(rebar_prv_app_builder).
+
+-behaviour(provider).
+
+-export([init/1,
+         do/1,
+         format_error/1]).
+
+-export([build_app_file/2,
+         build_app_file/3]).
+
+-include_lib("providers/include/providers.hrl").
+-include("rebar.hrl").
+
+-define(PROVIDER, compile).
+-define(DEPS, [erlc_compile]).
+
+-spec init(rebar_state:t()) -> {ok, rebar_state:t()}.
+init(State) ->
+    State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
+                                                               {module, ?MODULE},
+                                                               {bare, true},
+                                                               {deps, ?DEPS},
+                                                               {example, "rebar3 compile"},
+                                                               {short_desc, "Compile apps .app.src and .erl files."},
+                                                               {desc, "Compile apps .app.src and .erl files."},
+                                                               {opts, []}])),
+    {ok, State1}.
+
+-spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
+do(State) ->
+    ProjectApps = rebar_state:project_apps(State),
+    Deps = rebar_state:deps_to_build(State),
+    Providers = rebar_state:providers(State),
+    Cwd = rebar_state:dir(State),
+
+    ?INFO("Deps: ~p", [Deps]),
+
+    build_app_files(State, Providers, Deps),
+    {ok, ProjectApps1} = rebar_digraph:compile_order(ProjectApps),
+
+    rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
+
+    ProjectApps2 = build_app_files(State, Providers, ProjectApps1),
+    State2 = rebar_state:project_apps(State, ProjectApps2),
+
+    ?INFO("ProjectApps: ~p", [ProjectApps2]),
+
+    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State2),
+
+    case rebar_state:has_all_artifacts(State2) of
+        {false, File} ->
+            throw(?PRV_ERROR({missing_artifact, File}));
+        true ->
+            true
+    end,
+    rebar_utils:cleanup_code_path(rebar_state:code_paths(State2, default)
+                                 ++ rebar_state:code_paths(State, all_plugin_deps)),
+
+    {ok, State2}.
+
+-spec format_error(any()) -> iolist().
+format_error({missing_artifact, File}) ->
+    io_lib:format("Missing artifact ~s", [File]);
+format_error(Reason) ->
+    io_lib:format("~p", [Reason]).
+
+build_app_files(State, Providers, Apps) ->
+    [ build_app_file(State, Providers, AppInfo) || AppInfo <- Apps ].
+
+build_app_file(State, AppInfo) ->
+    build_app_file(State, rebar_state:providers(State), AppInfo).
+
+build_app_file(State, Providers, AppInfo) ->
+    ?INFO("Packaging ~p", [rebar_app_info:name(AppInfo)]),
+    AppDir = rebar_app_info:dir(AppInfo),
+    AppInfo1 = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER, Providers, AppInfo, State),
+    case rebar_otp_app:compile(State, AppInfo1) of
+        {ok, AppInfo2} ->
+            AppInfo3 = rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo2, State),
+            has_all_artifacts(AppInfo3),
+            AppInfo3;
+        Error ->
+            throw(Error)
+    end.
+
+has_all_artifacts(AppInfo) ->
+    case rebar_app_info:has_all_artifacts(AppInfo) of
+        {false, File} ->
+            throw(?PRV_ERROR({missing_artifact, File}));
+        true ->
+            true
+    end.

--- a/src/rebar_prv_app_builder.erl
+++ b/src/rebar_prv_app_builder.erl
@@ -34,7 +34,6 @@ do(State) ->
     Providers = rebar_state:providers(State),
     Cwd = rebar_state:dir(State),
 
-    ?INFO("Deps: ~p", [Deps]),
 
     build_app_files(State, Providers, Deps),
     {ok, ProjectApps1} = rebar_digraph:compile_order(ProjectApps),
@@ -44,7 +43,6 @@ do(State) ->
     ProjectApps2 = build_app_files(State, Providers, ProjectApps1),
     State2 = rebar_state:project_apps(State, ProjectApps2),
 
-    ?INFO("ProjectApps: ~p", [ProjectApps2]),
 
     rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State2),
 
@@ -72,7 +70,7 @@ build_app_file(State, AppInfo) ->
     build_app_file(State, rebar_state:providers(State), AppInfo).
 
 build_app_file(State, Providers, AppInfo) ->
-    ?INFO("Packaging ~p", [rebar_app_info:name(AppInfo)]),
+    ?INFO("Packaging ~s", [rebar_app_info:name(AppInfo)]),
     AppDir = rebar_app_info:dir(AppInfo),
     AppInfo1 = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER, Providers, AppInfo, State),
     case rebar_otp_app:compile(State, AppInfo1) of

--- a/src/rebar_prv_bare_compile.erl
+++ b/src/rebar_prv_bare_compile.erl
@@ -44,7 +44,8 @@ do(State) ->
 
     [AppInfo] = rebar_state:project_apps(State),
     AppInfo1 = rebar_app_info:out_dir(AppInfo, rebar_dir:get_cwd()),
-    rebar_prv_compile:compile(State, AppInfo1),
+    AppInfo2 = rebar_prv_compile:compile(State, AppInfo1),
+    rebar_prv_app_builder:build_app_file(State, AppInfo2),
 
     rebar_utils:cleanup_code_path(OrigPath),
 

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -256,8 +256,13 @@ do_compile(State) ->
     case rebar_prv_compile:do(State) of
         %% successfully compiled apps
         {ok, S} ->
-            ok = maybe_cover_compile(S),
-            {ok, S};
+            case rebar_prv_app_builder:do(S) of
+                {ok, S1} ->
+                    ok = maybe_cover_compile(S1),
+                    {ok, S1};
+                Error ->
+                    Error
+            end;
         %% this should look like a compiler error, not an eunit error
         Error   -> Error
     end.

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -23,11 +23,8 @@
 init(State) ->
     State1 = rebar_state:add_provider(State, providers:create([{name, ?PROVIDER},
                                                                {module, ?MODULE},
-                                                               {bare, true},
+                                                               {bare, false},
                                                                {deps, ?DEPS},
-                                                               {example, "rebar3 compile"},
-                                                               {short_desc, "Compile apps .app.src and .erl files."},
-                                                               {desc, "Compile apps .app.src and .erl files."},
                                                                {opts, []}])),
     {ok, State1}.
 

--- a/src/rebar_prv_compile.erl
+++ b/src/rebar_prv_compile.erl
@@ -12,7 +12,7 @@
 -include_lib("providers/include/providers.hrl").
 -include("rebar.hrl").
 
--define(PROVIDER, compile).
+-define(PROVIDER, erlc_compile).
 -define(DEPS, [lock]).
 
 %% ===================================================================
@@ -58,20 +58,10 @@ do(State) ->
     State3 = update_code_paths(State2, ProjectApps2, DepsPaths),
 
     rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State2),
-    case rebar_state:has_all_artifacts(State3) of
-        {false, File} ->
-            throw(?PRV_ERROR({missing_artifact, File}));
-        true ->
-            true
-    end,
-    rebar_utils:cleanup_code_path(rebar_state:code_paths(State3, default)
-                                 ++ rebar_state:code_paths(State, all_plugin_deps)),
 
     {ok, State3}.
 
 -spec format_error(any()) -> iolist().
-format_error({missing_artifact, File}) ->
-    io_lib:format("Missing artifact ~s", [File]);
 format_error(Reason) ->
     io_lib:format("~p", [Reason]).
 
@@ -114,17 +104,12 @@ compile(State, AppInfo) ->
 compile(State, Providers, AppInfo) ->
     ?INFO("Compiling ~s", [rebar_app_info:name(AppInfo)]),
     AppDir = rebar_app_info:dir(AppInfo),
-    AppInfo1 = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER,  Providers, AppInfo, State),
 
+    AppInfo1 = rebar_hooks:run_all_hooks(AppDir, pre, ?PROVIDER,  Providers, AppInfo, State),
     rebar_erlc_compiler:compile(AppInfo1),
-    case rebar_otp_app:compile(State, AppInfo1) of
-        {ok, AppInfo2} ->
-            AppInfo3 = rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo2, State),
-            has_all_artifacts(AppInfo3),
-            AppInfo3;
-        Error ->
-            throw(Error)
-    end.
+    AppInfo2 = rebar_hooks:run_all_hooks(AppDir, post, ?PROVIDER, Providers, AppInfo1, State),
+
+    AppInfo2.
 
 %% ===================================================================
 %% Internal functions
@@ -143,7 +128,7 @@ paths_for_apps([App|Rest], Acc) ->
     Paths = [filename:join([rebar_app_info:out_dir(App), Dir]) || Dir <- ["ebin"|ExtraDirs]],
     FilteredPaths = lists:filter(fun ec_file:is_dir/1, Paths),
     paths_for_apps(Rest, Acc ++ FilteredPaths).
-    
+
 paths_for_extras(State, Apps) ->
     F = fun(App) -> rebar_app_info:dir(App) == rebar_state:dir(State) end,
     %% check that this app hasn't already been dealt with
@@ -157,13 +142,6 @@ paths_for_extras(State) ->
     Paths = [filename:join([rebar_dir:base_dir(State), "extras", Dir]) || Dir <- ExtraDirs],
     lists:filter(fun ec_file:is_dir/1, Paths).
 
-has_all_artifacts(AppInfo1) ->
-    case rebar_app_info:has_all_artifacts(AppInfo1) of
-        {false, File} ->
-            throw(?PRV_ERROR({missing_artifact, File}));
-        true ->
-            true
-    end.
 
 copy_app_dirs(AppInfo, OldAppDir, AppDir) ->
     case ec_cnv:to_binary(filename:absname(OldAppDir)) =/=

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -190,7 +190,7 @@ dedupe_tests({AppMods, TestMods}) ->
     %% in AppMods that will trigger it
     F = fun(Mod) ->
         M = filename:basename(Mod, ".erl"),
-        MatchesTest = fun(Dir) -> filename:basename(Dir, ".erl") ++ "_tests" == M end, 
+        MatchesTest = fun(Dir) -> filename:basename(Dir, ".erl") ++ "_tests" == M end,
         case lists:any(MatchesTest, AppMods) of
             false -> {true, {module, list_to_atom(M)}};
             true  -> false
@@ -291,8 +291,13 @@ compile(State) ->
     case rebar_prv_compile:do(State) of
         %% successfully compiled apps
         {ok, S} ->
-            ok = maybe_cover_compile(S),
-            {ok, S};
+            case rebar_prv_app_builder:do(S) of
+                {ok, S1} ->
+                    ok = maybe_cover_compile(S1),
+                    {ok, S1};
+                Error ->
+                    Error
+            end;
         %% this should look like a compiler error, not an eunit error
         Error   -> Error
     end.

--- a/src/rebar_prv_plugins_upgrade.erl
+++ b/src/rebar_prv_plugins_upgrade.erl
@@ -93,4 +93,5 @@ build_plugin(AppInfo, Apps, State) ->
     C = rebar_config:consult(AppDir),
     S = rebar_state:new(rebar_state:all_deps(rebar_state:new(), Apps), C, AppDir),
     AppInfo1 = rebar_app_info:update_opts(AppInfo, rebar_app_info:opts(AppInfo), C),
-    rebar_prv_compile:compile(S, Providers, AppInfo1).
+    AppInfo2 = rebar_prv_compile:compile(S, Providers, AppInfo1),
+    rebar_prv_app_builder:build_app_file(S, Providers, AppInfo2).

--- a/test/rebar_hooks_SUITE.erl
+++ b/test/rebar_hooks_SUITE.erl
@@ -70,7 +70,7 @@ escriptize_artifacts(Config) ->
     try rebar_test_utils:run_and_check(Config, RConf, ["compile"], return)
     catch
         {error,
-         {rebar_prv_compile,
+         {rebar_prv_app_builder,
           {missing_artifact, Artifact}}} ->
             ok
     end,


### PR DESCRIPTION
Alternative solution to #1044: splitting rebar_prv_compile into two providers.

rebar_prv_app_builder is a new provider which compiles .app.src files into .app files.

In this version, rebar_prv_app_builder supplants rebar_prv_compile as the compile provider, and rebar_prv_compile becomes a dependency of rebar_prv_app_builder. With this variation, plugins which rely on pre-compile hooks and expect BEAMs to not yet have been generated are in for a surprise.