### PR TITLE
Make lock files future-proof

### DIFF
--- a/src/rebar_app_info.erl
+++ b/src/rebar_app_info.erl
@@ -165,13 +165,13 @@ update_opts(AppInfo, Opts, Config) ->
 
 deps_from_config(Dir, Config) ->
     case rebar_config:consult_lock_file(filename:join(Dir, ?LOCK_FILE)) of
-        [D] ->
+        [] ->
+            [{{deps, default}, proplists:get_value(deps, Config, [])}];
+        D ->
             %% We want the top level deps only from the lock file.
             %% This ensures deterministic overrides for configs.
             Deps = [X || X <- D, element(3, X) =:= 0],
-            [{{locks, default}, D}, {{deps, default}, Deps}];
-        _ ->
-            [{{deps, default}, proplists:get_value(deps, Config, [])}]
+            [{{locks, default}, D}, {{deps, default}, Deps}]
     end.
 
 %% @doc discover a complete version of the app info with all fields set.

--- a/src/rebar_prv_lock.erl
+++ b/src/rebar_prv_lock.erl
@@ -35,8 +35,7 @@ do(State) ->
             OldLocks = rebar_state:get(State, {locks, default}, []),
             Locks = lists:keysort(1, build_locks(State)),
             Dir = rebar_state:dir(State),
-            file:write_file(filename:join(Dir, ?LOCK_FILE),
-                            io_lib:format("~p.~n", [Locks])),
+            rebar_config:write_lock_file(filename:join(Dir, ?LOCK_FILE), Locks),
             State1 = rebar_state:set(State, {locks, default}, Locks),
 
             OldLockNames = [element(1,L) || L <- OldLocks],

--- a/src/rebar_prv_unlock.erl
+++ b/src/rebar_prv_unlock.erl
@@ -46,15 +46,14 @@ do(State) ->
             {ok, State};
         {error, Reason} ->
             ?PRV_ERROR({file,Reason});
-        {ok, [Locks]} ->
+        {ok, _} ->
+            Locks = rebar_config:consult_lock_file(LockFile),
             case handle_unlocks(State, Locks, LockFile) of
                 ok ->
                     {ok, State};
                 {error, Reason} ->
                     ?PRV_ERROR({file,Reason})
-            end;
-        {ok, _Other} ->
-            ?PRV_ERROR(unknown_lock_format)
+            end
     end.
 
 -spec format_error(any()) -> iolist().
@@ -74,7 +73,7 @@ handle_unlocks(State, Locks, LockFile) ->
         _ when Names =:= [] -> % implicitly all locks
             file:delete(LockFile);
         NewLocks ->
-            file:write_file(LockFile, io_lib:format("~p.~n", [NewLocks]))
+            rebar_config:write_lock_file(LockFile, NewLocks)
     end.
 
 parse_names(Bin) ->

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -115,13 +115,13 @@ new(ParentState, Config, Deps, Dir) ->
 
 deps_from_config(Dir, Config) ->
     case rebar_config:consult_lock_file(filename:join(Dir, ?LOCK_FILE)) of
-        [D] ->
+        [] ->
+            [{{deps, default}, proplists:get_value(deps, Config, [])}];
+        D ->
             %% We want the top level deps only from the lock file.
             %% This ensures deterministic overrides for configs.
             Deps = [X || X <- D, element(3, X) =:= 0],
-            [{{locks, default}, D}, {{deps, default}, Deps}];
-        _ ->
-            [{{deps, default}, proplists:get_value(deps, Config, [])}]
+            [{{locks, default}, D}, {{deps, default}, Deps}]
     end.
 
 base_state() ->

