### PR TITLE
add project_providers after initing default providers but allow overrides

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -124,10 +124,10 @@ run_aux(State, RawArgs) ->
                              filename:join(filename:absname(rebar_state:dir(State3)), BaseDir)),
 
     {ok, Providers} = application:get_env(rebar, providers),
-    %% Initializing project_plugins before providers allows top level plugins to take precedence
-    State5 = rebar_plugins:project_plugins_install(State4),
     %% Providers can modify profiles stored in opts, so set default after initializing providers
-    State6 = rebar_state:create_logic_providers(Providers, State5),
+    State5 = rebar_state:create_logic_providers(Providers, State4),
+    %% Initializing project_plugins which can override default providers
+    State6 = rebar_plugins:project_plugins_install(State5),
     State7 = rebar_plugins:top_level_install(State6),
     State8 = rebar_state:default(State7, rebar_state:opts(State7)),
 

--- a/src/rebar_plugins.erl
+++ b/src/rebar_plugins.erl
@@ -19,10 +19,12 @@
 -spec project_plugins_install(rebar_state:t()) -> rebar_state:t().
 project_plugins_install(State) ->
     Profiles = rebar_state:current_profiles(State),
-    lists:foldl(fun(Profile, StateAcc) ->
-                        Plugins = rebar_state:get(State, {project_plugins, Profile}, []),
-                        handle_plugins(Profile, Plugins, StateAcc)
-                end, State, Profiles).
+    State1 = rebar_state:allow_provider_overrides(State, true),
+    State2 = lists:foldl(fun(Profile, StateAcc) ->
+                             Plugins = rebar_state:get(State, {project_plugins, Profile}, []),
+                             handle_plugins(Profile, Plugins, StateAcc)
+                         end, State1, Profiles),
+    rebar_state:allow_provider_overrides(State2, false).
 
 -spec top_level_install(rebar_state:t()) -> rebar_state:t().
 top_level_install(State) ->

--- a/src/rebar_state.erl
+++ b/src/rebar_state.erl
@@ -36,9 +36,10 @@
 
          deps_names/1,
 
-
          resources/1, resources/2, add_resource/2,
-         providers/1, providers/2, add_provider/2]).
+         providers/1, providers/2, add_provider/2,
+         allow_provider_overrides/1, allow_provider_overrides/2
+        ]).
 
 -include("rebar.hrl").
 -include_lib("providers/include/providers.hrl").
@@ -63,7 +64,8 @@
                   all_deps            = []          :: [rebar_app_info:t()],
 
                   resources           = [],
-                  providers           = []}).
+                  providers           = [],
+                  allow_provider_overrides = false  :: boolean()}).
 
 -export_type([t/0]).
 
@@ -370,8 +372,16 @@ providers(#state_t{providers=Providers}) ->
 providers(State, NewProviders) ->
     State#state_t{providers=NewProviders}.
 
+allow_provider_overrides(#state_t{allow_provider_overrides=Allow}) ->
+    Allow.
+
+allow_provider_overrides(State, Allow) ->
+    State#state_t{allow_provider_overrides=Allow}.
+
 -spec add_provider(t(), providers:t()) -> t().
-add_provider(State=#state_t{providers=Providers}, Provider) ->
+add_provider(State=#state_t{providers=Providers, allow_provider_overrides=true}, Provider) ->
+    State#state_t{providers=[Provider | Providers]};
+add_provider(State=#state_t{providers=Providers, allow_provider_overrides=false}, Provider) ->
     Name = providers:impl(Provider),
     Namespace = providers:namespace(Provider),
     Module = providers:module(Provider),


### PR DESCRIPTION
Providers weren't initialized deps of plugins like cuttlefish would fail to build since there was no `escriptize` provider at the time of build.