### PR TITLE
break up do/1 function in install_deps to make upgrade less confusing

### DIFF
--- a/src/rebar_prv_install_deps.erl
+++ b/src/rebar_prv_install_deps.erl
@@ -35,7 +35,8 @@
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").
 
--export([handle_deps_as_profile/4,
+-export([do_/1,
+         handle_deps_as_profile/4,
          profile_dep_dir/2,
          find_cycles/1,
          cull_compile/2]).
@@ -69,8 +70,11 @@ init(State) ->
 
 -spec do(rebar_state:t()) -> {ok, rebar_state:t()} | {error, string()}.
 do(State) ->
+    ?INFO("Verifying dependencies...", []),
+    do_(State).
+
+do_(State) ->
     try
-        ?INFO("Verifying dependencies...", []),
         Profiles = rebar_state:current_profiles(State),
         ProjectApps = rebar_state:project_apps(State),
 

--- a/src/rebar_prv_upgrade.erl
+++ b/src/rebar_prv_upgrade.erl
@@ -61,7 +61,7 @@ do(State) ->
             State4 = rebar_state:set(State3, upgrade, true),
             UpdatedLocks = [L || L <- rebar_state:lock(State4),
                                  lists:keymember(rebar_app_info:name(L), 1, Locks0)],
-            Res = rebar_prv_install_deps:do(rebar_state:lock(State4, UpdatedLocks)),
+            Res = rebar_prv_install_deps:do_(rebar_state:lock(State4, UpdatedLocks)),
             case Res of
                 {ok, State5} ->
                     rebar_utils:info_useless(


### PR DESCRIPTION
Without this change there was sort of confusing output any time you ran `upgrade` because it had the same entry point as the provider:

```
===> Verifying dependencies...
===> Verifying dependencies...
...
```