### PR TITLE
Take CT options errors and turn them to warnings

### DIFF
--- a/src/rebar_prv_common_test.erl
+++ b/src/rebar_prv_common_test.erl
@@ -168,12 +168,15 @@ cfgopts(State) ->
     end.
 
 ensure_opts([], Acc) -> lists:reverse(Acc);
-ensure_opts([{test_spec, _}|_Rest], _Acc) ->
-    ?PRV_ERROR({badconfig, "Test specs not supported. See http://www.rebar3.org/docs/running-tests#common-test"});
-ensure_opts([{cover, _}|_Rest], _Acc) ->
-    ?PRV_ERROR({badconfig, "Cover specs not supported. See http://www.rebar3.org/docs/running-tests#common-test"});
-ensure_opts([{auto_compile, _}|_Rest], _Acc) ->
-    ?PRV_ERROR({badconfig, "Auto compile not supported"});
+ensure_opts([{test_spec, _}|Rest], Acc) ->
+    ?WARN("Test specs not supported. See http://www.rebar3.org/docs/running-tests#common-test", []),
+    ensure_opts(Rest, Acc);
+ensure_opts([{cover, _}|Rest], Acc) ->
+    ?WARN("Cover specs not supported. See http://www.rebar3.org/docs/running-tests#common-test", []),
+    ensure_opts(Rest, Acc);
+ensure_opts([{auto_compile, _}|Rest], Acc) ->
+    ?WARN("Auto compile not supported", []),
+    ensure_opts(Rest, Acc);
 ensure_opts([{suite, Suite}|Rest], Acc) when is_integer(hd(Suite)) ->
     ensure_opts(Rest, [{suite, Suite}|Acc]);
 ensure_opts([{suite, Suite}|Rest], Acc) when is_atom(Suite) ->

--- a/test/rebar_ct_SUITE.erl
+++ b/test/rebar_ct_SUITE.erl
@@ -1045,13 +1045,13 @@ cfg_test_spec(Config) ->
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
-    RebarConfig = [{ct_opts, [{test_spec, "spec/foo.spec"}]}],
+    RebarConfig = [{ct_opts, [Opt = {test_spec, "spec/foo.spec"}]}],
 
     {ok, State} = rebar_test_utils:run_and_check(C, RebarConfig, ["as", "test", "lock"], return),
 
-    {error, {rebar_prv_common_test, Error}} = rebar_prv_common_test:prepare_tests(State),
+    {ok, TestOpts} = rebar_prv_common_test:prepare_tests(State),
 
-    {badconfig, "Test specs not supported. See http://www.rebar3.org/docs/running-tests#common-test"} = Error.
+    false = lists:member(Opt, TestOpts).
 
 cfg_cover_spec(Config) ->
     C = rebar_test_utils:init_rebar_state(Config, "ct_cfg_cover_spec_opts_"),
@@ -1062,13 +1062,13 @@ cfg_cover_spec(Config) ->
     Vsn = rebar_test_utils:create_random_vsn(),
     rebar_test_utils:create_app(AppDir, Name, Vsn, [kernel, stdlib]),
 
-    RebarConfig = [{ct_opts, [{cover, "spec/foo.spec"}]}],
+    RebarConfig = [{ct_opts, [Opt = {cover, "spec/foo.spec"}]}],
 
     {ok, State} = rebar_test_utils:run_and_check(C, RebarConfig, ["as", "test", "lock"], return),
 
-    {error, {rebar_prv_common_test, Error}} = rebar_prv_common_test:prepare_tests(State),
+    {ok, TestOpts} = rebar_prv_common_test:prepare_tests(State),
 
-    {badconfig, "Cover specs not supported. See http://www.rebar3.org/docs/running-tests#common-test"} = Error.
+    false = lists:member(Opt, TestOpts).
 
 cfg_atom_suites(Config) ->
     C = rebar_test_utils:init_rebar_state(Config, "ct_cfg_atom_suites_"),


### PR DESCRIPTION
The idea is that given we accept arbitrary config items for CT, we
should similarly be able to pass unsupported options and keep things
running.

However for unsupported options, a warning is very useful to have.

CC @talentdeficit 