### PR TITLE
upgrade relx to 3.17.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,13 +1,13 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 
-{deps, [{erlware_commons,     "0.18.0"},
+{deps, [{erlware_commons,     "0.19.0"},
         {ssl_verify_hostname, "1.0.5"},
         {certifi,             "0.3.0"},
         {providers,           "1.6.0"},
         {getopt,              "0.8.2"},
         {bbmustache,          "1.0.4"},
-        {relx,                "3.16.0"},
+        {relx,                "3.17.0"},
         {cf,                  "0.2.1"},
         {cth_readable,        "1.2.0"},
         {eunit_formatters,    "0.3.1"}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,9 +2,9 @@
  {<<"certifi">>,{pkg,<<"certifi">>,<<"0.3.0">>},0},
  {<<"cf">>,{pkg,<<"cf">>,<<"0.2.1">>},0},
  {<<"cth_readable">>,{pkg,<<"cth_readable">>,<<"1.2.0">>},0},
- {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.18.0">>},0},
+ {<<"erlware_commons">>,{pkg,<<"erlware_commons">>,<<"0.19.0">>},0},
  {<<"eunit_formatters">>,{pkg,<<"eunit_formatters">>,<<"0.3.1">>},0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},0},
  {<<"providers">>,{pkg,<<"providers">>,<<"1.6.0">>},0},
- {<<"relx">>,{pkg,<<"relx">>,<<"3.16.0">>},0},
+ {<<"relx">>,{pkg,<<"relx">>,<<"3.17.0">>},0},
  {<<"ssl_verify_hostname">>,{pkg,<<"ssl_verify_hostname">>,<<"1.0.5">>},0}].


### PR DESCRIPTION
Includes changes to relx to support cuttlefish. Mainly that you can now set `sys_config` and `vm_args` to `false` to tell relx not to create defaults. 

Also a bug fix when building a tarball with no `sys.config` or `vm.args`.