### PR TITLE
Run all hooks

### DIFF
--- a/src/rebar_hooks.erl
+++ b/src/rebar_hooks.erl
@@ -2,6 +2,7 @@
 
 -export([run_all_hooks/5
         ,run_all_hooks/6
+        ,run_project_and_app_hooks/5
         ,format_error/1]).
 
 -include("rebar.hrl").
@@ -19,6 +20,11 @@ run_all_hooks(Dir, Type, Command, Providers, AppInfo, State) ->
 run_all_hooks(Dir, Type, Command, Providers, State) ->
     run_provider_hooks(Dir, Type, Command, Providers, rebar_state:opts(State), State),
     run_hooks(Dir, Type, Command, rebar_state:opts(State), State).
+
+run_project_and_app_hooks(Dir, Type, Command, Providers, State) ->
+    ProjectApps = rebar_state:project_apps(State),
+    [rebar_hooks:run_all_hooks(Dir, Type, Command, Providers, AppInfo, State) || AppInfo <- ProjectApps],
+    run_all_hooks(Dir, Type, Command, Providers, State).
 
 run_provider_hooks(Dir, Type, Command, Providers, Opts, State) ->
     case rebar_opts:get(Opts, provider_hooks, []) of

--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -52,14 +52,16 @@ do(State, Tests) ->
     %% Run ct provider prehooks
     Providers = rebar_state:providers(State),
     Cwd = rebar_dir:get_cwd(),
-    rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
+
+    %% Run ct provider pre hooks for all project apps and top level project hooks
+    rebar_hooks:run_project_and_app_hooks(Cwd, pre, ?PROVIDER, Providers, State),
 
     case Tests of
         {ok, T} ->
             case run_tests(State, T) of
                 ok    ->
-                    %% Run ct provider posthooks
-                    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State),
+                    %% Run ct provider post hooks for all project apps and top level project hooks
+                    rebar_hooks:run_project_and_app_hooks(Cwd, post, ?PROVIDER, Providers, State),
                     rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
                     {ok, State};
                 Error ->
@@ -653,4 +655,3 @@ help(verbose) ->
     "Verbose output";
 help(_) ->
     "".
-

--- a/src/rebar_prv_eunit.erl
+++ b/src/rebar_prv_eunit.erl
@@ -56,14 +56,14 @@ do(State, Tests) ->
     %% Run eunit provider prehooks
     Providers = rebar_state:providers(State),
     Cwd = rebar_dir:get_cwd(),
-    rebar_hooks:run_all_hooks(Cwd, pre, ?PROVIDER, Providers, State),
+    rebar_hooks:run_project_and_app_hooks(Cwd, pre, ?PROVIDER, Providers, State),
 
     case validate_tests(State, Tests) of
         {ok, T} ->
             case run_tests(State, T) of
                 {ok, State1} ->
                     %% Run eunit provider posthooks
-                    rebar_hooks:run_all_hooks(Cwd, post, ?PROVIDER, Providers, State1),
+                    rebar_hooks:run_project_and_app_hooks(Cwd, post, ?PROVIDER, Providers, State1),
                     rebar_utils:cleanup_code_path(rebar_state:code_paths(State, default)),
                     {ok, State1};
                 Error ->
@@ -190,7 +190,7 @@ dedupe_tests({AppMods, TestMods}) ->
     %% in AppMods that will trigger it
     F = fun(Mod) ->
         M = filename:basename(Mod, ".erl"),
-        MatchesTest = fun(Dir) -> filename:basename(Dir, ".erl") ++ "_tests" == M end, 
+        MatchesTest = fun(Dir) -> filename:basename(Dir, ".erl") ++ "_tests" == M end,
         case lists:any(MatchesTest, AppMods) of
             false -> {true, {module, list_to_atom(M)}};
             true  -> false

--- a/src/rebar_relx.erl
+++ b/src/rebar_relx.erl
@@ -25,7 +25,7 @@ do(Module, Command, Provider, State) ->
     AllOptions = string:join([Command | Options], " "),
     Cwd = rebar_state:dir(State),
     Providers = rebar_state:providers(State),
-    rebar_hooks:run_all_hooks(Cwd, pre, Provider, Providers, State),
+    rebar_hooks:run_project_and_app_hooks(Cwd, pre, Provider, Providers, State),
     try
         case rebar_state:get(State, relx, []) of
             [] ->
@@ -37,7 +37,7 @@ do(Module, Command, Provider, State) ->
                           ,{config, Config1}
                           ,{caller, api} | output_dir(OutputDir, Options)], AllOptions)
         end,
-        rebar_hooks:run_all_hooks(Cwd, post, Provider, Providers, State),
+        rebar_hooks:run_project_and_app_hooks(Cwd, post, Provider, Providers, State),
         {ok, State}
     catch
         throw:T ->


### PR DESCRIPTION
Fixes https://github.com/rebar/rebar3/issues/1089

Issue is that some providers, like `compile` and `clean`, distinguish between top level hooks and per-app hooks. in order to keep them from running twice we remove the hooks from the top level State if it is a single top level app in the project (the hook stays with the app). But in the case of `eunit` and `ct` and `relx` these per-app hooks are not run. To fix this I have it now run all hooks for those providers. I think that is the proper fix but open to alternatives.