### PR TITLE
Bump cth_readable

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
         {bbmustache,          "1.0.4"},
         {relx,                "3.17.0"},
         {cf,                  "0.2.1"},
-        {cth_readable,        "1.2.0"},
+        {cth_readable,        "1.2.1"},
         {eunit_formatters,    "0.3.1"}]}.
 
 {escript_name, rebar3}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,7 +1,7 @@
 [{<<"bbmustache">>,{pkg,<<"bbmustache">>,<<"1.0.4">>},0},
  {<<"certifi">>,{pkg,<<"certifi">>,<<"0.3.0">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.2.1">>},0},
- {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.2.0">>},0},
+ {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.2.1">>},0},
  {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.19.0">>},0},
  {<<"eunit_formatters">>,{pkg,<<"eunit_formatters">>,<<"0.3.1">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},


### PR DESCRIPTION
The new version fixes parse transforms over OTP incompatibility that
would crash entire compile runs before.

Fixes https://github.com/rebar/rebar3/issues/1063