--- a/test/rebar_lock_SUITE.erl
+++ b/test/rebar_lock_SUITE.erl
@@ -1,0 +1,46 @@
+%%% Most locking tests are implicit in other test suites handling
+%%% dependencies.
+%%% This suite is to test the compatibility layers between various
+%%% versions of lockfiles.
+-module(rebar_lock_SUITE).
+-compile(export_all).
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+all() -> [current_version, future_versions_no_attrs, future_versions_attrs].
+
+current_version(Config) ->
+    %% Current version just dumps the locks as is on disk.
+    LockFile = filename:join(?config(priv_dir, Config), "current_version"),
+    Locks = [{<<"app1">>, {git,"some_url", {ref,"some_ref"}}, 2},
+             {<<"app2">>, {git,"some_url", {ref,"some_ref"}}, 0},
+             {<<"app3">>, {hg,"some_url", {ref,"some_ref"}}, 1},
+             {<<"pkg1">>,{pkg,<<"name">>,<<"0.1.6">>},3}],
+    file:write_file(LockFile, io_lib:format("~p.~n", [Locks])),
+    ?assertEqual(Locks, rebar_config:consult_lock_file(LockFile)).
+
+future_versions_no_attrs(Config) ->
+    %% Future versions will keep the same core attribute in there, but
+    %% will do so under a new format bundled with a version and potentially
+    %% some trailing attributes
+    LockFile = filename:join(?config(priv_dir, Config), "future_versions"),
+    Locks = [{<<"app1">>, {git,"some_url", {ref,"some_ref"}}, 2},
+             {<<"app2">>, {git,"some_url", {ref,"some_ref"}}, 0},
+             {<<"app3">>, {hg,"some_url", {ref,"some_ref"}}, 1},
+             {<<"pkg1">>,{pkg,<<"name">>,<<"0.1.6">>},3}],
+    LockData = {"3.5.2", Locks},
+    file:write_file(LockFile, io_lib:format("~p.~n", [LockData])),
+    ?assertEqual(Locks, rebar_config:consult_lock_file(LockFile)).
+
+future_versions_attrs(Config) ->
+    %% Future versions will keep the same core attribute in there, but
+    %% will do so under a new format bundled with a version and potentially
+    %% some trailing attributes
+    LockFile = filename:join(?config(priv_dir, Config), "future_versions"),
+    Locks = [{<<"app1">>, {git,"some_url", {ref,"some_ref"}}, 2},
+             {<<"app2">>, {git,"some_url", {ref,"some_ref"}}, 0},
+             {<<"app3">>, {hg,"some_url", {ref,"some_ref"}}, 1},
+             {<<"pkg1">>,{pkg,<<"name">>,<<"0.1.6">>},3}],
+    LockData = {"3.5.2", Locks},
+    file:write_file(LockFile, io_lib:format("~p.~na.~n{b,c}.~n[d,e,f].~n", [LockData])),
+    ?assertEqual(Locks, rebar_config:consult_lock_file(LockFile)).


### PR DESCRIPTION
Changes to how hex or packages may work in the future will necessarily
bring changes to the format of lock files.

This commit adds an optional framing for future lock files of the form:

    {Version, LockList}.
    <Whatever consultable attributes>

This format is supported such as the LockList is the current lockfile
contents, and will never have more information than it currently does.

Attributes can be whatever and are currently undefined.

Rebar copies will be able to:
- Keep using the core locklist (which avoids breaking the last year or
  so of community libraries using rebar3)
- Warn when it runs an outdated copy in comparison to the lock file
- Automatically rewrite lock files in the format it supports
- Augment or parse files in a version-specific manner.

This changes the usage interface slightly, but is backwards *and*
forwards compatible.

If we wanted to add, for example, a list of source indexes for given
dependencies, we could have a lockfile of the form:

```erlang
{"3.7.2", [
   {<<"pkg1">>,{pkg,<<"name1">>,<<"0.1.6">>},0},
   {<<"pkg2">>,{pkg,<<"name2">>,<<"0.1.6">>},1},
   {<<"pkg3">>,{pkg,<<"name3">>,<<"0.1.6">>},2}
]}.
{pkg_indexes, [{<<"pkg2">>, "http://example.org"}]}.
```
Currently it wouldn't be expected that plugins or users write
arbitrary data to the lock file.

A conversion layer is added when reading and writing from/to
disk such that while the snippet above represents the on-disk
format, Rebar3 could internally work with:

```erlang
[{<<"pkg1">>,{pkg,<<"name1">>,<<"0.1.6">>},0},
 {<<"pkg2">>,{pkg,<<"name2">>,<<"0.1.6">>, "http://example.org"},1},
 {<<"pkg3">>,{pkg,<<"name3">>,<<"0.1.6">>},2}]
```
And just do what it needs. All we need to do is maintain a set of
functions to map from past versions to future versions,
and to read what we can afford to read from future versions,
losing whatever information we must to keep going (while
displaying a big warning) 