### PR TITLE
make omar happy

### DIFF
--- a/src/rebar3.erl
+++ b/src/rebar3.erl
@@ -337,19 +337,18 @@ state_from_global_config(Config, GlobalConfigFile) ->
 
 test_state(State) ->
     ErlOpts = rebar_state:get(State, erl_opts, []),
-    TestOpts = safe_define_test_macro(ErlOpts, 'TEST'),
-    MoreTestOpts = safe_define_test_macro(ErlOpts, 'EUNIT'),
-    [{extra_src_dirs, ["test"]}, {erl_opts, TestOpts ++ MoreTestOpts}].
+    TestOpts = safe_define_test_macro(ErlOpts),
+    [{extra_src_dirs, ["test"]}, {erl_opts, TestOpts}].
 
-safe_define_test_macro(Opts, Macro) ->
+safe_define_test_macro(Opts) ->
     %% defining a compile macro twice results in an exception so
-    %% make sure 'TEST' or 'EUNIT' is only defined once
-    case test_defined(Opts, Macro) of
+    %% make sure 'TEST' is only defined once
+    case test_defined(Opts) of
        true  -> [];
-       false -> [{d, Macro}]
+       false -> [{d, 'TEST'}]
     end.
 
-test_defined([{d, Macro}|_], Macro) -> true;
-test_defined([{d, Macro, true}|_], Macro) -> true;
-test_defined([_|Rest], Macro) -> test_defined(Rest, Macro);
-test_defined([], _) -> false.
+test_defined([{d, 'TEST'}|_]) -> true;
+test_defined([{d, 'TEST', true}|_]) -> true;
+test_defined([_|Rest]) -> test_defined(Rest);
+test_defined([]) -> false.

--- a/test/rebar_profiles_SUITE.erl
+++ b/test/rebar_profiles_SUITE.erl
@@ -377,8 +377,7 @@ test_profile_applied_at_completion(Config) ->
 
     [App] = rebar_state:project_apps(State),
     ErlOpts = rebar_app_info:get(App, erl_opts),
-    true = lists:member({d, 'TEST'}, ErlOpts),
-    true = lists:member({d, 'EUNIT'}, ErlOpts).
+    true = lists:member({d, 'TEST'}, ErlOpts).
 
 test_profile_applied_before_compile(Config) ->
     AppDir = ?config(apps, Config),
@@ -394,9 +393,7 @@ test_profile_applied_before_compile(Config) ->
     code:add_paths(rebar_state:code_paths(State, all_deps)),
 
     S = list_to_atom("not_a_real_src_" ++ Name),
-    Opts = proplists:get_value(options, S:module_info(compile), []),
-    true = lists:member({d, 'TEST'}, Opts),
-    true = lists:member({d, 'EUNIT'}, Opts).
+    true = lists:member({d, 'TEST'}, proplists:get_value(options, S:module_info(compile), [])).
 
 test_profile_applied_before_eunit(Config) ->
     AppDir = ?config(apps, Config),
@@ -412,9 +409,7 @@ test_profile_applied_before_eunit(Config) ->
     code:add_paths(rebar_state:code_paths(State, all_deps)),
 
     T = list_to_atom("not_a_real_src_" ++ Name ++ "_tests"),
-    Opts = proplists:get_value(options, T:module_info(compile), []),
-    true = lists:member({d, 'TEST'}, Opts),
-    true = lists:member({d, 'EUNIT'}, Opts).
+    true = lists:member({d, 'TEST'}, proplists:get_value(options, T:module_info(compile), [])).
 
 test_profile_applied_to_apps(Config) ->
     AppDir = ?config(apps, Config),
@@ -435,6 +430,5 @@ test_profile_applied_to_apps(Config) ->
     lists:foreach(fun(App) ->
         Opts = rebar_app_info:opts(App),
         ErlOpts = dict:fetch(erl_opts, Opts),
-        true = lists:member({d, 'TEST'}, ErlOpts),
-        true = lists:member({d, 'EUNIT'}, ErlOpts)
+        true = lists:member({d, 'TEST'}, ErlOpts)
     end, Apps).


### PR DESCRIPTION
with this change 'EUNIT' will only be set when running the eunit provider and 'COMMON_TEST' will be set by the ct provider. this does mean users that run both eunit and ct tests will see a recompile when alternating between the two test runners