### PR TITLE
give top level plugin providers precedence over default providers

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -124,16 +124,18 @@ run_aux(State, RawArgs) ->
                              filename:join(filename:absname(rebar_state:dir(State3)), BaseDir)),
 
     {ok, Providers} = application:get_env(rebar, providers),
+    %% Initializing project_plugins before providers allows top level plugins to take precedence
+    State5 = rebar_plugins:project_plugins_install(State4),
     %% Providers can modify profiles stored in opts, so set default after initializing providers
-    State5 = rebar_state:create_logic_providers(Providers, State4),
-    State6 = rebar_plugins:top_level_install(State5),
-    State7 = rebar_state:default(State6, rebar_state:opts(State6)),
+    State6 = rebar_state:create_logic_providers(Providers, State5),
+    State7 = rebar_plugins:top_level_install(State6),
+    State8 = rebar_state:default(State7, rebar_state:opts(State7)),
 
     {Task, Args} = parse_args(RawArgs),
 
-    State8 = rebar_state:code_paths(State7, default, code:get_path()),
+    State9 = rebar_state:code_paths(State8, default, code:get_path()),
 
-    rebar_core:init_command(rebar_state:command_args(State8, Args), Task).
+    rebar_core:init_command(rebar_state:command_args(State9, Args), Task).
 
 init_config() ->
     %% Initialize logging system

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -3,7 +3,8 @@
 
 -module(rebar_plugins).
 
--export([top_level_install/1
+-export([project_plugins_install/1
+        ,top_level_install/1
         ,project_apps_install/1
         ,install/2
         ,handle_plugins/3
@@ -14,6 +15,14 @@
 %% ===================================================================
 %% Public API
 %% ===================================================================
+
+-spec project_plugins_install(rebar_state:t()) -> rebar_state:t().
+project_plugins_install(State) ->
+    Profiles = rebar_state:current_profiles(State),
+    lists:foldl(fun(Profile, StateAcc) ->
+                        Plugins = rebar_state:get(State, {project_plugins, Profile}, []),
+                        handle_plugins(Profile, Plugins, StateAcc)
+                end, State, Profiles).
 
 -spec top_level_install(rebar_state:t()) -> rebar_state:t().
 top_level_install(State) ->

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -103,7 +103,8 @@ new(ParentState, Config, Dir) ->
 new(ParentState, Config, Deps, Dir) ->
     Opts = ParentState#state_t.opts,
     Plugins = proplists:get_value(plugins, Config, []),
-    Terms = Deps++[{{plugins, default}, Plugins} | Config],
+    ProjectPlugins = proplists:get_value(project_plugins, Config, []),
+    Terms = Deps++[{{project_plugins, default}, ProjectPlugins}, {{plugins, default}, Plugins} | Config],
     true = rebar_config:verify_config_format(Terms),
     LocalOpts = dict:from_list(Terms),
 
@@ -136,7 +137,8 @@ base_state() ->
 base_opts(Config) ->
     Deps = proplists:get_value(deps, Config, []),
     Plugins = proplists:get_value(plugins, Config, []),
-    Terms = [{{deps, default}, Deps}, {{plugins, default}, Plugins} | Config],
+    ProjectPlugins = proplists:get_value(project_plugins, Config, []),
+    Terms = [{{deps, default}, Deps}, {{plugins, default}, Plugins}, {{project_plugins, default}, ProjectPlugins} | Config],
     true = rebar_config:verify_config_format(Terms),
     dict:from_list(Terms).
 


### PR DESCRIPTION
This change allows top level plugins to take the names of default providers. For example, the cuttlefish plugin, which requires control over the release building, will be `{default, release}` and `{default, tar}` in order to make this possible.